### PR TITLE
Reintroduce old wrapping rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -619,62 +619,6 @@ _You can enable the following settings in Xcode by running [this script](resourc
   ```
 
   </details>
-
-### Closures
-
-* <a id='favor-void-closure-return'></a>(<a href='#favor-void-closure-return'>link</a>) **Favor `Void` return types over `()` in closure declarations.** If you must specify a `Void` return type in a function declaration, use `Void` rather than `()` to improve readability. [![SwiftLint: void_return](https://img.shields.io/badge/SwiftLint-void__return-007A87.svg)](https://github.com/realm/SwiftLint/blob/master/Rules.md#void-return)
-
-  <details>
-
-  ```swift
-  // WRONG
-  func method(completion: () -> ()) {
-    ...
-  }
-
-  // RIGHT
-  func method(completion: () -> Void) {
-    ...
-  }
-  ```
-
-  </details>
-
-* <a id='unused-closure-parameter-naming'></a>(<a href='#unused-closure-parameter-naming'>link</a>) **Name unused closure parameters as underscores (`_`).** [![SwiftLint: unused_closure_parameter](https://img.shields.io/badge/SwiftLint-unused__closure__parameter-007A87.svg)](https://github.com/realm/SwiftLint/blob/master/Rules.md#unused-closure-parameter)
-
-    <details>
-
-    #### Why?
-    Naming unused closure parameters as underscores reduces the cognitive overhead required to read
-    closures by making it obvious which parameters are used and which are unused.
-
-    ```swift
-    // WRONG
-    someAsyncThing() { argument1, argument2, argument3 in
-      print(argument3)
-    }
-
-    // RIGHT
-    someAsyncThing() { _, _, argument3 in
-      print(argument3)
-    }
-    ```
-
-    </details>
-
-* <a id='closure-brace-spacing'></a>(<a href='#closure-brace-spacing'>link</a>) **Single-line closures should have a space inside each brace.** [![SwiftLint: closure_spacing](https://img.shields.io/badge/SwiftLint-closure__spacing-007A87.svg)](https://github.com/realm/SwiftLint/blob/master/Rules.md#closure-spacing)
-
-  <details>
-
-  ```swift
-  // WRONG
-  let evenSquares = numbers.filter {$0 % 2 == 0}.map {  $0 * $0  }
-
-  // RIGHT
-  let evenSquares = numbers.filter { $0 % 2 == 0 }.map { $0 * $0 }
-  ```
-
-  </details>
   
 * <a id='long-function-declaration'></a>(<a href='#long-function-declaration'>link</a>) **Separate [long](https://github.com/airbnb/swift#column-width) function declarations with line breaks before each argument label and before the return signature.** Put the open curly brace on the next line so the first executable line doesn't look like it's another parameter. [![SwiftFormat: wrapArguments](https://img.shields.io/badge/SwiftFormat-wrapArguments-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapArguments) [![SwiftFormat: wrapMultilineStatementBraces](https://img.shields.io/badge/SwiftFormat-wrapMultilineStatementBraces-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapMultilineStatementBraces)
 
@@ -757,6 +701,62 @@ _You can enable the following settings in Xcode by running [this script](resourc
     5,
     .stars,
     at: location)
+  ```
+
+  </details>
+
+### Closures
+
+* <a id='favor-void-closure-return'></a>(<a href='#favor-void-closure-return'>link</a>) **Favor `Void` return types over `()` in closure declarations.** If you must specify a `Void` return type in a function declaration, use `Void` rather than `()` to improve readability. [![SwiftLint: void_return](https://img.shields.io/badge/SwiftLint-void__return-007A87.svg)](https://github.com/realm/SwiftLint/blob/master/Rules.md#void-return)
+
+  <details>
+
+  ```swift
+  // WRONG
+  func method(completion: () -> ()) {
+    ...
+  }
+
+  // RIGHT
+  func method(completion: () -> Void) {
+    ...
+  }
+  ```
+
+  </details>
+
+* <a id='unused-closure-parameter-naming'></a>(<a href='#unused-closure-parameter-naming'>link</a>) **Name unused closure parameters as underscores (`_`).** [![SwiftLint: unused_closure_parameter](https://img.shields.io/badge/SwiftLint-unused__closure__parameter-007A87.svg)](https://github.com/realm/SwiftLint/blob/master/Rules.md#unused-closure-parameter)
+
+    <details>
+
+    #### Why?
+    Naming unused closure parameters as underscores reduces the cognitive overhead required to read
+    closures by making it obvious which parameters are used and which are unused.
+
+    ```swift
+    // WRONG
+    someAsyncThing() { argument1, argument2, argument3 in
+      print(argument3)
+    }
+
+    // RIGHT
+    someAsyncThing() { _, _, argument3 in
+      print(argument3)
+    }
+    ```
+
+    </details>
+
+* <a id='closure-brace-spacing'></a>(<a href='#closure-brace-spacing'>link</a>) **Single-line closures should have a space inside each brace.** [![SwiftLint: closure_spacing](https://img.shields.io/badge/SwiftLint-closure__spacing-007A87.svg)](https://github.com/realm/SwiftLint/blob/master/Rules.md#closure-spacing)
+
+  <details>
+
+  ```swift
+  // WRONG
+  let evenSquares = numbers.filter {$0 % 2 == 0}.map {  $0 * $0  }
+
+  // RIGHT
+  let evenSquares = numbers.filter { $0 % 2 == 0 }.map { $0 * $0 }
   ```
 
   </details>

--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
-* <a id='long-function-declaration'></a>(<a href='#long-function-declaration'>link</a>) **Separate [long](https://github.com/airbnb/swift#column-width) function declarations with line breaks before each argument label and before the return signature.** Put the open curly brace on the next line so the first executable line doesn't look like it's another parameter. [![SwiftFormat: wrapArguments](https://img.shields.io/badge/SwiftFormat-wrapArguments-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapArguments) [![SwiftFormat: wrapMultilineStatementBraces](https://img.shields.io/badge/SwiftFormat-wrapArguments-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapArguments)
+* <a id='long-function-declaration'></a>(<a href='#long-function-declaration'>link</a>) **Separate [long](https://github.com/airbnb/swift#column-width) function declarations with line breaks before each argument label and before the return signature.** Put the open curly brace on the next line so the first executable line doesn't look like it's another parameter. [![SwiftFormat: wrapArguments](https://img.shields.io/badge/SwiftFormat-wrapArguments-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapArguments) [![SwiftFormat: wrapMultilineStatementBraces](https://img.shields.io/badge/SwiftFormat-wrapMultilineStatementBraces-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapMultilineStatementBraces)
 
   <details>
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
-* <a id='spaces-over-tabs'></a>(<a href='#spaces-over-tabs'>link</a>) **Use 2 spaces to indent lines.**
+* <a id='spaces-over-tabs'></a>(<a href='#spaces-over-tabs'>link</a>) **Use 2 spaces to indent lines.** [![SwiftFormat: indent](https://img.shields.io/badge/SwiftFormat-indent-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#indent)
 
 * <a id='trailing-whitespace'></a>(<a href='#trailing-whitespace'>link</a>) **Trim trailing whitespace in all lines.** [![SwiftFormat: trailingSpace](https://img.shields.io/badge/SwiftFormat-trailingSpace-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#trailingSpace)
 

--- a/README.md
+++ b/README.md
@@ -387,6 +387,32 @@ _You can enable the following settings in Xcode by running [this script](resourc
   ```
 
   </details>
+  
+  * <a id='multi-line-array'></a>(<a href='#multi-line-array'>link</a>) **Multi-line arrays should have each bracket on a separate line.** Put the opening and closing brackets on separate lines from any of the elements of the array. Also add a trailing comma on the last element.
+
+  <details>
+
+  ```swift
+  // WRONG
+  let rowContent = [listingUrgencyDatesRowContent(),
+                    listingUrgencyBookedRowContent(),
+                    listingUrgencyBookedShortRowContent()]
+
+  let rowContent = [
+    listingUrgencyDatesRowContent(),
+    listingUrgencyBookedRowContent(),
+    listingUrgencyBookedShortRowContent()
+  ]
+
+  // RIGHT
+  let rowContent = [
+    listingUrgencyDatesRowContent(),
+    listingUrgencyBookedRowContent(),
+    listingUrgencyBookedShortRowContent(),
+  ]
+  ```
+
+  </details>
 
 * <a id='omit-self'></a>(<a href='#omit-self'>link</a>) **Don't use `self` unless it's necessary for disambiguation or required by the language.** [![SwiftFormat: redundantSelf](https://img.shields.io/badge/SwiftFormat-redundantSelf-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#redundantSelf)
 

--- a/README.md
+++ b/README.md
@@ -303,6 +303,72 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
+* <a id='long-function-declaration'></a>(<a href='#long-function-declaration'>link</a>) **Separate [long](https://github.com/airbnb/swift#column-width) function declarations with line breaks before each argument label and before the return signature.** Put the open curly brace on the next line so the first executable line doesn't look like it's another parameter. [![SwiftFormat: wrapArguments](https://img.shields.io/badge/SwiftFormat-wrapArguments-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapArguments) [![SwiftFormat: wrapMultilineStatementBraces](https://img.shields.io/badge/SwiftFormat-wrapArguments-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapArguments)
+
+  <details>
+
+  ```swift
+  class Universe {
+
+    // WRONG
+    func generateStars(at location: Point, count: Int, color: StarColor, withAverageDistance averageDistance: Float) -> String {
+      // This is too long and will probably auto-wrap in a weird way
+    }
+
+    // WRONG
+    func generateStars(at location: Point,
+                       count: Int,
+                       color: StarColor,
+                       withAverageDistance averageDistance: Float) -> String
+    {
+      // Xcode indents all the arguments
+    }
+
+    // WRONG
+    func generateStars(
+      at location: Point,
+      count: Int,
+      color: StarColor,
+      withAverageDistance averageDistance: Float) -> String {
+      populateUniverse() // this line blends in with the argument list
+    }
+
+    // WRONG
+    func generateStars(
+      at location: Point,
+      count: Int,
+      color: StarColor,
+      withAverageDistance averageDistance: Float) throws
+      -> String {
+      populateUniverse() // this line blends in with the argument list
+    }
+
+    // RIGHT
+    func generateStars(
+      at location: Point,
+      count: Int,
+      color: StarColor,
+      withAverageDistance averageDistance: Float) 
+      -> String
+    {
+      populateUniverse()
+    }
+
+    // RIGHT
+    func generateStars(
+      at location: Point,
+      count: Int,
+      color: StarColor,
+      withAverageDistance averageDistance: Float) 
+      throws -> String
+    {
+      populateUniverse()
+    }
+  }
+  ```
+
+  </details>
+
 * <a id='long-function-invocation'></a>(<a href='#long-function-invocation'>link</a>) **[Long](https://github.com/airbnb/swift#column-width) function invocations should also break on each argument.** Put the closing parenthesis on the last line of the invocation. [![SwiftFormat: wrapArguments](https://img.shields.io/badge/SwiftFormat-wrapArguments-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapArguments)
 
   <details>

--- a/README.md
+++ b/README.md
@@ -388,7 +388,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
   
-  * <a id='multi-line-array'></a>(<a href='#multi-line-array'>link</a>) **Multi-line arrays should have each bracket on a separate line.** Put the opening and closing brackets on separate lines from any of the elements of the array. Also add a trailing comma on the last element.
+  * <a id='multi-line-array'></a>(<a href='#multi-line-array'>link</a>) **Multi-line arrays should have each bracket on a separate line.** Put the opening and closing brackets on separate lines from any of the elements of the array. Also add a trailing comma on the last element. [![SwiftFormat: wrapArguments](https://img.shields.io/badge/SwiftFormat-wrapArguments-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapArguments)
 
   <details>
 
@@ -641,6 +641,31 @@ _You can enable the following settings in Xcode by running [this script](resourc
   switch animal {
   case .dog:
     ...
+  }
+  ```
+
+  </details>
+  
+* <a id='attributes-on-prev-line'></a>(<a href='#attributes-on-prev-line'>link</a>) **Place function/type attributes on the line above the declaration**. [![SwiftFormat: wrapAttributes](https://img.shields.io/badge/SwiftFormat-wrapAttributes-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapAttributes)
+
+  <details>
+
+  ```swift
+  // WRONG
+  @objc class Spaceship: NSObject {
+  
+    @discardableResult func fly() -> Bool {
+    }
+  }
+
+  // RIGHT
+
+  @objc
+  class Spaceship: NSObject {
+  
+    @discardableResult
+    func fly() -> Bool {
+    }
   }
   ```
 

--- a/README.md
+++ b/README.md
@@ -303,6 +303,25 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
+* <a id='long-function-invocation'></a>(<a href='#long-function-invocation'>link</a>) **[Long](https://github.com/airbnb/swift#column-width) function invocations should also break on each argument.** Put the closing parenthesis on the last line of the invocation. [![SwiftFormat: wrapArguments](https://img.shields.io/badge/SwiftFormat-wrapArguments-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapArguments)
+
+  <details>
+
+  ```swift
+  universe.generateStars(
+    at: location,
+    count: 5,
+    color: starColor,
+    withAverageDistance: 4)
+
+  universe.generate(
+    5,
+    .stars,
+    at: location)
+  ```
+
+  </details>
+
 * <a id='omit-self'></a>(<a href='#omit-self'>link</a>) **Don't use `self` unless it's necessary for disambiguation or required by the language.** [![SwiftFormat: redundantSelf](https://img.shields.io/badge/SwiftFormat-redundantSelf-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#redundantSelf)
 
   <details>

--- a/README.md
+++ b/README.md
@@ -541,7 +541,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   ```swift
   // WRONG
-  @objc class Spaceship: NSObject {
+  @objc class Spaceship {
   
     @discardableResult func fly() -> Bool {
     }
@@ -550,7 +550,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
   // RIGHT
 
   @objc
-  class Spaceship: NSObject {
+  class Spaceship {
   
     @discardableResult
     func fly() -> Bool {
@@ -691,12 +691,36 @@ _You can enable the following settings in Xcode by running [this script](resourc
   <details>
 
   ```swift
+  // WRONG
+  universe.generateStars(at: location, count: 5, color: starColor, withAverageDistance: 4)
+
+  // WRONG
+  universe.generateStars(at: location,
+                         count: 5,
+                         color: starColor,
+                         withAverageDistance: 4)
+
+  // WRONG
+  universe.generateStars(
+    at: location,
+    count: 5,
+    color: starColor,
+    withAverageDistance: 4
+  )
+
+  // WRONG
+  universe.generate(5,
+    .stars,
+    at: location)
+
+  // RIGHT
   universe.generateStars(
     at: location,
     count: 5,
     color: starColor,
     withAverageDistance: 4)
 
+  // RIGHT
   universe.generate(
     5,
     .stars,
@@ -795,7 +819,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   ```swift
   // WRONG
-  class MyClass: NSObject {
+  class MyClass {
 
     init() {
       super.init()
@@ -806,7 +830,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
   }
 
   // RIGHT
-  class MyClass: NSObject {
+  class MyClass {
 
     init() {
       someValue = 0

--- a/README.md
+++ b/README.md
@@ -303,117 +303,6 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
-* <a id='long-function-declaration'></a>(<a href='#long-function-declaration'>link</a>) **Separate [long](https://github.com/airbnb/swift#column-width) function declarations with line breaks before each argument label and before the return signature.** Put the open curly brace on the next line so the first executable line doesn't look like it's another parameter. [![SwiftFormat: wrapArguments](https://img.shields.io/badge/SwiftFormat-wrapArguments-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapArguments) [![SwiftFormat: wrapMultilineStatementBraces](https://img.shields.io/badge/SwiftFormat-wrapMultilineStatementBraces-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapMultilineStatementBraces)
-
-  <details>
-
-  ```swift
-  class Universe {
-
-    // WRONG
-    func generateStars(at location: Point, count: Int, color: StarColor, withAverageDistance averageDistance: Float) -> String {
-      // This is too long and will probably auto-wrap in a weird way
-    }
-
-    // WRONG
-    func generateStars(at location: Point,
-                       count: Int,
-                       color: StarColor,
-                       withAverageDistance averageDistance: Float) -> String
-    {
-      // Xcode indents all the arguments
-    }
-
-    // WRONG
-    func generateStars(
-      at location: Point,
-      count: Int,
-      color: StarColor,
-      withAverageDistance averageDistance: Float) -> String {
-      populateUniverse() // this line blends in with the argument list
-    }
-
-    // WRONG
-    func generateStars(
-      at location: Point,
-      count: Int,
-      color: StarColor,
-      withAverageDistance averageDistance: Float) throws
-      -> String {
-      populateUniverse() // this line blends in with the argument list
-    }
-
-    // RIGHT
-    func generateStars(
-      at location: Point,
-      count: Int,
-      color: StarColor,
-      withAverageDistance averageDistance: Float) 
-      -> String
-    {
-      populateUniverse()
-    }
-
-    // RIGHT
-    func generateStars(
-      at location: Point,
-      count: Int,
-      color: StarColor,
-      withAverageDistance averageDistance: Float) 
-      throws -> String
-    {
-      populateUniverse()
-    }
-  }
-  ```
-
-  </details>
-
-* <a id='long-function-invocation'></a>(<a href='#long-function-invocation'>link</a>) **[Long](https://github.com/airbnb/swift#column-width) function invocations should also break on each argument.** Put the closing parenthesis on the last line of the invocation. [![SwiftFormat: wrapArguments](https://img.shields.io/badge/SwiftFormat-wrapArguments-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapArguments)
-
-  <details>
-
-  ```swift
-  universe.generateStars(
-    at: location,
-    count: 5,
-    color: starColor,
-    withAverageDistance: 4)
-
-  universe.generate(
-    5,
-    .stars,
-    at: location)
-  ```
-
-  </details>
-  
-  * <a id='multi-line-array'></a>(<a href='#multi-line-array'>link</a>) **Multi-line arrays should have each bracket on a separate line.** Put the opening and closing brackets on separate lines from any of the elements of the array. Also add a trailing comma on the last element. [![SwiftFormat: wrapArguments](https://img.shields.io/badge/SwiftFormat-wrapArguments-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapArguments)
-
-  <details>
-
-  ```swift
-  // WRONG
-  let rowContent = [listingUrgencyDatesRowContent(),
-                    listingUrgencyBookedRowContent(),
-                    listingUrgencyBookedShortRowContent()]
-
-  let rowContent = [
-    listingUrgencyDatesRowContent(),
-    listingUrgencyBookedRowContent(),
-    listingUrgencyBookedShortRowContent()
-  ]
-
-  // RIGHT
-  let rowContent = [
-    listingUrgencyDatesRowContent(),
-    listingUrgencyBookedRowContent(),
-    listingUrgencyBookedShortRowContent(),
-  ]
-  ```
-
-  </details>
-
 * <a id='omit-self'></a>(<a href='#omit-self'>link</a>) **Don't use `self` unless it's necessary for disambiguation or required by the language.** [![SwiftFormat: redundantSelf](https://img.shields.io/badge/SwiftFormat-redundantSelf-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#redundantSelf)
 
   <details>
@@ -670,6 +559,32 @@ _You can enable the following settings in Xcode by running [this script](resourc
   ```
 
   </details>
+  
+* <a id='multi-line-array'></a>(<a href='#multi-line-array'>link</a>) **Multi-line arrays should have each bracket on a separate line.** Put the opening and closing brackets on separate lines from any of the elements of the array. Also add a trailing comma on the last element. [![SwiftFormat: wrapArguments](https://img.shields.io/badge/SwiftFormat-wrapArguments-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapArguments)
+
+  <details>
+
+  ```swift
+  // WRONG
+  let rowContent = [listingUrgencyDatesRowContent(),
+                    listingUrgencyBookedRowContent(),
+                    listingUrgencyBookedShortRowContent()]
+
+  let rowContent = [
+    listingUrgencyDatesRowContent(),
+    listingUrgencyBookedRowContent(),
+    listingUrgencyBookedShortRowContent()
+  ]
+
+  // RIGHT
+  let rowContent = [
+    listingUrgencyDatesRowContent(),
+    listingUrgencyBookedRowContent(),
+    listingUrgencyBookedShortRowContent(),
+  ]
+  ```
+
+  </details>
 
 * <a id='favor-constructors'></a>(<a href='#favor-constructors'>link</a>) **Use constructors instead of Make() functions for NSRange and others.** [![SwiftLint: legacy_constructor](https://img.shields.io/badge/SwiftLint-legacy__constructor-007A87.svg)](https://github.com/realm/SwiftLint/blob/master/Rules.md#legacy-constructor)
 
@@ -757,6 +672,91 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   // RIGHT
   let evenSquares = numbers.filter { $0 % 2 == 0 }.map { $0 * $0 }
+  ```
+
+  </details>
+  
+* <a id='long-function-declaration'></a>(<a href='#long-function-declaration'>link</a>) **Separate [long](https://github.com/airbnb/swift#column-width) function declarations with line breaks before each argument label and before the return signature.** Put the open curly brace on the next line so the first executable line doesn't look like it's another parameter. [![SwiftFormat: wrapArguments](https://img.shields.io/badge/SwiftFormat-wrapArguments-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapArguments) [![SwiftFormat: wrapMultilineStatementBraces](https://img.shields.io/badge/SwiftFormat-wrapMultilineStatementBraces-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapMultilineStatementBraces)
+
+  <details>
+
+  ```swift
+  class Universe {
+
+    // WRONG
+    func generateStars(at location: Point, count: Int, color: StarColor, withAverageDistance averageDistance: Float) -> String {
+      // This is too long and will probably auto-wrap in a weird way
+    }
+
+    // WRONG
+    func generateStars(at location: Point,
+                       count: Int,
+                       color: StarColor,
+                       withAverageDistance averageDistance: Float) -> String
+    {
+      // Xcode indents all the arguments
+    }
+
+    // WRONG
+    func generateStars(
+      at location: Point,
+      count: Int,
+      color: StarColor,
+      withAverageDistance averageDistance: Float) -> String {
+      populateUniverse() // this line blends in with the argument list
+    }
+
+    // WRONG
+    func generateStars(
+      at location: Point,
+      count: Int,
+      color: StarColor,
+      withAverageDistance averageDistance: Float) throws
+      -> String {
+      populateUniverse() // this line blends in with the argument list
+    }
+
+    // RIGHT
+    func generateStars(
+      at location: Point,
+      count: Int,
+      color: StarColor,
+      withAverageDistance averageDistance: Float) 
+      -> String
+    {
+      populateUniverse()
+    }
+
+    // RIGHT
+    func generateStars(
+      at location: Point,
+      count: Int,
+      color: StarColor,
+      withAverageDistance averageDistance: Float) 
+      throws -> String
+    {
+      populateUniverse()
+    }
+  }
+  ```
+
+  </details>
+
+* <a id='long-function-invocation'></a>(<a href='#long-function-invocation'>link</a>) **[Long](https://github.com/airbnb/swift#column-width) function invocations should also break on each argument.** Put the closing parenthesis on the last line of the invocation. [![SwiftFormat: wrapArguments](https://img.shields.io/badge/SwiftFormat-wrapArguments-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapArguments)
+
+  <details>
+
+  ```swift
+  universe.generateStars(
+    at: location,
+    count: 5,
+    color: starColor,
+    withAverageDistance: 4)
+
+  universe.generate(
+    5,
+    .stars,
+    at: location)
   ```
 
   </details>

--- a/resources/airbnb.swiftformat
+++ b/resources/airbnb.swiftformat
@@ -3,7 +3,15 @@
 --importgrouping testable-bottom # sortedImports
 --commas always # trailingCommas
 --trimwhitespace always # trailingSpace
+--indent 2 #indent
+--ifdef no-indent #indent
+--wraparguments before-first # wrapArguments
+--wrapparameters before-first # wrapArguments
+--wrapcollections before-first # wrapArguments
+--closingparen same-line # wrapArguments
+--funcattributes prev-line # wrapAttributes
+--typeattributes prev-line # wrapAttributes
 --swiftversion 5.1
 
 # rules
---rules anyObjectProtocol,redundantParens,redundantReturn,redundantSelf,sortedImports,strongifiedSelf,trailingCommas,trailingSpace
+--rules anyObjectProtocol,redundantParens,redundantReturn,redundantSelf,sortedImports,strongifiedSelf,trailingCommas,trailingSpace,wrapArguments,wrapMultilineStatementBraces,indent,wrapAttributes


### PR DESCRIPTION
#### Summary

This PR reintroduces several of our old wrapping rules:
  - [Separate long function declarations with line breaks before each argument label and before the return signature](https://github.com/airbnb/swift/issues/38)
  - [Long function invocations should also break on each argument](https://github.com/airbnb/swift/issues/40)
  - [Multi-line arrays should have each bracket on a separate line](https://github.com/airbnb/swift/issues/42)
  - [Place function/type attributes on the line above the declaration](https://github.com/airbnb/swift/issues/46)

We removed these rules because they were missing autocorrect, but they are fully supported by SwiftFormat in `0.45.1`.