### PR TITLE
Add guiding tenet to strive to make all rules lintable

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ At minimum every rule should contain:
 
 1. A permalink to reference easily.
 1. A short description.
-1. If the rule is lintable, a link to the appropriate SwiftLint rule.
+1. A link to the appropriate [SwiftLint](https://github.com/realm/SwiftLint) / [SwiftFormat](https://github.com/nicklockwood/SwiftFormat) rule.
 1. _(optional)_ A "Why?" section describing the reasoning behind the rule.
 1. A code example describing the incorrect and correct behaviours.
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Note that brevity is not a primary goal. Code should be made more concise only i
 
 * This guide is in addition to the official [Swift API Design Guidelines](https://swift.org/documentation/api-design-guidelines/). These rules should not contradict that document.
 * These rules should not fight Xcode's <kbd>^</kbd> + <kbd>I</kbd> indentation behavior.
+* We strive to make every rule lintable:
+  * If a rule changes the format of the code, it needs to be able to be reformatted automatically (either using [SwiftLint](https://github.com/realm/SwiftLint) autocorrect or [SwiftFormat](https://github.com/nicklockwood/SwiftFormat)).
+  * For rules that don't directly change the format of the code, we should have a lint rule that throws a warning.
+  * Exceptions to these rules should be rare and heavily justified.
 
 ## Table of Contents
 


### PR DESCRIPTION
#### Summary

Add guiding tenet to strive to make all rules lintable

#### Reasoning

See [this PR](https://github.com/airbnb/swift/pull/34) for further context.

This PR clarifies our intention to make all of our rules linted. 

---

### Update on this plan on September 3rd, 2020

- We will keep all the rules that have missing autocorrect open
- Any rule that has missing autocorrect needs to go through the normal process to be approved now, it is **not** automatically approved when/if someone puts a PR up

---

### Plan if this is approved as of Dec 12, 2018

**For each rule that change the format of our code we'll:**
- Create 1 issue for each rule that doesn't comply with this new tenet
- Create 1 PR removing each rule that doesn't comply with this new tenet pointing to the issue and merge it.
- All of these rules will be automatically approved when/if someone puts a PR to SwiftFormat/SwiftLint to make them follow this new tenet, unless the discussion in the issue itself clearly points in the direction that we would not want to add this rule again (by using our usual criteria to approve/decline rules)
- If an issue has been open for more than 1 year, we'll close it.

**For rules that don't change the format of our code:**
- We'll keep them as is but with the intention of trying to increase linting as much as possible and possibly revisiting them later.

#### Reviewers
cc @airbnb/swift-styleguide-maintainers

_Please react with 👍/👎 if you agree or disagree with this proposal._
