### PR TITLE
Update complex closure example

### DIFF
--- a/README.md
+++ b/README.md
@@ -745,12 +745,12 @@ _You can enable the following settings in Xcode by running [this script](resourc
     func request(completion: () -> Void) {
       API.request() { [weak self] response in
         guard let self = self else { return }
-        self.doSomething(self.property)
+        self.doSomething(with: self.property, response: response)
         completion()
       }
     }
 
-    func doSomething(nonOptionalParameter: SomeClass) {
+    func doSomething(with nonOptionalParameter: SomeClass, response: SomeResponseClass) {
       // Processing and side effects
     }
   }


### PR DESCRIPTION
#### Summary

Hello old friends! I found a thing I don't like in the complex closure example, so I fixed it

#### Reasoning

As it is, the `RIGHT` example violates the unused closure parameter rule. Just adding `response` as a parameter to `doSomething` to make things more clear.

#### Reviewers
cc @airbnb/swift-styleguide-maintainers

_Please react with 👍/👎 if you agree or disagree with this proposal._
