### PR TITLE
Add redundantParens to airbnb.swiftformat

### DIFF
--- a/resources/airbnb.swiftformat
+++ b/resources/airbnb.swiftformat
@@ -4,4 +4,4 @@
 --trimwhitespace always # trailingSpace
 
 # rules
---rules sortedImports,trailingCommas,trailingSpace
+--rules redundantParens,sortedImports,trailingCommas,trailingSpace


### PR DESCRIPTION
#### Summary

I forgot about requiring this after [this PR](https://github.com/airbnb/swift/pull/77)

#### Reviewers
cc @airbnb/swift-styleguide-maintainers
