### PR TITLE
Add style for upgrading weak self to strong reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,46 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
+* <a id='upgrade-self'></a>(<a href='#upgrade-self'>link</a>) **Bind to `self` when upgrading from a weak reference.** 
+
+  <details>
+
+  ```swift
+  //WRONG
+  class MyClass {
+
+    func request(completion: () -> Void) {
+      API.request() { [weak self] response in
+        guard let strongSelf = self else { return }
+        strongSelf.doSomething(strongSelf.property)
+        completion()
+      }
+    }
+    
+    func doSomething(nonOptionalParameter: SomeClass) {
+      // Processing and side effects
+    }
+  }
+
+  // RIGHT
+  class MyClass {
+
+    func request(completion: () -> Void) {
+      API.request() { [weak self] response in
+        guard let self = self else { return }
+        self.doSomething(self.property)
+        completion()
+      }
+    }
+
+    func doSomething(nonOptionalParameter: SomeClass) {
+      // Processing and side effects
+    }
+  }
+  ```
+
+  </details>
+
 * <a id='trailing-comma-array'></a>(<a href='#trailing-comma-array'>link</a>) **Add a trailing comma on the last element of a multi-line array.** [![SwiftFormat: trailingCommas](https://img.shields.io/badge/SwiftFormat-trailingCommas-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#trailingCommas)
 
   <details>
@@ -713,7 +753,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
     func request(completion: () -> Void) {
       API.request() { [weak self] response in
-        if let strongSelf = self {
+        if let self = self {
           // Processing and side effects
         }
         completion()
@@ -726,8 +766,8 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
     func request(completion: () -> Void) {
       API.request() { [weak self] response in
-        guard let strongSelf = self else { return }
-        strongSelf.doSomething(strongSelf.property)
+        guard let self = self else { return }
+        self.doSomething(self.property)
         completion()
       }
     }

--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
       API.request() { [weak self] response in
         guard let strongSelf = self else { return }
         // Do work
+        completion()
       }
     }
   }
@@ -362,6 +363,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
       API.request() { [weak self] response in
         guard let self = self else { return }
         // Do work
+        completion()
       }
     }
   }

--- a/README.md
+++ b/README.md
@@ -350,13 +350,8 @@ _You can enable the following settings in Xcode by running [this script](resourc
     func request(completion: () -> Void) {
       API.request() { [weak self] response in
         guard let strongSelf = self else { return }
-        strongSelf.doSomething(strongSelf.property)
-        completion()
+        // Do work
       }
-    }
-    
-    func doSomething(nonOptionalParameter: SomeClass) {
-      // Processing and side effects
     }
   }
 
@@ -366,13 +361,8 @@ _You can enable the following settings in Xcode by running [this script](resourc
     func request(completion: () -> Void) {
       API.request() { [weak self] response in
         guard let self = self else { return }
-        self.doSomething(self.property)
-        completion()
+        // Do work
       }
-    }
-
-    func doSomething(nonOptionalParameter: SomeClass) {
-      // Processing and side effects
     }
   }
   ```


### PR DESCRIPTION
#### Summary

Starting in Swift 4.2 (released September 2018), `self` is allowed to be upgraded from a weak reference to strong reference: [Allow using optional binding to upgrade self from a weak to strong reference](https://github.com/apple/swift-evolution/blob/master/proposals/0079-upgrade-self-from-weak-to-strong.md)

#### Reasoning

I propose that we adopt this style for the same reasons it was accepted into Swift language.

* Avoid having to deal with `strongSelf`, `s`, `ss`
* Follows existing Swift convention of optional binding that reuses the name of the variable.

#### Reviewers
cc @airbnb/swift-styleguide-maintainers

_Please react with 👍/👎 if you agree or disagree with this proposal._
