### PR TITLE
Update PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,4 @@
 
 <!--- required --->
 
-#### Reviewers
-cc @airbnb/swift-styleguide-maintainers
-
 _Please react with 👍/👎 if you agree or disagree with this proposal._


### PR DESCRIPTION
#### Summary

I'm removing the explicit REVIEWERS section of the PR template.

#### Reasoning

This is only triggered when a member of the @airbnb org is the author. See examples of PRs that don't tag this group [here](https://github.com/airbnb/swift/pull/77) or [here](https://github.com/airbnb/swift/pull/91).

Since we already have an integration to notify us on Slack, this is not needed anyways.

@airbnb/swift-styleguide-maintainers 
