### PR TITLE
Update to SwiftFormat 0.47.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1448,7 +1448,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 * <a id='mark-types-and-extensions'></a>(<a href='#mark-types-and-extensions'>link</a>) **Each type and extension which implements a conformance should be preceded by a `MARK` comment.** [![SwiftFormat: markTypes](https://img.shields.io/badge/SwiftFormat-markTypes-008489.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#markTypes)
   * Types should be preceded by a `// MARK: - TypeName` comment.
   * Extensions that add a conformance should be preceded by a `// MARK: - TypeName + ProtocolName` comment.
-  * Extensions that follow the type being extended should omit that type's name and instead use `// MARK: ProtocolName`.
+  * Extensions that immediately follow the type being extended should omit that type's name and instead use `// MARK: ProtocolName`.
   * If there is only one type or extension in a file, the `MARK` comment can be omitted.
   * If the extension in question is empty (e.g. has no declarations in its body), the `MARK` comment can be omitted.
   * For extensions that do not add new conformances, consider adding a `MARK` with a descriptive comment.

--- a/resources/airbnb.swiftformat
+++ b/resources/airbnb.swiftformat
@@ -1,4 +1,4 @@
-# Current version of SwiftFormat used at Airbnb: 0.47.3
+# Current version of SwiftFormat used at Airbnb: 0.47.4
 
 # options
 --self remove # redundantSelf


### PR DESCRIPTION
#### Summary

This PR updates `airbnb.swiftformat` to reflect that we now use SwiftFormat `0.47.4`, and updates the description of the `mark-types-and-extensions` to reflect the [updated behavior](https://github.com/nicklockwood/SwiftFormat/pull/802) of the `markTypes` rule.
