### PR TITLE
Add custom_rules to whitelist

### DIFF
--- a/resources/swiftlint.yml
+++ b/resources/swiftlint.yml
@@ -21,6 +21,7 @@ whitelist_rules:
   - unused_optional_binding
   - vertical_whitespace
   - void_return
+  - custom_rules
 
 excluded:
   - Carthage


### PR DESCRIPTION
#### Summary

This will add custom_rules to the whitlist, otherwise they won´t get applied.

#### Reasoning
If using custom rules alongside a whitelist, make sure to add custom_rules as an item under whitelist_rules. See also [SwiftLint README](https://github.com/realm/SwiftLint/blob/master/README.md#defining-custom-rules)

#### Reviewers
cc @airbnb/swift-styleguide-maintainers

_Please react with 👍/👎 if you agree or disagree with this proposal._
