### PR TITLE
Add SwiftFormat badge in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ At minimum every rule should contain:
 #### Example:
 
 * <a id='an-id'></a><a href='#an-id'>(link)</a>
-**This is the description of the rule.** [![SwiftLint: some_rule](https://img.shields.io/badge/SwiftLint-some__rule-008489.svg)](https://github.com/realm/SwiftLint/blob/master/Rules.md#some_rule)
+**This is the description of the rule.** [![SwiftLint: some_rule](https://img.shields.io/badge/SwiftLint-some__rule-008489.svg)](https://github.com/realm/SwiftLint/blob/master/Rules.md#some_rule) [![SwiftFormat: some_rule](https://img.shields.io/badge/SwiftFormat-some__rule-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat#rules)
 
   <details>
 


### PR DESCRIPTION
#### Summary

Adds a badge option for SwiftFormat to our CONTRIBUTING.md

#### Reasoning

We already support SwiftFormat in our style guide but we didn't have a badge for it in CONTRIBUTING. This adds the option. I'm using Hackberry for the badge color.

#### Reviewers
cc @airbnb/swift-styleguide-maintainers
