### PR TITLE
Minimize rules that go against the community

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Note that brevity is not a primary goal. Code should be made more concise only i
 
 * This guide is in addition to the official [Swift API Design Guidelines](https://swift.org/documentation/api-design-guidelines/). These rules should not contradict that document.
 * These rules should not fight Xcode's <kbd>^</kbd> + <kbd>I</kbd> indentation behavior.
-* Rules that go directly against the way Apple, or the vast Swift community, does things should be minimized. These kinds of rules will need even more justification to be approved. This makes it easier for others to adopt the style guide; especially new people contributing to code bases that already adopt this style guide.
+* Rules that go directly against the way Apple, or the vast Swift community, does things should be minimized. These kinds of rules will need even more justification to be approved. This makes it easier for others to adopt the style guide, especially new people contributing to code bases that already adopt this style guide.
 
 ## Table of Contents
 


### PR DESCRIPTION
#### Summary

Adds a new guiding tenet to minimize the amount of rules that go directly against the way Apple or the vast Swift community does things.

#### Reasoning

We should always take into account what Apple and the broader Swift community is doing. 

This will:

1. Make the style guide easier to adopt on existing codebases.
2. Ease the transition of new contributors to a codebase that uses this style guide. 

However, the decision is always ours in the end. This is why the word "minimize" is used. We don't want to eliminate, just reduce.

And when we do have a rule that is in direct opposition to the community, it should be even more important to include a strong justification as to why it's that way.

#### Reviewers
cc @airbnb/swift-styleguide-maintainers

_Please react with 👍/👎 if you agree or disagree with this proposal._