### PR TITLE
Add link to SwiftFormat’s redundantSelf rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
-* <a id='omit-self'></a>(<a href='#omit-self'>link</a>) **Don't use `self` unless it's necessary for disambiguation or required by the language.**
+* <a id='omit-self'></a>(<a href='#omit-self'>link</a>) **Don't use `self` unless it's necessary for disambiguation or required by the language.** [![SwiftFormat: redundantSelf](https://img.shields.io/badge/SwiftFormat-redundantSelf-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#redundantSelf)
 
   <details>
 

--- a/resources/airbnb.swiftformat
+++ b/resources/airbnb.swiftformat
@@ -1,7 +1,8 @@
 # options
+--self remove # redundantSelf
 --importgrouping testable-bottom # sortedImports
 --commas always # trailingCommas
 --trimwhitespace always # trailingSpace
 
 # rules
---rules redundantParens,sortedImports,trailingCommas,trailingSpace
+--rules redundantParens,redundantSelf,sortedImports,trailingCommas,trailingSpace


### PR DESCRIPTION
#### Summary

Added link to SwiftFormat rule for removing implicit self.

#### Reasoning

SwiftFormat is able to reliably remove all redundant uses of `self` automatically (SwiftLint can automatically insert `self`, but not remove it).

#### Reviewers
cc @airbnb/swift-styleguide-maintainers

_Please react with 👍/👎 if you agree or disagree with this proposal._
