### PR TITLE
Remove Each type in a file should be preceded by MARK rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -1287,15 +1287,6 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
 * <a id='limit-vertical-whitespace'></a>(<a href='#limit-vertical-whitespace'>link</a>) **Limit empty vertical whitespace to one line.** Favor the following formatting guidelines over whitespace of varying heights to divide files into logical groupings. [![SwiftLint: vertical_whitespace](https://img.shields.io/badge/SwiftLint-vertical__whitespace-008489.svg)](https://github.com/realm/SwiftLint/blob/master/Rules.md#vertical-whitespace)
 
-* <a id='marks-for-types'></a>(<a href='#marks-for-types'>link</a>) **Each type in a file should be preceded by `// MARK: - TypeName`.** [![SwiftLint: mark](https://img.shields.io/badge/SwiftLint-mark-008489.svg)](https://github.com/realm/SwiftLint/blob/master/Rules.md#mark)
-
-  <details>
-
-  #### Why?
-  The hyphen visually distinguishes types from sections within those types (described below).
-
-  </details>
-
 * <a id='marks-within-types'></a>(<a href='#marks-within-types'>link</a>) **Use `// MARK:` to separate the contents of a type definition into the sections listed below, in order.** All type definitions should be divided up in this consistent way, allowing a new reader of your code to easily jump to what he or she is interested in. [![SwiftLint: mark](https://img.shields.io/badge/SwiftLint-mark-008489.svg)](https://github.com/realm/SwiftLint/blob/master/Rules.md#mark)
   * `// MARK: Lifecycle` for `init` and `deinit` methods.
   * `// MARK: Open` for `open` properties and methods.


### PR DESCRIPTION
#### Summary

Remove Each type in a file should be preceded by MARK rule: #54 

#### Reasoning

Following the new tenet added in this PR https://github.com/airbnb/swift/pull/35

#### Reviewers
cc @airbnb/swift-styleguide-maintainers