### PR TITLE
Bump SwiftFormat to 0.47.12

### DIFF
--- a/resources/airbnb.swiftformat
+++ b/resources/airbnb.swiftformat
@@ -1,4 +1,4 @@
-# Current version of SwiftFormat used at Airbnb: 0.47.4
+# Current version of SwiftFormat used at Airbnb: 0.47.12
 
 # options
 --self remove # redundantSelf


### PR DESCRIPTION
This PR updates `airbnb.swiftformat` to show that we are now using SwiftFormat `0.47.12` internally. 