### PR TITLE
Add omit-return rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -1076,6 +1076,46 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
+* <a id='omit-single-expression-return'></a>(<a href='#omit-single-expression-return'>link</a>) **Omit the `return` keyword from single-expression functions, accessors, and closures.** [![SwiftFormat: redundantReturn](https://img.shields.io/badge/SwiftFormat-redundantReturn-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#redundantReturn)
+
+  <details>
+  
+  ```swift
+  // WRONG
+  ["1", "2", "3"].compactMap { return Int($0) }
+  
+  var size: CGSize {
+    return CGSize(
+      width: 100.0,
+      height: 100.0)
+  }
+  
+  func makeInfoAlert(message: String) -> UIAlertController {
+    return UIAlertController(
+      title: "ℹ️ Info",
+      message: message,
+      preferredStyle: .alert)
+  }
+  
+  // RIGHT
+  ["1", "2", "3"].compactMap { Int($0) }
+  
+  var size: CGSize {
+    CGSize(
+      width: 100.0,
+      height: 100.0)
+  }
+  
+  func makeInfoAlert(message: String) -> UIAlertController {
+    UIAlertController(
+      title: "ℹ️ Info",
+      message: message,
+      preferredStyle: .alert)
+  }
+  ```
+  
+  </details>
+
 **[⬆ back to top](#table-of-contents)**
 
 ## File Organization

--- a/README.md
+++ b/README.md
@@ -1076,7 +1076,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
-* <a id='omit-single-expression-return'></a>(<a href='#omit-single-expression-return'>link</a>) **Omit the `return` keyword from single-expression functions, accessors, and closures.** [![SwiftFormat: redundantReturn](https://img.shields.io/badge/SwiftFormat-redundantReturn-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#redundantReturn)
+* <a id='omit-single-expression-return'></a>(<a href='#omit-single-expression-return'>link</a>) **Omit the `return` keyword when not required by the language.** [![SwiftFormat: redundantReturn](https://img.shields.io/badge/SwiftFormat-redundantReturn-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#redundantReturn)
 
   <details>
   

--- a/README.md
+++ b/README.md
@@ -1076,7 +1076,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
-* <a id='omit-single-expression-return'></a>(<a href='#omit-single-expression-return'>link</a>) **Omit the `return` keyword when not required by the language.** [![SwiftFormat: redundantReturn](https://img.shields.io/badge/SwiftFormat-redundantReturn-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#redundantReturn)
+* <a id='omit-return'></a>(<a href='#omit-return'>link</a>) **Omit the `return` keyword when not required by the language.** [![SwiftFormat: redundantReturn](https://img.shields.io/badge/SwiftFormat-redundantReturn-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#redundantReturn)
 
   <details>
   

--- a/resources/airbnb.swiftformat
+++ b/resources/airbnb.swiftformat
@@ -3,7 +3,7 @@
 --importgrouping testable-bottom # sortedImports
 --commas always # trailingCommas
 --trimwhitespace always # trailingSpace
---swiftversion 5
+--swiftversion 5.1
 
 # rules
---rules redundantParens,redundantSelf,sortedImports,strongifiedSelf,trailingCommas,trailingSpace
+--rules redundantParens,redundantReturn,redundantSelf,sortedImports,strongifiedSelf,trailingCommas,trailingSpace


### PR DESCRIPTION
#### Summary

I propose we adopt a new `omit-return` rule:

> **Omit the `return` keyword when not required by the language.** 
> **[[SwiftFormat: redundantReturn]](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#redundantReturn)**

```swift
// WRONG
["1", "2", "3"].compactMap { return Int($0) }

var size: CGSize {
  return CGSize(
    width: 100.0,
    height: 100.0)
}

func makeInfoAlert(message: String) -> UIAlertController {
  return UIAlertController(
    title: "ℹ️ Info",
    message: message,
    preferredStyle: .alert)
}

// RIGHT
["1", "2", "3"].compactMap { Int($0) }

var size: CGSize {
  CGSize(
    width: 100.0,
    height: 100.0)
}

func makeInfoAlert(message: String) -> UIAlertController {
  UIAlertController(
    title: "ℹ️ Info",
    message: message,
    preferredStyle: .alert)
}
```

#### Reasoning

- As of Swift 5.1 ([SE-255](https://github.com/apple/swift-evolution/blob/master/proposals/0255-omit-return.md)), the `return` keyword can now be omitted from single-expression functions and accessors.
- It isn't currently codified in the style guide, but omitting return is already strongly preferred for single-element closures
  - e.g. we would already tend to prefer `["1", "2", "3"].compactMap { Int($0) }` over `["1", "2", "3"].compactMap { return Int($0) }`.
- Our style guide prefers omitting keywords and types when permitted by the compiler:
  - Don't use `self` unless it's necessary for disambiguation or required by the language. (<a href='https://github.com/airbnb/swift#omit-self'>link</a>)
  - Don't include types where they can be easily inferred. (<a href='https://github.com/airbnb/swift#use-implicit-types'>link</a>)
  - Omit `Void` return types from function definitions. (<a href='https://github.com/airbnb/swift#omit-function-void-return'>link</a>)


<!--- required --->

#### Reviewers
cc @airbnb/swift-styleguide-maintainers

_Please react with 👍/👎 if you agree or disagree with this proposal._
