### PR TITLE
Update example of omit-self

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,20 +302,20 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   ```swift
   final class Listing {
-  
+
     init(capacity: Int, allowsPets: Bool) {      
       // WRONG
       self.capacity = capacity
       self.isFamilyFriendly = !allowsPets // `self.` not required here
-      
+
       // RIGHT
       self.capacity = capacity
       isFamilyFriendly = !allowsPets
     }
-    
+
     private let isFamilyFriendly: Bool
     private var capacity: Int
-    
+
     private func increaseCapacity(by amount: Int) {
       // WRONG
       self.capacity += amount


### PR DESCRIPTION
#### Summary

I've seen people misinterpret or not follow this rule with the logic of we should keep the init consistent with `self.` everywhere. We might as well make it less ambiguous and include an example that shows what exactly we mean.

#### Reasoning

Make rules less ambiguous is usually a good thing.

#### Reviewers
cc @airbnb/swift-styleguide-maintainers
