### PR TITLE
Remove multi line array rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,32 +339,6 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
-* <a id='multi-line-array'></a>(<a href='#multi-line-array'>link</a>) **Multi-line arrays should have each bracket on a separate line.** Put the opening and closing brackets on separate lines from any of the elements of the array. Also add a trailing comma on the last element.
-
-  <details>
-
-  ```swift
-  // WRONG
-  let rowContent = [listingUrgencyDatesRowContent(),
-                    listingUrgencyBookedRowContent(),
-                    listingUrgencyBookedShortRowContent()]
-
-  let rowContent = [
-    listingUrgencyDatesRowContent(),
-    listingUrgencyBookedRowContent(),
-    listingUrgencyBookedShortRowContent()
-  ]
-
-  // RIGHT
-  let rowContent = [
-    listingUrgencyDatesRowContent(),
-    listingUrgencyBookedRowContent(),
-    listingUrgencyBookedShortRowContent(),
-  ]
-  ```
-
-  </details>
-
 * <a id='long-if-statement'></a>(<a href='#long-if-statement'>link</a>) **When an `if`/`guard` statement becomes [too long](#column-width), start each condition with a newline, including the first.** This includes the last clause: put the opening curly brace on a new line to ensure proper indentation of the statement body. The first condition is also indented to vertically align all conditions.
 
   <details>


### PR DESCRIPTION
#### Summary

Remove multi line array rule: #42  

#### Reasoning

Following the new tenet added in this PR https://github.com/airbnb/swift/pull/35

#### Reviewers
cc @airbnb/swift-styleguide-maintainers