### PR TITLE
Remove closure_end_indentation rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,42 +593,6 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
     </details>
 
-* <a id='closure-end-brace-indentation'></a>(<a href='#closure-end-brace-indentation'>link</a>) **Closure end braces should have the same indentation as the line with their opening brace.** This makes it easier to follow control flow through closures. [![SwiftLint: closure_end_indentation](https://img.shields.io/badge/SwiftLint-closure__end__indentation-007A87.svg)](https://github.com/realm/SwiftLint/blob/master/Rules.md#closure-end-indentation)
-
-  <details>
-
-  ```swift
-  // WRONG
-
-  match(pattern: pattern)
-    .compactMap { range in
-      return Command(string: contents, range: range)
-  }
-    .compactMap { command in
-      return command.expand()
-  }
-
-  values.forEach { value in
-    print(value)
-    }
-
-  // RIGHT
-
-  match(pattern: pattern)
-    .compactMap { range in
-      return Command(string: contents, range: range)
-    }
-    .compactMap { command in
-      return command.expand()
-    }
-
-  values.forEach { value in
-    print(value)
-  }
-  ```
-
-  </details>
-
 * <a id='closure-brace-spacing'></a>(<a href='#closure-brace-spacing'>link</a>) **Single-line closures should have a space inside each brace.** [![SwiftLint: closure_spacing](https://img.shields.io/badge/SwiftLint-closure__spacing-007A87.svg)](https://github.com/realm/SwiftLint/blob/master/Rules.md#closure-spacing)
 
   <details>

--- a/resources/swiftlint.yml
+++ b/resources/swiftlint.yml
@@ -1,5 +1,4 @@
 whitelist_rules:
-  - closure_end_indentation
   - closure_spacing
   - colon
   - control_statement


### PR DESCRIPTION
#### Summary

Remove the closure_end_indentation rule

#### Reasoning

It violates the second guiding tenet of the style guide:
> These rules should not fight Xcode's ^ + I indentation behavior.

![image](https://user-images.githubusercontent.com/443086/52456585-3deb2a00-2b0a-11e9-9755-c599ada1e3c6.png)

I understand that many people dislike Xcode's default style of indenting closure end braces, but I think the guiding tenet is more important. This exception will negatively impact programmer experience and productivity by guaranteeing a locally inconsistent style and linting failure every time Xcode autocompletes a block or we use ^+I.  

The "don't fight Xcode" tenet is important to me because it, in turn, reflects a much broader tenet: "do no harm". It's an assurance that the goal of the style guide is to assist and supplement our other tools to improve the clarity and consistency of code -- not to impose rules even if there are negative side effects.

P.S. `SwiftLint` is new to me so I don't know if there's a way to modify the rule to reflect Xcode's default indentation and leave the door open to change the details later (e.g. if Xcode ever makes this configurable).

#### Reviewers
cc @airbnb/swift-styleguide-maintainers

_Please react with 👍/👎 if you agree or disagree with this proposal._
