### PR TITLE
Remove the need to indent code blocks (sample)

### DIFF
--- a/README.md
+++ b/README.md
@@ -635,55 +635,55 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
 ### Functions
 
-* <a id='omit-function-void-return'></a>(<a href='#omit-function-void-return'>link</a>) **Omit `Void` return types from function definitions.** SwiftLint: [`redundant_void_return`](https://github.com/realm/SwiftLint/blob/master/Rules.md#redundant-void-return)
+#### <a id='omit-function-void-return'></a>(<a href='#omit-function-void-return'>link</a>) Omit `Void` return types from function definitions. SwiftLint: [`redundant_void_return`](https://github.com/realm/SwiftLint/blob/master/Rules.md#redundant-void-return)
 
-  <details>
+<details>
 
-  ```swift
-  // WRONG
-  func doSomething() -> Void {
-    ...
+```swift
+// WRONG
+func doSomething() -> Void {
+  ...
+}
+
+// RIGHT
+func doSomething() {
+  ...
+}
+```
+
+</details>
+
+#### <a id='long-function-chains'></a>(<a href='#long-function-chains'>link</a>) Separate [long](#column-width) function chains with line breaks before each dot. SwiftLint: [`multiline_function_chains`](https://github.com/realm/SwiftLint/blob/master/Rules.md#multiline-function-chains)
+
+<details>
+
+##### Why?
+It's easier to follow control flow through long function chains when each call has the same indentation.
+
+```swift
+/// WRONG
+
+match(pattern: pattern).compactMap { range in
+    return Command(string: contents, range: range)
+  }.compactMap { command in
+    return command.expand()
+}
+
+/// RIGHT
+
+match(pattern: pattern)
+  .compactMap { range in
+    return Command(string: contents, range: range)
   }
+  .compactMap { command in
+    return command.expand()
+}
 
-  // RIGHT
-  func doSomething() {
-    ...
-  }
-  ```
+// Short function chains can still be on one line:
+let evenSquares = [20, 17, 35, 4].filter { $0 % 2 == 0 }.map { $0 * $0 }
+```
 
-  </details>
-
-* <a id='long-function-chains'></a>(<a href='#long-function-chains'>link</a>) **Separate [long](#column-width) function chains with line breaks before each dot.** SwiftLint: [`multiline_function_chains`](https://github.com/realm/SwiftLint/blob/master/Rules.md#multiline-function-chains)
-
-  <details>
-
-  #### Why?
-  It's easier to follow control flow through long function chains when each call has the same indentation.
-
-  ```swift
-  /// WRONG
-
-  match(pattern: pattern).compactMap { range in
-      return Command(string: contents, range: range)
-    }.compactMap { command in
-      return command.expand()
-  }
-
-  /// RIGHT
-
-  match(pattern: pattern)
-    .compactMap { range in
-      return Command(string: contents, range: range)
-    }
-    .compactMap { command in
-      return command.expand()
-  }
-
-  // Short function chains can still be on one line:
-  let evenSquares = [20, 17, 35, 4].filter { $0 % 2 == 0 }.map { $0 * $0 }
-  ```
-
-  </details>
+</details>
 
 ### Closures
 


### PR DESCRIPTION
#### Summary

Pros:
- We no longer have to indent code blocks.

Cons:
- We no longer have bold and non-bold sections in rule titles.

Alternatives considered:
- Instead of using a heading on the rules, use just standard bold. This causes the "details" link to hug the next rule and doesn't provide the spacing we'd like.

#### Reasoning

#### Reviewers
cc @airbnb/swift-styleguide-maintainers

_Please react with 👍/👎 if you agree or disagree with this proposal._
