### PR TITLE
Bump SwiftFormat version to 0.48.0

### DIFF
--- a/resources/airbnb.swiftformat
+++ b/resources/airbnb.swiftformat
@@ -1,4 +1,4 @@
-# Current version of SwiftFormat used at Airbnb: 0.47.12
+# Current version of SwiftFormat used at Airbnb: 0.48.0
 
 # options
 --self remove # redundantSelf


### PR DESCRIPTION
We are now using SwiftFormat `0.48.0` at Airbnb