### PR TITLE
Remove "Prefer putting constants in the top level of a file if they are private" rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -959,7 +959,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
-* <a id='namespace-using-enums'></a>(<a href='#namespace-using-enums'>link</a>) **Prefer using caseless `enum`s for organizing `public` or `internal` constants and functions into namespaces.**
+* <a id='namespace-using-enums'></a>(<a href='#namespace-using-enums'>link</a>) **Use caseless `enum`s for organizing `public` or `internal` constants and functions into namespaces.**
   * Feel free to nest namespaces where it adds clarity.
   * Avoid creating non-namespaced global constants and functions.
   * `private` globals are permitted, since they are scoped to a single file and do not pollute the global namespace. Consider placing private globals in an `enum` namespace to match the guidelines for other declaration types.

--- a/README.md
+++ b/README.md
@@ -960,8 +960,8 @@ _You can enable the following settings in Xcode by running [this script](resourc
   </details>
 
 * <a id='namespace-using-enums'></a>(<a href='#namespace-using-enums'>link</a>) **Use caseless `enum`s for organizing `public` or `internal` constants and functions into namespaces.**
-  * Feel free to nest namespaces where it adds clarity.
   * Avoid creating non-namespaced global constants and functions.
+  * Feel free to nest namespaces where it adds clarity.
   * `private` globals are permitted, since they are scoped to a single file and do not pollute the global namespace. Consider placing private globals in an `enum` namespace to match the guidelines for other declaration types.
 
   <details>

--- a/README.md
+++ b/README.md
@@ -959,7 +959,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
-* <a id='namespace-using-enums'></a>(<a href='#namespace-using-enums'>link</a>) **Use caseless `enum`s for organizing `public` or `internal` constants and functions into namespaces.** Avoid creating non-namespaced global constants and functions. Feel free to nest namespaces where it adds clarity.
+* <a id='namespace-using-enums'></a>(<a href='#namespace-using-enums'>link</a>) **Use caseless `enum`s for organizing constants and functions into namespaces.** Avoid creating non-namespaced global constants and functions. Feel free to nest namespaces where it adds clarity.
 
   <details>
 

--- a/README.md
+++ b/README.md
@@ -962,7 +962,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 * <a id='namespace-using-enums'></a>(<a href='#namespace-using-enums'>link</a>) **Prefer using caseless `enum`s for organizing `public` or `internal` constants and functions into namespaces.**
   * Feel free to nest namespaces where it adds clarity.
   * Avoid creating non-namespaced global constants and functions.
-  * `private` globals are permitted, since they are scoped to a single file and do not pollute the global namespace. Consider placing private globals in an enum namespace to match the guidelines for other declaration types.
+  * `private` globals are permitted, since they are scoped to a single file and do not pollute the global namespace. Consider placing private globals in an `enum` namespace to match the guidelines for other declaration types.
 
   <details>
 

--- a/README.md
+++ b/README.md
@@ -959,7 +959,10 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
-* <a id='namespace-using-enums'></a>(<a href='#namespace-using-enums'>link</a>) **Use caseless `enum`s for organizing constants and functions into namespaces.** Avoid creating non-namespaced global constants and functions. Feel free to nest namespaces where it adds clarity.
+* <a id='namespace-using-enums'></a>(<a href='#namespace-using-enums'>link</a>) **Prefer using caseless `enum`s for organizing `public` or `internal` constants and functions into namespaces.**
+  * Feel free to nest namespaces where it adds clarity.
+  * Avoid creating non-namespaced global constants and functions.
+  * `private` globals are permitted, since they are scoped to a single file and do not pollute the global namespace. Consider placing private globals in an enum namespace to match the guidelines for other declaration types.
 
   <details>
 

--- a/README.md
+++ b/README.md
@@ -959,26 +959,6 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
-* <a id='private-constants'></a>(<a href='#private-constants'>link</a>) **Prefer putting constants in the top level of a file if they are `private`.** If they are `public` or `internal`, define them as static properties, for namespacing purposes.
-
-  <details>
-
-  ```swift
-  private let privateValue = "secret"
-
-  public class MyClass {
-
-    public static let publicValue = "something"
-
-    func doSomething() {
-      print(privateValue)
-      print(MyClass.publicValue)
-    }
-  }
-  ```
-
-  </details>
-
 * <a id='namespace-using-enums'></a>(<a href='#namespace-using-enums'>link</a>) **Use caseless `enum`s for organizing `public` or `internal` constants and functions into namespaces.** Avoid creating non-namespaced global constants and functions. Feel free to nest namespaces where it adds clarity.
 
   <details>


### PR DESCRIPTION
#### Summary

This PR proposes removing this rule from our style guide:

> **Prefer putting constants in the top level of a file if they are `private`.** If they are `public` or `internal`, define them as static properties, for namespacing purposes.
> 
>   ```swift
>   private let privateValue = "secret"
>
>   public class MyClass {
>
>     public static let publicValue = "something"
>
>     func doSomething() {
>       print(privateValue)
>       print(MyClass.publicValue)
>     }
>
>   }
>   ```

Instead, I think we should recommend placing these constants in `enum` namespaces (as an extension to the existing [namespace-using-enums](https://github.com/airbnb/swift#namespace-using-enums) rule).

<!--- required --->

#### Reasoning

1. I don't think we should be suggesting that folks create top-level declarations. This feels at-odds with the [Avoid creating non-namespaced global constants and functions](https://github.com/airbnb/swift#namespace-using-enums) rule.
2. This is a really old rule (that was [added](https://github.com/airbnb/swift/commit/c93ee5aae718d25401e001e78308bef73a4b5ac9#diff-9ba7d4d50c31dd7166688703e242142dR9) in 2016!). I don't think this rule represents idiomatic Swift anymore, now that the language has evolved and `enum` namespaces have become much more common.

<!--- required --->

_Please react with 👍/👎 if you agree or disagree with this proposal._
