### PR TITLE
Clarify detail example for guard in preconditions-and-asserts

### DIFF
--- a/README.md
+++ b/README.md
@@ -942,7 +942,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
   func didSubmitText(_ text: String) {
     // It's unclear how this was called with an empty string; our custom text field shouldn't allow this.
     // This assert is useful for debugging but it's OK if we simply ignore this scenario in production.
-    guard text.isEmpty else {
+    guard !text.isEmpty else {
       assertionFailure("Unexpected empty string")
       return
     }


### PR DESCRIPTION
#### Summary

I believe the intention of this guard was to guard against an empty string for the assertionFailure.
This is pretty small but hopefully clarifies the intention of the guard given the comment above it.

#### Reasoning

As the code is written, this would actually have the opposite effect and alway call the assertionFailure.  I think its minor but I just saw it while reading through the rules.

#### Reviewers
cc @airbnb/swift-styleguide-maintainers

_Please react with 👍/👎 if you agree or disagree with this proposal._