### PR TITLE
Consider Markdown for Repository Language Determination

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.md linguist-detectable=true
+*.md linguist-documentation=false


### PR DESCRIPTION
#### Summary

Currently, GitHub incorrectly displays this repository as being a Shell project:

<img width="997" alt="Screen Shot 2019-10-03 at 09 13 22" src="https://user-images.githubusercontent.com/7659/66144761-4c68e300-e5be-11e9-9e7d-4e23457c67d3.png">

This PR adds a `.gitattributes` file so that GitHub will consider Markdown files when making its language determination for this repository:

<img width="993" alt="Screen Shot 2019-10-03 at 09 12 54" src="https://user-images.githubusercontent.com/7659/66144841-74f0dd00-e5be-11e9-8b71-41107a85bca9.png">

#### Reasoning

This is a similar change to what I proposed on Swift Evolution (https://github.com/apple/swift-evolution/pull/1074), and much of the same rationale applies here as well. The basic gist is that correcting this categorization will help discoverability and encourage new contributions.  

#### Reviewers
cc @airbnb/swift-styleguide-maintainers

_Please react with 👍/👎 if you agree or disagree with this proposal._
