### PR TITLE
Add "No direct standard out" rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -1382,7 +1382,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
   <details>
 
   #### Why?
-  All log messages should flow into intermediary logging systems that can direct them to the correct destination(s) based on the app's environment or configuration. `print(…)`, `debugPrint(…)`, or `dump(…)` will write directly to standard out in all app configurations and can potentially leak personally identifiable information (PII).
+  All log messages should flow into intermediate logging systems that can direct them to the correct destination(s) based on the app's environment or configuration. `print(…)`, `debugPrint(…)`, or `dump(…)` will write directly to standard out in all app configurations and can potentially leak personally identifiable information (PII).
 
   </details>
 

--- a/README.md
+++ b/README.md
@@ -1377,12 +1377,12 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
-* <a id='no-direct-standard-out-logs'></a>(<a href='#no-direct-standard-out-logs'>link</a>) **Prefer dedicated logging systems like [`os_log`](https://developer.apple.com/documentation/os/logging) or [`swift-log`](https://github.com/apple/swift-log) over writing directly to standard out using `print(…)`, `logDebug(…)`, or `dump(…)`.**
+* <a id='no-direct-standard-out-logs'></a>(<a href='#no-direct-standard-out-logs'>link</a>) **Prefer dedicated logging systems like [`os_log`](https://developer.apple.com/documentation/os/logging) or [`swift-log`](https://github.com/apple/swift-log) over writing directly to standard out using `print(…)`, `debugPrint(…)`, or `dump(…)`.**
 
   <details>
 
   #### Why?
-  All log messages should flow into intermediate logging systems that can direct them to the correct destination(s) based on the app's environment or configuration. `print(…)`, `debugPrint(…)`, or `dump(…)` will write directly to standard out in all app configurations and can potentially leak personally identifiable information (PII).
+  All log messages should flow into intermediate logging systems that can direct messages to the correct destination(s) and potentially filter messages based on the app's environment or configuration. `print(…)`, `debugPrint(…)`, or `dump(…)` will write all messages directly to standard out in all app configurations and can potentially leak personally identifiable information (PII).
 
   </details>
 

--- a/README.md
+++ b/README.md
@@ -1377,6 +1377,15 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
+* <a id='no_direct_standard_out'></a>(<a href='#no_direct_standard_out'>link</a>) **Prefer dedicated logging systems like [`os_log`](https://developer.apple.com/documentation/os/logging) or [`swift-log`](https://github.com/apple/swift-log) over writing logs directly to standard out using `print(…)`, `logDebug(…)`, or `dump(…)`.**
+
+  <details>
+
+  #### Why?
+  All log messages should flow into intermediary logging systems that can direct them to the correct destination(s) based on the app's environment or configuration. `print(…)`, `debugPrint(…)`, or `dump(…)` will write directly to standard out in all app configurations and can potentially leak personally identifiable information (PII).
+
+  </details>
+
 **[⬆ back to top](#table-of-contents)**
 
 ## File Organization

--- a/README.md
+++ b/README.md
@@ -1377,7 +1377,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
-* <a id='no_direct_standard_out'></a>(<a href='#no_direct_standard_out'>link</a>) **Prefer dedicated logging systems like [`os_log`](https://developer.apple.com/documentation/os/logging) or [`swift-log`](https://github.com/apple/swift-log) over writing directly to standard out using `print(…)`, `logDebug(…)`, or `dump(…)`.**
+* <a id='no-direct-standard-out-logs'></a>(<a href='#no-direct-standard-out-logs'>link</a>) **Prefer dedicated logging systems like [`os_log`](https://developer.apple.com/documentation/os/logging) or [`swift-log`](https://github.com/apple/swift-log) over writing directly to standard out using `print(…)`, `logDebug(…)`, or `dump(…)`.**
 
   <details>
 

--- a/README.md
+++ b/README.md
@@ -1377,7 +1377,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
-* <a id='no_direct_standard_out'></a>(<a href='#no_direct_standard_out'>link</a>) **Prefer dedicated logging systems like [`os_log`](https://developer.apple.com/documentation/os/logging) or [`swift-log`](https://github.com/apple/swift-log) over writing logs directly to standard out using `print(…)`, `logDebug(…)`, or `dump(…)`.**
+* <a id='no_direct_standard_out'></a>(<a href='#no_direct_standard_out'>link</a>) **Prefer dedicated logging systems like [`os_log`](https://developer.apple.com/documentation/os/logging) or [`swift-log`](https://github.com/apple/swift-log) over writing directly to standard out using `print(…)`, `logDebug(…)`, or `dump(…)`.**
 
   <details>
 

--- a/resources/swiftlint.yml
+++ b/resources/swiftlint.yml
@@ -38,10 +38,10 @@ custom_rules:
     regex: "@objcMembers"
     message: "Explicitly use @objc on each member you want to expose to Objective-C"
     severity: error
-  no_direct_standard_out:
+  no_direct_standard_out_logs:
     name: "Writing directly to standard out disallowed"
     regex: "(\\bprint|\\bdebugPrint|\\bdump|Swift\\.print|Swift\\.debugPrint|Swift\\.dump)\\s*\\("
     match_kinds:
     - identifier
-    message: "Don't commit `print(…)`, `debugPrint(…)`, or `dump(…)` as they write to standard out in release. Either log to a dedicated logging system or silence this warning in debug-only scenarios explicitly using `// swiftlint:disable:next no_direct_standard_out`"
+    message: "Don't commit `print(…)`, `debugPrint(…)`, or `dump(…)` as they write to standard out in release. Either log to a dedicated logging system or silence this warning in debug-only scenarios explicitly using `// swiftlint:disable:next no_direct_standard_out_logs`"
     severity: warning

--- a/resources/swiftlint.yml
+++ b/resources/swiftlint.yml
@@ -43,5 +43,5 @@ custom_rules:
     regex: "(\\bprint|\\bdebugPrint|\\bdump|Swift\\.print|Swift\\.debugPrint|Swift\\.dump)\\s*\\("
     match_kinds:
     - identifier
-    message: "Don't commit `print(…)`, `debugPrint(…)`, or `dump(…)` as they write to standard out in release. Prefer `logDebug(…)` instead or silence this warning in debug-only scenarios explicitly using `// swiftlint:disable:next no_direct_standard_out`"
+    message: "Don't commit `print(…)`, `debugPrint(…)`, or `dump(…)` as they write to standard out in release. Either log to a dedicated logging system or silence this warning in debug-only scenarios explicitly using `// swiftlint:disable:next no_direct_standard_out`"
     severity: warning

--- a/resources/swiftlint.yml
+++ b/resources/swiftlint.yml
@@ -38,3 +38,10 @@ custom_rules:
     regex: "@objcMembers"
     message: "Explicitly use @objc on each member you want to expose to Objective-C"
     severity: error
+  no_direct_standard_out:
+    name: "Writing directly to standard out disallowed"
+    regex: "(\\bprint|\\bdebugPrint|\\bdump|Swift\\.print|Swift\\.debugPrint|Swift\\.dump)\\s*\\("
+    match_kinds:
+    - identifier
+    message: "Don't commit `print(…)`, `debugPrint(…)`, or `dump(…)` as they write to standard out in release. Prefer `logDebug(…)` instead or silence this warning in debug-only scenarios explicitly using `// swiftlint:disable:next no_direct_standard_out`"
+    severity: warning

--- a/resources/swiftlint.yml
+++ b/resources/swiftlint.yml
@@ -39,7 +39,7 @@ custom_rules:
     message: "Explicitly use @objc on each member you want to expose to Objective-C"
     severity: error
   no_direct_standard_out_logs:
-    name: "Writing directly to standard out disallowed"
+    name: "Writing log messages directly to standard out is disallowed"
     regex: "(\\bprint|\\bdebugPrint|\\bdump|Swift\\.print|Swift\\.debugPrint|Swift\\.dump)\\s*\\("
     match_kinds:
     - identifier


### PR DESCRIPTION
### Summary
**Prefer dedicated logging systems like [`os_log`](https://developer.apple.com/documentation/os/logging) or [`swift-log`](https://github.com/apple/swift-log) over writing directly to standard out using `print(…)`, `logDebug(…)`, or `dump(…)`.**

Additionally includes a custom SwiftLint regex rule to flag violations as warnings. This rule isn't possible to autocorrect in the general case as the correct logging method depends on the specific app.

### Reasoning
All log messages should flow into intermediary logging systems that can direct them to the correct destination(s) based on the app's environment or configuration. `print(…)`, `debugPrint(…)`, or `dump(…)` will write directly to standard out in all app configurations and can potentially leak personally identifiable information (PII).

_Please react with 👍/👎 if you agree or disagree with this proposal._
