### PR TITLE
Fix capitalization of "Spacefleet" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
     // ...
   }
 
-  class Spacefleet: SpaceThing {
+  class SpaceFleet: SpaceThing {
 
     enum Formation {
       // ...
@@ -83,7 +83,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
     }
   }
 
-  let myFleet = Spacefleet()
+  let myFleet = SpaceFleet()
   ```
 
   </details>


### PR DESCRIPTION
#### Summary
Since space fleet is two words, the class name used in this example should have the correct casing to reflect that. `Spacefleet` -> `SpaceFleet`.

#### Reasoning
Our examples should follow Apple's guidelines of using `UpperCamelCase` for type names.

#### Reviewers
cc @airbnb/swift-styleguide-maintainers

_Please react with 👍/👎 if you agree or disagree with this proposal._
