### PR TITLE
Adjust Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -688,10 +688,10 @@ _You can enable the following settings in Xcode by running [this script](resourc
   // RIGHT
   class TextField {
     var text: String? {
-      didSet { updateText(from: oldValue) }
+      didSet { textDidUpdate(from: oldValue) }
     }
 
-    private func updateText(from oldValue: String?) {
+    private func textDidUpdate(from oldValue: String?) {
       guard oldValue != text else {
         return
       }


### PR DESCRIPTION
#### Summary

Updated Function Name in Example

#### Reasoning

Example should conform to previous rule: "Event-handling functions should be named like past-tense sentences"

#### Reviewers
cc @airbnb/swift-styleguide-maintainers

_Please react with 👍/👎 if you agree or disagree with this proposal._
