### PR TITLE
Change camel case acronym rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,38 +138,38 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
 * <a id='bool-names'></a>(<a href='#bool-names'>link</a>) **Name booleans like `isSpaceship`, `hasSpacesuit`, etc.** This makes it clear that they are booleans and not other types.
 
-* <a id='capitalize-acronyms'></a>(<a href='#capitalize-acronyms'>link</a>) **Acronyms in names (e.g. `URL`) should be all-caps except when it’s the start of a name that would otherwise be lowerCamelCase, in which case it should be uniformly lower-cased.**
+* <a id='camel-case-acronyms'></a>(<a href='camel-case-acronyms'>link</a>) **Acronyms in names (e.g. `URL`) should follow the standard rules of CamelCase.**
 
   <details>
 
   ```swift
   // WRONG
-  class UrlValidator {
-
-    func isValidUrl(_ URL: URL) -> Bool {
-      // ...
-    }
-
-    func isUrlReachable(_ URL: URL) -> Bool {
-      // ...
-    }
-  }
-
-  let URLValidator = UrlValidator().isValidUrl(/* some URL */)
-
-  // RIGHT
   class URLValidator {
 
-    func isValidURL(_ url: URL) -> Bool {
+    func isValidURL(_ URL: URL) -> Bool {
       // ...
     }
 
-    func isURLReachable(_ url: URL) -> Bool {
+    func isURLReachable(_ URL: URL) -> Bool {
       // ...
     }
   }
 
-  let urlValidator = URLValidator().isValidURL(/* some URL */)
+  let URLValidator = URLValidator().isValidURL(/* some URL */)
+
+  // RIGHT
+  class UrlValidator {
+
+    func isValidUrl(_ url: url) -> Bool {
+      // ...
+    }
+
+    func isUrlReachable(_ url: url) -> Bool {
+      // ...
+    }
+  }
+
+  let urlValidator = UrlValidator().isValidUrl(/* some URL */)
   ```
 
   </details>


### PR DESCRIPTION
#### Summary

This would update the style guide to treat acronyms as normal words within camel case.

No matter what happens, I'll work on a linter rule so we can keep things consistent.

Please read the reasoning below and mark with 👍/👎

#### Reasoning

Pros:
- Easier transitioning between snake_case (from the server and from Codable models) and camelCase because every word is consistent without exception. This way we won't have to write special code or have an acronym whitelist to to convert variables with acronyms in them.
- Potentially better for GraphQL variable conversion in the future.
- Argument for readability: Easier to mentally separate the words with no all caps acronyms running into the next word. For examples: `httpURLRequest` vs `httpUrlRequest`
- We won't be the only ones: Google's Java style guide does this https://google.github.io/styleguide/javaguide.html#s5.3-camel-case

Cons:
- This isn't how Apple treats acronyms in camelCase (https://swift.org/documentation/api-design-guidelines/#general-conventions)
- Mental overhead of thinking about what name something should be depending on whether it's defined by Apple or Airbnb
- Argument for readability: Acronyms in real English are in fact all caps

#### Reviewers
cc @airbnb/swift-styleguide-maintainers

_Please react with 👍/👎 if you agree or disagree with this proposal._
