### PR TITLE
Add guiding tenet to make all rules lintable

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ At minimum every rule should contain:
 
 1. A permalink to reference easily.
 1. A short description.
-1. If the rule is lintable, a link to the appropriate SwiftLint rule.
+1. A link to the appropriate [SwiftLint](https://github.com/realm/SwiftLint)/[SwiftFormat](https://github.com/nicklockwood/SwiftFormat) rule.
 1. _(optional)_ A "Why?" section describing the reasoning behind the rule.
 1. A code example describing the incorrect and correct behaviours.
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ Note that brevity is not a primary goal. Code should be made more concise only i
 
 * This guide is in addition to the official [Swift API Design Guidelines](https://swift.org/documentation/api-design-guidelines/). These rules should not contradict that document.
 * These rules should not fight Xcode's <kbd>^</kbd> + <kbd>I</kbd> indentation behavior.
+* Every rule needs to be lintable.
+  * If the rule is changing the format of the code, it needs to be able to be reformatted automatically (either using [SwiftLint](https://github.com/realm/SwiftLint) autocorrect or [SwiftFormat](https://github.com/nicklockwood/SwiftFormat)).
+  * If it's not, then it should be able to produce a warning.
 
 ## Table of Contents
 


### PR DESCRIPTION
#### Summary

Add guiding tenet to make all rules lintable

#### Reasoning

We've been discussing how to make this Style Guide scale with our team. We decided we should make _all rules lintable_ and make all rules that reformat our code automatically reformatted.

I'm introducing the usage of SwiftFormat as another option to make this happen since that project intention is to reformat Swift code while SwiftLint main purpose is to lint for it with the option of reformat it, so it seems appropriate.

#### Plan if this is approved

If this is approved I'll:

- Create 1 issue for each rule that doesn't comply with this new tenet.
- Create 1 PR removing each rule that doesn't comply with this new tenet pointing to the issue and merge it.
- All of these rules will be automatically approved when/if someone puts a PR to SwiftFormat/SwiftLint to make them follow this new tenet, unless the discussion in the issue itself clearly points in the direction that we would not want to add this rule again (by using our usual criteria to approve/decline rules)
- If an issue has been open for more than 1 year, we'll close it.

#### Reviewers
cc @airbnb/swift-styleguide-maintainers

_Please react with 👍/👎 if you agree or disagree with this proposal._
