### PR TITLE
Prefer AnyObject over class in protocol definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1119,6 +1119,11 @@ _You can enable the following settings in Xcode by running [this script](resourc
 * <a id='use-anyobject'></a>(<a href='#use-anyobject'>link</a>) **Use `AnyObject` instead of `class` in protocol definitions.** [![SwiftFormat: anyObjectProtocol](https://img.shields.io/badge/SwiftFormat-anyObjectProtocol-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#anyobjectprotocol)
 
   <details>
+  ### Why?
+  
+  [SE-0156](https://github.com/apple/swift-evolution/blob/master/proposals/0156-subclass-existentials.md]), which introduced support for using the `AnyObject` keyword as a protocol constraint, recommends preferring `AnyObject` over `class`:
+  
+  > This proposal merges the concepts of `class` and `AnyObject`, which now have the same meaning: they represent an existential for classes. To get rid of the duplication, we suggest only keeping `AnyObject` around. To reduce source-breakage to a minimum, `class` could be redefined as `typealias class = AnyObject` and give a deprecation warning on class for the first version of Swift this proposal is implemented in. Later, `class` could be removed in a subsequent version of Swift.
   
   ```swift
   // WRONG

--- a/README.md
+++ b/README.md
@@ -1116,6 +1116,20 @@ _You can enable the following settings in Xcode by running [this script](resourc
   
   </details>
 
+* <a id='use-anyobject'></a>(<a href='#use-anyobject'>link</a>) **Use `AnyObject` instead of `class` in protocol definitions.** [![SwiftFormat: anyObjectProtocol](https://img.shields.io/badge/SwiftFormat-anyObjectProtocol-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#anyobjectprotocol)
+
+  <details>
+  
+  ```swift
+  // WRONG
+  protocol Foo: class {}
+  
+  // RIGHT
+  protocol Foo: AnyObject {}
+  ```
+  
+  </details>
+
 **[⬆ back to top](#table-of-contents)**
 
 ## File Organization

--- a/resources/airbnb.swiftformat
+++ b/resources/airbnb.swiftformat
@@ -6,4 +6,4 @@
 --swiftversion 5.1
 
 # rules
---rules redundantParens,redundantReturn,redundantSelf,sortedImports,strongifiedSelf,trailingCommas,trailingSpace
+--rules anyObjectProtocol,redundantParens,redundantReturn,redundantSelf,sortedImports,strongifiedSelf,trailingCommas,trailingSpace

--- a/resources/swiftlint.yml
+++ b/resources/swiftlint.yml
@@ -1,5 +1,4 @@
 whitelist_rules:
-  - anyobject_protocol
   - closure_spacing
   - colon
   - empty_enum_arguments

--- a/resources/swiftlint.yml
+++ b/resources/swiftlint.yml
@@ -1,4 +1,5 @@
 whitelist_rules:
+  - anyobject_protocol
   - closure_spacing
   - colon
   - empty_enum_arguments


### PR DESCRIPTION
#### Summary
https://github.com/airbnb/swift/issues/97

Use `: AnyObject` instead of `: class` in protocol definitions

#### Reasoning

[This accepted Swift proposal](https://github.com/apple/swift-evolution/blob/master/proposals/0156-subclass-existentials.md#class-and-anyobject) that merges the concepts of `class` and `AnyObject` states that

> we suggest only keeping AnyObject around

We should update the guide to align with this evolution of Swift.

Popular linters such as Swift format and Swift lint already have rules for this:

https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#anyobjectprotocol

https://github.com/realm/SwiftLint/tree/master/Source/SwiftLintFramework/Rules/Lint

_Please react with 👍/👎 if you agree or disagree with this proposal._
