### PR TITLE
Add SwiftFormat sortedImports and trailingSpace badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
 * <a id='spaces-over-tabs'></a>(<a href='#spaces-over-tabs'>link</a>) **Use 2 spaces to indent lines.**
 
-* <a id='trailing-whitespace'></a>(<a href='#trailing-whitespace'>link</a>) **Trim trailing whitespace in all lines.**
+* <a id='trailing-whitespace'></a>(<a href='#trailing-whitespace'>link</a>) **Trim trailing whitespace in all lines.** [![SwiftFormat: trailingSpace](https://img.shields.io/badge/SwiftFormat-trailingSpace-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat#rules)
 
 **[⬆ back to top](#table-of-contents)**
 
@@ -1130,7 +1130,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
 ## File Organization
 
-* <a id='alphabetize-imports'></a>(<a href='#alphabetize-imports'>link</a>) **Alphabetize module imports at the top of the file a single line below the last line of the header comments. Do not add additional line breaks between import statements.** [![SwiftLint: sorted_imports](https://img.shields.io/badge/SwiftLint-sorted__imports-007A87.svg)](https://github.com/realm/SwiftLint/blob/master/Rules.md#sorted-imports)
+* <a id='alphabetize-imports'></a>(<a href='#alphabetize-imports'>link</a>) **Alphabetize module imports at the top of the file a single line below the last line of the header comments. Do not add additional line breaks between import statements.** [![SwiftFormat: sortedImports](https://img.shields.io/badge/SwiftFormat-sortedImports-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat#rules)
 
   <details>
 


### PR DESCRIPTION
#### Summary

Add SwiftFormat sortedImports and trailingSpace badges

#### Reasoning

We're using both of these in our [airbnb.swiftformat](https://github.com/airbnb/swift/blob/master/resources/airbnb.swiftformat) file. This just adds it to the Style Guide.

#### Reviewers
cc @airbnb/swift-styleguide-maintainers
