### PR TITLE
Remove caseless enum rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -1063,28 +1063,6 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
-* <a id='namespace-using-enums'></a>(<a href='#namespace-using-enums'>link</a>) **Use caseless `enum`s for organizing `public` or `internal` constants and functions into namespaces.** Avoid creating non-namespaced global constants and functions. Feel free to nest namespaces where it adds clarity.
-
-  <details>
-
-  #### Why?
-  Caseless `enum`s work well as namespaces because they cannot be instantiated, which matches their intent.
-
-  ```swift
-  enum Environment {
-
-    enum Earth {
-      static let gravity = 9.8
-    }
-
-    enum Moon {
-      static let gravity = 1.6
-    }
-  }
-  ```
-
-  </details>
-
 * <a id='auto-enum-values'></a>(<a href='#auto-enum-values'>link</a>) **Use Swift's automatic enum values unless they map to an external source.** Add a comment explaining why explicit values are defined. [![SwiftLint: redundant_string_enum_value](https://img.shields.io/badge/SwiftLint-redundant__string__enum__value-008489.svg)](https://github.com/realm/SwiftLint/blob/master/Rules.md#redundant-string-enum-value)
 
   <details>


### PR DESCRIPTION
#### Summary

Remove caseless enum rule

#### Reasoning

1. Not lintable
2. Too prescriptive and we're not really following in our codebase. This should be left to developer discretion.

#### Reviewers
cc @airbnb/swift-styleguide-maintainers

_Please react with 👍/👎 if you agree or disagree with this proposal._
