### PR TITLE
Adopt redundantType SwiftFormat rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
 ## Style
 
-* <a id='use-implicit-types'></a>(<a href='#use-implicit-types'>link</a>) **Don't include types where they can be easily inferred.**
+* <a id='use-implicit-types'></a>(<a href='#use-implicit-types'>link</a>) **Don't include types where they can be easily inferred.** [![SwiftFormat: redundantType](https://img.shields.io/badge/SwiftFormat-redundantType-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#redundantType)
 
   <details>
 

--- a/resources/airbnb.swiftformat
+++ b/resources/airbnb.swiftformat
@@ -22,4 +22,4 @@
 --swiftversion 5.1
 
 # rules
---rules anyObjectProtocol,redundantParens,redundantReturn,redundantSelf,sortedImports,strongifiedSelf,trailingCommas,trailingSpace,wrapArguments,wrapMultilineStatementBraces,indent,wrapAttributes,organizeDeclarations,markTypes,extensionAccessControl,duplicateImports
+--rules anyObjectProtocol,redundantParens,redundantReturn,redundantSelf,sortedImports,strongifiedSelf,trailingCommas,trailingSpace,wrapArguments,wrapMultilineStatementBraces,indent,wrapAttributes,organizeDeclarations,markTypes,extensionAccessControl,duplicateImports,redundantType


### PR DESCRIPTION
#### Summary

This PR enables the [`redundantType`](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#redundantType) SwiftFormat rule. This enforces the _"Don't include types where they can be easily inferred."_ rule [in our style guide](https://github.com/airbnb/swift#use-implicit-types).
