### PR TITLE
Remove unused SwiftLint rules

### DIFF
--- a/resources/swiftlint.yml
+++ b/resources/swiftlint.yml
@@ -1,5 +1,4 @@
 whitelist_rules:
-  - closing_brace
   - closure_end_indentation
   - closure_spacing
   - colon
@@ -15,9 +14,6 @@ whitelist_rules:
   - legacy_constant
   - legacy_constructor
   - legacy_nsgeometry_functions
-  - mark
-  - multiline_function_chains
-  - multiline_parameters
   - operator_usage_whitespace
   - redundant_string_enum_value
   - redundant_void_return
@@ -26,7 +22,6 @@ whitelist_rules:
   - type_name
   - unneeded_parentheses_in_closure_argument
   - unused_closure_parameter
-  - vertical_parameter_alignment_on_call
   - vertical_whitespace
   - void_return
 
@@ -44,10 +39,4 @@ custom_rules:
     name: "@objcMembers"
     regex: "@objcMembers"
     message: "Explicitly use @objc on each member you want to expose to Objective-C"
-    severity: error
-
-  long_function_return_arrow_newline:
-    name: "long_function_return_arrow_newline"
-    regex: (\bfunc [^(]+\(\n[^)]+?\)) *(throws\b|->)
-    message: "Return arrow in long function declarations should be on the newline just like the arguments. For more details on the regex visit this link: https://regex101.com/r/h7qzfy/3"
     severity: error


### PR DESCRIPTION
#### Summary

After our [new guiding tenet](https://github.com/airbnb/swift/pull/35) was added I went ahead and removed all the rules that didn't comply to this. This PR removes the now unused SwiftLint rules.

#### Details

- `closing_brace` is not actually part of our style guide
- `mark` removed here https://github.com/airbnb/swift/issues/54, https://github.com/airbnb/swift/issues/56
- `multiline_function_chains` removed here https://github.com/airbnb/swift/issues/48
- `multiline_parameters` removed here https://github.com/airbnb/swift/issues/38, https://github.com/airbnb/swift/issues/40
- `vertical_parameter_alignment_on_call` removed here https://github.com/airbnb/swift/issues/38, https://github.com/airbnb/swift/issues/40
- `long_function_return_arrow_newline` removed here https://github.com/airbnb/swift/issues/48

#### Reasoning

This rules are not in our style guide anymore and thus should be removed.

#### Reviewers
cc @airbnb/swift-styleguide-maintainers
