### PR TITLE
Change 'whitelist_rules' to 'only_rules'

### DIFF
--- a/resources/swiftlint.yml
+++ b/resources/swiftlint.yml
@@ -1,4 +1,4 @@
-whitelist_rules:
+only_rules:
   - closure_spacing
   - colon
   - empty_enum_arguments


### PR DESCRIPTION
#### Summary

Ran swiftlint --fix in terminal and received a warning that whitelist_rules had been renamed to only_rules.

<img width="720" alt="Screen Shot 2021-04-23 at 1 09 03 PM" src="https://user-images.githubusercontent.com/66537008/115909739-e828a100-a439-11eb-913b-2975a86c0167.png">

Changes in SwiftLint.yml: 
'whitelist_rules' to 'only_rules'

#### Reasoning

whitelist_rules throws a warning and will be removed in the future.

_Please react with 👍/👎 if you agree or disagree with this proposal._
