### PR TITLE
Replace complex property accessor guidelines with complex property observer guideline

### DIFF
--- a/README.md
+++ b/README.md
@@ -703,7 +703,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
 * <a id='time-intensive-init'></a>(<a href='#time-intensive-init'>link</a>) **Avoid performing any meaningful or time-intensive work in `init()`.** Avoid doing things like opening database connections, making network requests, reading large amounts of data from disk, etc. Create something like a `start()` method if these things need to be done before an object is ready for use.
 
-* <a id='complex-property-observers'></a>(<a href='#complex-computed-properties-and-observers'>link</a>) **Extract complex property observers into methods.** This reduces nestedness, separates side-effects from property declarations, and makes the usage of implicitly-passed parameters like `oldValue` explicit.
+* <a id='complex-property-observers'></a>(<a href='#complex-property-observers'>link</a>) **Extract complex property observers into methods.** This reduces nestedness, separates side-effects from property declarations, and makes the usage of implicitly-passed parameters like `oldValue` explicit.
 
   <details>
 


### PR DESCRIPTION
#### Summary
Replaces the existing "Use functions instead of computed properties if they get to be complicated" rule with a new rule that only suggests that complex property observers should be extracted out into separate functions in line with our existing "Extract complex callback blocks into methods" rule. 

#### Reasoning
Not only do we not really follow this rule in practice, but I think it would actively harm the readability of our codebase by throwing out the property semantics of complex properties if we exhaustively followed it.
- Computed properties do not contribute to deep nestedness, and naming the function for a "complex" computed property feels like it would not follow swift naming conventions—would you just prefix the property with with `get`?
- We don't frequently have large implementations of getters and setters, so I think we can just leave these out entirely.

Additionally, there's already a specific rule in the Swift API design guidelines that handles this scenario in a lighter touch way by recommending a documentation based-approach for complex computed properties, which I think we should defer to:
> Document the complexity of any computed property that is not O(1). People often assume that property access involves no significant computation, because they have stored properties as a mental model. Be sure to alert them when that assumption may be violated.

The reason why I replaced this rule rather than deleting it outright is that I do see us frequently using property observers, and it's a common pattern we follow to extract them out. It seemed worth enshrining into the style guide.

#### Reviewers
@bachand @fdiaz cc @airbnb/swift-styleguide-maintainers

_Please react with 👍/👎 if you agree or disagree with this proposal._