### PR TITLE
Add "prefer immutable statics" rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -1154,7 +1154,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
-* <a id='prefer-immutable-statics'></a>(<a href='#prefer-immutable-statics'>link</a>) **Prefer immutable or computed static variables over mutable ones whenever possible.** Use stored `static let` properties or computed `static var` properties over stored `static var`s properties whenever possible, as stored `static var` properties are global mutable state.
+* <a id='prefer-immutable-statics'></a>(<a href='#prefer-immutable-statics'>link</a>) **Prefer immutable or computed static properties over mutable ones whenever possible.** Use stored `static let` properties or computed `static var` properties over stored `static var`s properties whenever possible, as stored `static var` properties are global mutable state.
 
   <details>
 
@@ -1181,7 +1181,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
     static var initial = FeatureState(count: 0)
   }
 
-  // Right
+  // RIGHT
   struct FeatureState {
     var count: Int
 
@@ -1193,7 +1193,6 @@ _You can enable the following settings in Xcode by running [this script](resourc
   ```
 
   </details>
-
 
 * <a id='preconditions-and-asserts'></a>(<a href='#preconditions-and-asserts'>link</a>) **Handle an unexpected but recoverable condition with an `assert` method combined with the appropriate logging in production. If the unexpected condition is not recoverable, prefer a `precondition` method or `fatalError()`.** This strikes a balance between crashing and providing insight into unexpected conditions in the wild. Only prefer `fatalError` over a `precondition` method when the failure message is dynamic, since a `precondition` method won't report the message in the crash report. [![SwiftLint: fatal_error_message](https://img.shields.io/badge/SwiftLint-fatal__error__message-007A87.svg)](https://github.com/realm/SwiftLint/blob/master/Rules.md#fatal-error-message) [![SwiftLint: force_cast](https://img.shields.io/badge/SwiftLint-force__cast-007A87.svg)](https://github.com/realm/SwiftLint/blob/master/Rules.md#force-cast) [![SwiftLint: force_try](https://img.shields.io/badge/SwiftLint-force__try-007A87.svg)](https://github.com/realm/SwiftLint/blob/master/Rules.md#force-try) [![SwiftLint: force_unwrapping](https://img.shields.io/badge/SwiftLint-force__unwrapping-007A87.svg)](https://github.com/realm/SwiftLint/blob/master/Rules.md#force-unwrapping)
 

--- a/README.md
+++ b/README.md
@@ -1176,18 +1176,18 @@ _You can enable the following settings in Xcode by running [this script](resourc
   ```swift
   // WRONG
   struct FeatureState {
-    var count = 1
+    var count: Int
 
-    static var initial = FeatureState()
+    static var initial = FeatureState(count: 0)
   }
 
   // Right
   struct FeatureState {
-    var count = 1
+    var count: Int
 
     static var initial: FeatureState {
       // Vend static properties that are cheap to compute
-      FeatureState()
+      FeatureState(count: 0)
     }
   }
   ```

--- a/README.md
+++ b/README.md
@@ -1154,6 +1154,47 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
+* <a id='prefer-immutable-statics'></a>(<a href='#prefer-immutable-statics'>link</a>) **Prefer immutable or computed static variables over mutable ones whenever possible.** Use stored `static let` properties or computed `static var` properties over stored `static var`s properties whenever possible, as stored `static var` properties are global mutable state.
+
+  <details>
+
+  #### Why?
+  Global mutable state increases complexity and makes it harder to reason about the behavior of applications. It should be avoided when possible.
+
+  ```swift
+  // WRONG
+  enum Fonts {
+    static var title = UIFont(…)
+  }
+
+  // RIGHT
+  enum Fonts {
+    static let title = UIFont(…)
+  }
+  ```
+
+  ```swift
+  // WRONG
+  struct FeatureState {
+    var count = 1
+
+    static var initial = FeatureState()
+  }
+
+  // Right
+  struct FeatureState {
+    var count = 1
+
+    static var initial: FeatureState {
+      // Vend static properties that are cheap to compute
+      FeatureState()
+    }
+  }
+  ```
+
+  </details>
+
+
 * <a id='preconditions-and-asserts'></a>(<a href='#preconditions-and-asserts'>link</a>) **Handle an unexpected but recoverable condition with an `assert` method combined with the appropriate logging in production. If the unexpected condition is not recoverable, prefer a `precondition` method or `fatalError()`.** This strikes a balance between crashing and providing insight into unexpected conditions in the wild. Only prefer `fatalError` over a `precondition` method when the failure message is dynamic, since a `precondition` method won't report the message in the crash report. [![SwiftLint: fatal_error_message](https://img.shields.io/badge/SwiftLint-fatal__error__message-007A87.svg)](https://github.com/realm/SwiftLint/blob/master/Rules.md#fatal-error-message) [![SwiftLint: force_cast](https://img.shields.io/badge/SwiftLint-force__cast-007A87.svg)](https://github.com/realm/SwiftLint/blob/master/Rules.md#force-cast) [![SwiftLint: force_try](https://img.shields.io/badge/SwiftLint-force__try-007A87.svg)](https://github.com/realm/SwiftLint/blob/master/Rules.md#force-try) [![SwiftLint: force_unwrapping](https://img.shields.io/badge/SwiftLint-force__unwrapping-007A87.svg)](https://github.com/realm/SwiftLint/blob/master/Rules.md#force-unwrapping)
 
   <details>


### PR DESCRIPTION
## Summary
**Prefer immutable or computed static properties over mutable ones whenever possible.** Use stored `static let` properties or computed `static var` properties over stored `static var`s properties whenever possible, as stored `static var` properties are global mutable state.

  #### Why?
  Global mutable state increases complexity and makes it harder to reason about the behavior of applications. It should be avoided when possible.

  ```swift
  // WRONG
  enum Fonts {
    static var title = UIFont(…)
  }

  // RIGHT
  enum Fonts {
    static let title = UIFont(…)
  }
  ```

  ```swift
  // WRONG
  struct FeatureState {
    var count: Int

    static var initial = FeatureState(count: 0)
  }

  // RIGHT
  struct FeatureState {
    var count: Int

    static var initial: FeatureState {
      // Vend static properties that are cheap to compute
      FeatureState(count: 0)
    }
  }
  ```
## Correction

The reason that we can't autocorrect this rule is that there's multiple potential fixes for any given static variable, and the linter doesn't have the context to decide for you. Some global mutable state is necessary, some global properties should be computed, and other global properties should be stored.

As a follow-up, I'll potentially add a SwiftLint regex rule with a warning to flag global stored static vars as a warning via the following regex:
```regex
\bstatic\s+var\s+\S+(:\s+\S+)?\s+=
```

_Please react with 👍/👎 if you agree or disagree with this proposal._