### PR TITLE
Multi-line conditional statements should break after the leading keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -583,6 +583,58 @@ _You can enable the following settings in Xcode by running [this script](resourc
     listingUrgencyBookedShortRowContent(),
   ]
   ```
+  
+* <a id='multi-line-conditions'></a>(<a href='#multi-line-conditions'>link</a>) **Multi-line conditional statements should break after the leading keyword.** Indent each individual statement by [2 spaces](https://github.com/airbnb/swift#spaces-over-tabs). Put the open curly brace on the next line. [![SwiftFormat: wrapArguments](https://img.shields.io/badge/SwiftFormat-wrapArguments-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapArguments) [![SwiftFormat: wrapMultilineStatementBraces](https://img.shields.io/badge/SwiftFormat-wrapMultilineStatementBraces-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapMultilineStatementBraces)
+
+  <details>
+    
+  #### Why?
+  Breaking after the leading keyword resets indentation to the standard [2-space grid](https://github.com/airbnb/swift#spaces-over-tabs),
+  which helps avoid fighting Xcode's <kbd>^</kbd> + <kbd>I</kbd> indentation behavior.
+
+  ```swift
+  // WRONG
+  if let galaxy = galaxy,
+    galaxy.name == "Milky Way" // Indenting by two spaces fights Xcode's ^+I indentation behavior
+  { … }
+  
+  // WRONG
+  guard let galaxy = galaxy,
+        galaxy.name == "Milky Way" else // Variable width indentation (6 spaces)
+  { … }
+  
+  // WRONG
+  if 
+    let galaxy = galaxy,
+    galaxy.name == "Milky Way" {
+    // This line blends in with the list of conditions  
+  }
+  
+  // WRONG
+  guard let earth = unvierse.find(
+         .planet,
+         named: "Earth") else // Variable width indentation (7 spaces)
+  { … }
+  
+  // RIGHT
+  if 
+    let galaxy = galaxy,
+    galaxy.name == "Milky Way" 
+  { … }
+  
+  // RIGHT
+  guard 
+    let galaxy = galaxy,
+    galaxy.name == "Milky Way" else
+  { … }
+  
+  // RIGHT
+  guard 
+    let earth = unvierse.find(
+      .planet,
+      named: "Earth") else
+  { … }
+  ```
 
   </details>
 

--- a/resources/airbnb.swiftformat
+++ b/resources/airbnb.swiftformat
@@ -1,4 +1,4 @@
-# Current version of SwiftFormat used at Airbnb: 0.46.1
+# Current version of SwiftFormat used at Airbnb: 0.47.1
 
 # options
 --self remove # redundantSelf
@@ -10,6 +10,7 @@
 --wraparguments before-first # wrapArguments
 --wrapparameters before-first # wrapArguments
 --wrapcollections before-first # wrapArguments
+--wrapconditions before-first # wrapArguments
 --closingparen same-line # wrapArguments
 --funcattributes prev-line # wrapAttributes
 --typeattributes prev-line # wrapAttributes


### PR DESCRIPTION
### Summary

This PR proposes a new rule that multi-line conditional statements should break after the leading keyword.

> **Multi-line conditional statements should break after the leading keyword.** Indent each individual statement by [2 spaces](https://github.com/airbnb/swift#spaces-over-tabs). Put the open curly brace on the next line.

```swift
if
  let galaxy = galaxy,
  galaxy.name == "Milky Way"
{ … }

guard
  let galaxy = galaxy,
  galaxy.name == "Milky Way" else
{ … }

guard
  let earth = unvierse.find(
    .planet,
    named: "Earth") else
{ … }
```

### Alternatives Considered

#### <a id='variable-width-indentation'></a>Variable-Width Indentation

Xcode 12's <kbd>^</kbd> + <kbd>I</kbd> indentation behavior uses variable-width indentation for multi-line conditional statements:

```swift
if let galaxy = galaxy,
   galaxy.name == "Milky Way" // Indented by 3 spaces
{ … }

guard let galaxy = galaxy,
      galaxy.name == "Milky Way" else // Indented by 6 spaces
{ … }

guard let earth = unvierse.find(
       .planet,
       named: "Earth") else // Indented by 7 spaces
{ … }
```

Our style guide is generally opposed to using variable-width indentation. For example, we prefer breaking [function declarations](https://github.com/airbnb/swift#long-function-declaration) and [invocations](https://github.com/airbnb/swift#long-function-invocation) before the first argument to reset indentation back to the 2-space grid:

```swift
// WRONG
universe.generateStars(at: location,
                       count: 5,
                       color: starColor,
                       withAverageDistance: 4)

// RIGHT
universe.generateStars(
  at: location,
  count: 5,
  color: starColor,
  withAverageDistance: 4)
```

#### Don't add linebreak, still indent by 2 spaces

One alternative style could be to _not_ break after the conditional keyword and to instead indent subsequent statements by 2 spaces. Unfortunately, using this style means that engineers must fight Xcode 12's <kbd>^</kbd> + <kbd>I</kbd> indentation behavior, which always <a href="#variable-width-indentation">adds extra indentation</a> to match the width of the keyword. This is at odds with one of the [guiding tenets](https://github.com/airbnb/swift#guiding-tenets) of our style guide:
> These rules should not fight Xcode's <kbd>^</kbd> + <kbd>I</kbd> indentation behavior.

```swift
if let galaxy = galaxy,
  galaxy.name == "Milky Way"
{ … }

guard let galaxy = galaxy,
  galaxy.name == "Milky Way"
{ … }

guard let earth = unvierse.find(
  .planet,
  named: "Earth") else
{ … }
```

_Please react with 👍/👎 if you agree or disagree with this proposal._
