### PR TITLE
Add SwiftLint rule for `optional-nil-check`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1100,7 +1100,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
-* <a id='optional-nil-check'></a>(<a href='#optional-nil-check'>link</a>) **Check for nil rather than using optional binding if you don't need to use the value.**
+* <a id='optional-nil-check'></a>(<a href='#optional-nil-check'>link</a>) **Check for nil rather than using optional binding if you don't need to use the value.** [![SwiftLint: unused_optional_binding](https://img.shields.io/badge/SwiftLint-unused_optional_binding-007A87.svg)](https://github.com/realm/SwiftLint/blob/master/Rules.md#unused_optional_binding)
 
   <details>
 

--- a/README.md
+++ b/README.md
@@ -1100,7 +1100,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
-* <a id='optional-nil-check'></a>(<a href='#optional-nil-check'>link</a>) **Check for nil rather than using optional binding if you don't need to use the value.** [![SwiftLint: unused_optional_binding](https://img.shields.io/badge/SwiftLint-unused_optional_binding-007A87.svg)](https://github.com/realm/SwiftLint/blob/master/Rules.md#unused_optional_binding)
+* <a id='optional-nil-check'></a>(<a href='#optional-nil-check'>link</a>) **Check for nil rather than using optional binding if you don't need to use the value.** [![SwiftLint: unused_optional_binding](https://img.shields.io/badge/SwiftLint-unused_optional_binding-007A87.svg)](https://github.com/realm/SwiftLint/blob/master/Rules.md#unused-optional-binding)
 
   <details>
 

--- a/resources/swiftlint.yml
+++ b/resources/swiftlint.yml
@@ -22,6 +22,7 @@ whitelist_rules:
   - type_name
   - unneeded_parentheses_in_closure_argument
   - unused_closure_parameter
+  - unused_optional_binding
   - vertical_whitespace
   - void_return
 


### PR DESCRIPTION
#### Summary

Closes https://github.com/airbnb/swift/issues/72 by attaching the appropriate [SwiftLint rule](https://github.com/realm/SwiftLint/blob/master/Rules.md#unused_optional_binding) to our `optional-nil-check` rule. 

#### Reviewers
cc @airbnb/swift-styleguide-maintainers