### PR TITLE
Remove Long function chains rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -688,38 +688,6 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
-* <a id='long-function-chains'></a>(<a href='#long-function-chains'>link</a>) **Separate [long](#column-width) function chains with line breaks before each dot.** [![SwiftLint: multiline_function_chains](https://img.shields.io/badge/SwiftLint-multiline__function__chains-008489.svg)](https://github.com/realm/SwiftLint/blob/master/Rules.md#multiline-function-chains)
-
-  <details>
-
-  #### Why?
-  It's easier to follow control flow through long function chains when each call has the same indentation.
-
-  ```swift
-  /// WRONG
-
-  match(pattern: pattern).compactMap { range in
-      return Command(string: contents, range: range)
-    }.compactMap { command in
-      return command.expand()
-  }
-
-  /// RIGHT
-
-  match(pattern: pattern)
-    .compactMap { range in
-      return Command(string: contents, range: range)
-    }
-    .compactMap { command in
-      return command.expand()
-  }
-
-  // Short function chains can still be on one line:
-  let evenSquares = [20, 17, 35, 4].filter { $0 % 2 == 0 }.map { $0 * $0 }
-  ```
-
-  </details>
-
 ### Closures
 
 * <a id='omit-closure-void-return'></a>(<a href='#omit-closure-void-return'>link</a>) **Omit `Void` return types from closure definitions.** (Even though that’s what autocomplete does.)


### PR DESCRIPTION
#### Summary

Remove Long function chains rule: #48 

#### Reasoning

Following the new tenet added in this PR https://github.com/airbnb/swift/pull/35

#### Reviewers
cc @airbnb/swift-styleguide-maintainers