### PR TITLE
Require explicit values to be defined on enums

### DIFF
--- a/README.md
+++ b/README.md
@@ -1062,7 +1062,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
-* <a id='auto-enum-values'></a>(<a href='#auto-enum-values'>link</a>) **Use Swift's automatic enum vales unless they map to an external source.** Add a comment explaining why explicit values are defined. SwiftLint: [`redundant_string_enum_value`](https://github.com/realm/SwiftLint/blob/master/Rules.md#redundant_string_enum_value)
+* <a id='auto-enum-values'></a>(<a href='#auto-enum-values'>link</a>) **Use Swift's automatic enum vales unless they map to an external source.** Add a comment explaining why explicit values are defined. SwiftLint: [`redundant_string_enum_value`](https://github.com/realm/SwiftLint/blob/master/Rules.md#redundant-string-enum-value)
 
   <details>
 


### PR DESCRIPTION
#### Summary

~Adds a new "Types" for organization and I believe several rules could be pulled in to there.~

Adds new rules for how to handle Swift's enum values (both implicit and explicit).

#### Reasoning

It's a feature of the language that can make developers more efficient, and the explicit rules ensure the codebase is more robust.

#### Reviewers
cc @airbnb/swift-styleguide-maintainers

_Please react with 👍/👎 if you agree or disagree with this proposal._
