### PR TITLE
Fix Contributors link to point at Swift and not JS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1421,7 +1421,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
 ## Contributors
 
-  - [View Contributors](https://github.com/airbnb/javascript/graphs/contributors)
+  - [View Contributors](https://github.com/airbnb/swift/graphs/contributors)
 
 **[⬆ back to top](#table-of-contents)**
 


### PR DESCRIPTION
#### Summary

Fix Contributors link to point at Swift and not JS

#### Reasoning

Made a mistake in [this PR](https://github.com/airbnb/swift/pull/6) by linking to our Javascript guide instead of our Swift guide 🤦‍♂️ 

#### Reviewers
cc @airbnb/swift-styleguide-maintainers