### PR TITLE
Explicitly mention typealiases in the subsection organization rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -1379,7 +1379,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
   * If the type in question is a simple value type (e.g. fewer than 20 lines), it is OK to omit the `// MARK:`s, as it would hurt legibility.
 
 * <a id='subsection-organization'></a>(<a href='#subsection-organization'>link</a>) **Within each top-level section, place content in the following order.** This allows a new reader of your code to more easily find what they are looking for. [![SwiftFormat: organizeDeclarations](https://img.shields.io/badge/SwiftFormat-organizeDeclarations-008489.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#organizeDeclarations)
-  * Nested types
+  * Nested types and typealiases
   * Static properties
   * Class properties
   * Instance properties


### PR DESCRIPTION
Follow-up to https://github.com/airbnb/swift/pull/102#discussion_r479558324.

Starting in SwiftFormat `0.46.1` (nicklockwood/SwiftFormat#724), `typealias` declarations are grouped with nested types. We should state this explicitly in the rule description.
