### PR TITLE
Adjust example code to the described rule.

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
   }
 
   let urlValidator = URLValidator()
-  let isProfile = urlValidator.isProfileUrl(urlToTest, userID: idOfUser)
+  let isProfile = urlValidator.isProfileURL(urlToTest, userID: idOfUser)
   ```
 
   </details>

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
     public func executeRequest(
       _ request: URLRequest,
       onSuccess: @escaping (ModelType, Bool) -> Void,
-      onFailure: @escaping (Error) -> Void) -> URLSessionCancellable
+      onFailure: @escaping (Error) -> Void) -> URLSessionCancellable)
     {
       return _executeRequest(request, session, parser, onSuccess, onFailure)
     }
@@ -116,7 +116,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
     private let _executeRequest: (
       URLRequest,
       @escaping (ModelType, Bool) -> Void,
-      @escaping (NSError) -> Void) -> URLSessionCancellable
+      @escaping (NSError) -> Void) -> URLSessionCancellable)
 
   }
   ```


### PR DESCRIPTION
#### Summary

* Fix "capitalize-acronyms" example
* Add missing parentheses in 'use-camel-case' example

#### Reasoning

The reasoning explanation is not necessary. It's just a bug/typo fix.

_Please react with 👍/👎 if you agree or disagree with this proposal._
