### PR TITLE
Add "ID" example capitalize-acronyms rule, and make example more powerful

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ _You can enable the following settings in Xcode by running [this script](resourc
     }
   }
 
+  let URLValidator = UrlValidator().isValidUrl(/* some URL */)
+
   // RIGHT
   class URLValidator {
 
@@ -166,6 +168,8 @@ _You can enable the following settings in Xcode by running [this script](resourc
       // ...
     }
   }
+
+  let urlValidator = URLValidator().isValidURL(/* some URL */)
   ```
 
   </details>

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
     }
   }
 
-  let urlValidator = urlValidator()
+  let urlValidator = URLValidator()
   let isProfile = urlValidator.isProfileUrl(urlToTest, userID: idOfUser)
   ```
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,8 @@ _You can enable the following settings in Xcode by running [this script](resourc
     }
   }
 
-  let URLValidator = UrlValidator().isValidUrl(/* some URL */)
+  let URLValidator = UrlValidator()
+  let isProfile = URLValidator.isProfileUrl(URLToTest, userId: IDOfUser)
 
   // RIGHT
   class URLValidator {
@@ -169,7 +170,8 @@ _You can enable the following settings in Xcode by running [this script](resourc
     }
   }
 
-  let urlValidator = URLValidator().isValidURL(/* some URL */)
+  let urlValidator = urlValidator()
+  let isProfile = urlValidator.isProfileUrl(urlToTest, userID: idOfUser)
   ```
 
   </details>

--- a/README.md
+++ b/README.md
@@ -150,12 +150,10 @@ _You can enable the following settings in Xcode by running [this script](resourc
       // ...
     }
 
-    func isUrlReachable(_ URL: URL) -> Bool {
+    func isProfileUrl(_ URL: URL, for userId: String) -> Bool {
       // ...
     }
   }
-
-  let URLValidator = UrlValidator().isValidUrl(/* some URL */)
 
   // RIGHT
   class URLValidator {
@@ -164,12 +162,10 @@ _You can enable the following settings in Xcode by running [this script](resourc
       // ...
     }
 
-    func isURLReachable(_ url: URL) -> Bool {
+    func isProfileURL(_ url: URL, for userID: String) -> Bool {
       // ...
     }
   }
-
-  let urlValidator = URLValidator().isValidURL(/* some URL */)
   ```
 
   </details>
@@ -500,7 +496,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
   ```
 
   </details>
-  
+
 * <a id='favor-constructors'></a>(<a href='#favor-constructors'>link</a>) **Use constructors instead of Make() functions for NSRange and others.** [![SwiftLint: legacy_constructor](https://img.shields.io/badge/SwiftLint-legacy__constructor-007A87.svg)](https://github.com/realm/SwiftLint/blob/master/Rules.md#legacy-constructor)
 
   <details>


### PR DESCRIPTION
#### Summary

- Removes `func isURLReachable(_:)`. IMHO this function was adding minimal educational value. The only difference between `func isURLReachable(_:)` and `isValidURL(_:)` is that "URL" is in the middle instead of the end. I don't think this is very debateable, and so I think we should simplify to focus on more interesting cases.
- The line of code `let urlValidator = URLValidator().isValidURL(/* some URL */)` doesn't make sense. We're creating a variable called `urlValidator` that is actually a `Bool` 🤦‍♂ The `urlValidator` variable now has semantic meaning.
- Adds examples that show how we recommend formatting "ID".

#### Reasoning

Apple's [`Identifiable` protocol](https://developer.apple.com/documentation/swift/identifiable) establishes that `ID` is [uppercase when used as a type](https://developer.apple.com/documentation/swift/identifiable/3285390-id) and [lowercase when used as a property](https://developer.apple.com/documentation/swift/identifiable/3285392-id). I believe that we should consider "ID" to be an acronym for the purposes of this rule.

#### Reviewers
cc @airbnb/swift-styleguide-maintainers

_Please react with 👍/👎 if you agree or disagree with this proposal._
