### PR TITLE
Update discardableResult example to return a value

### DIFF
--- a/README.md
+++ b/README.md
@@ -618,7 +618,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
   // WRONG
   @objc class Spaceship: NSObject {
   
-    @discardableResult func fly() -> Int {
+    @discardableResult func fly() -> Bool {
     }
   }
 
@@ -628,7 +628,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
   class Spaceship: NSObject {
   
     @discardableResult
-    func fly() -> Int {
+    func fly() -> Bool {
     }
   }
   ```


### PR DESCRIPTION
#### Summary

Update discardableResult example to return a value

#### Reasoning

It doesn't make sense to have discardableResult on a method that returns no value.

#### Reviewers
cc @fdiaz 