### PR TITLE
Remove redundant guideline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1044,35 +1044,6 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
-* <a id='switch-with-where'></a>(<a href='#switch-with-where'>link</a>) **Be careful when using `where` clauses when handling multiple cases in a `switch`.**
-
-  <details>
-
-  #### Why?
-  The where clause only applies to the last case in line.
-
-  ```swift
-  // WRONG
-  func doThing() {
-    switch anEnum {
-    //where x == y will only be evaluated if anEnum is .B
-    case .a, .b where x == y:
-      doDifferentThing()
-    }
-  }
-
-  // RIGHT
-  func doThing() {
-    switch anEnum {
-    case .a where x == y,
-         .b where x == y:
-      doDifferentThing()
-    }
-  }
-  ```
-
-  </details>
-
 * <a id='switch-never-default'></a>(<a href='#switch-never-default'>link</a>) **Never use the `default` case when `switch`ing over an enum.**
 
   <details>


### PR DESCRIPTION
#### Summary

Removed the guideline about `where`-clause positioning in `switch` statements.

#### Reasoning

Swift already generates a warning for this scenario (see screenshot), so mentioning it seems redundant (on the assumption that "code should compile with no warnings" is already an implicit guideline).

<img width="651" alt="screen shot 2019-02-07 at 23 53 46" src="https://user-images.githubusercontent.com/546885/52450773-62f49280-2b34-11e9-8daa-8575b1cc63ff.png">

#### Reviewers
cc @airbnb/swift-styleguide-maintainers

_Please react with 👍/👎 if you agree or disagree with this proposal._