### PR TITLE
Add --wrapreturntype if-multiline to airbnb.swiftformat

### DIFF
--- a/resources/airbnb.swiftformat
+++ b/resources/airbnb.swiftformat
@@ -11,6 +11,7 @@
 --wrapparameters before-first # wrapArguments
 --wrapcollections before-first # wrapArguments
 --wrapconditions before-first # wrapArguments
+--wrapreturntype if-multiline #wrapArguments
 --closingparen same-line # wrapArguments
 --funcattributes prev-line # wrapAttributes
 --typeattributes prev-line # wrapAttributes


### PR DESCRIPTION
#### Summary

This PR adds the `--wrapreturntype if-multiline` SwiftFormat option (added in [nicklockwood/SwiftFormat#764](https://github.com/nicklockwood/SwiftFormat/pull/764)) to `airbnb.swiftformat`.

This adds linter enforcement for an [existing rule](https://github.com/airbnb/swift#long-function-declaration) in our style guide:
> Separate long function declarations with line breaks before each argument label ***and before the return signature***. Put the open curly brace on the next line so the first executable line doesn't look like it's another parameter.

#### Reasoning

This rule is already described in our style guide -- we previously just weren't enforcing it through a linter.
