### PR TITLE
Add rule to always inline let keyword when destructuring enum cases and tuples

### DIFF
--- a/README.md
+++ b/README.md
@@ -541,23 +541,52 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   <details>
 
-  ```swift
-  // WRONG
-  switch result {
-    case let .value(value):
+    ```swift
+    // WRONG
+    switch result {
+    case let .success(value):
       // ...
     case let .error(errorCode, errorReason):
       // ...
-  }
+    }
 
-  // RIGHT
-  switch result {
-    case .value(let value):
+    // WRONG
+    guard let case .success(value) else { 
+      return 
+    }
+
+    // RIGHT
+    switch result {
+    case .success(let value):
       // ...
     case .error(let errorCode, let errorReason):
       // ...
-  }
-  ```
+    }
+
+    // RIGHT
+    guard case .success(let value) else {
+      return
+    }
+    ```
+    
+    ### Why?
+    
+    1. **Consistency**: We should prefer to either _always_ inline the `let` keyworkd or _never_ inline the `let` keyword. In Airbnb's Swift codebase, we [observed](https://github.com/airbnb/swift/pull/126#discussion_r631979244) that inline `let` is used far more often in practice (especially when destructuring enum cases with a single associated value).
+    
+    2. **Clarity**: Inlining the `let` keyword makes it more clear which identifiers are part of the conditional check and which identifiers are binding new variables, since the `let` keyword is always adjacent to the variable identifier. 
+    
+    ```swift
+    // `let` is adjacent to the variable identifier, so it is immediately obvious 
+    // at a glance that these identifiers represent new variable bindings
+    case .enumCaseWithSingleAssociatedValue(let string):
+    case .enumCaseWithMultipleAssociatedValues(let string, let int):
+
+    // The `let` keyword is quite far from the variable identifiers, 
+    // so its less obvious that they represent new variable bindings
+    case let .enumCaseWithSingleAssociatedValue(string):
+    case let .enumCaseWithMultipleAssociatedValues(string, int):
+
+    ```
 
   </details>
 

--- a/README.md
+++ b/README.md
@@ -537,7 +537,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
-* <a id='destructure-inline-let'></a> (<a href='#destructure-inline-let'>link</a>) **When destructuring an enum case or a tuple, place the `let` keyword inline, adjacent to each individual property assignment.** [![SwiftFormat: hoistPatternLet](https://img.shields.io/badge/SwiftFormat-hoistPatternLet-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#hoistPatternLet)
+* <a id='inline-let-when-destructuring'></a> (<a href='#inline-let-when-destructuring'>link</a>) **When destructuring an enum case or a tuple, place the `let` keyword inline, adjacent to each individual property assignment.** [![SwiftFormat: hoistPatternLet](https://img.shields.io/badge/SwiftFormat-hoistPatternLet-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#hoistPatternLet)
 
   <details>
 
@@ -569,7 +569,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
     }
     ```
     
-    ### Why?
+    #### Why?
     
     1. **Consistency**: We should prefer to either _always_ inline the `let` keyworkd or _never_ inline the `let` keyword. In Airbnb's Swift codebase, we [observed](https://github.com/airbnb/swift/pull/126#discussion_r631979244) that inline `let` is used far more often in practice (especially when destructuring enum cases with a single associated value).
     

--- a/README.md
+++ b/README.md
@@ -537,6 +537,30 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
+* <a id='destructure-inline-let'></a> (<a href='#destructure-inline-let'>link</a>) **When destructuring an enum case or a tuple, place the `let` keyword inline, adjacent to each individual property assignment.** [![SwiftFormat: hoistPatternLet](https://img.shields.io/badge/SwiftFormat-hoistPatternLet-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#hoistPatternLet)
+
+  <details>
+
+  ```swift
+  // WRONG
+  switch result {
+    case let .value(value):
+      // ...
+    case let .error(errorCode, errorReason):
+      // ...
+  }
+
+  // RIGHT
+  switch result {
+    case .value(let value):
+      // ...
+    case .error(let errorCode, let errorReason):
+      // ...
+  }
+  ```
+
+  </details>
+
 * <a id='attributes-on-prev-line'></a>(<a href='#attributes-on-prev-line'>link</a>) **Place function/type attributes on the line above the declaration**. [![SwiftFormat: wrapAttributes](https://img.shields.io/badge/SwiftFormat-wrapAttributes-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapAttributes)
 
   <details>

--- a/resources/airbnb.swiftformat
+++ b/resources/airbnb.swiftformat
@@ -19,7 +19,8 @@
 --enumthreshold 20 # organizeDeclarations
 --organizetypes class,struct,enum,extension # organizeDeclarations
 --extensionacl on-declarations # extensionAccessControl
+--patternlet inline # hoistPatternLet
 --swiftversion 5.1
 
 # rules
---rules anyObjectProtocol,redundantParens,redundantReturn,redundantSelf,sortedImports,strongifiedSelf,trailingCommas,trailingSpace,wrapArguments,wrapMultilineStatementBraces,indent,wrapAttributes,organizeDeclarations,markTypes,extensionAccessControl,duplicateImports,redundantType
+--rules anyObjectProtocol,redundantParens,redundantReturn,redundantSelf,sortedImports,strongifiedSelf,trailingCommas,trailingSpace,wrapArguments,wrapMultilineStatementBraces,indent,wrapAttributes,organizeDeclarations,markTypes,extensionAccessControl,duplicateImports,redundantType,hoistPatternLet


### PR DESCRIPTION
#### Summary

This PR proposes a new rule to always inline the `let` keyword when destructuring enum cases and tupes

> When destructuring an enum case or a tuple, place the `let` keyword inline, adjacent to each individual property assignment

```swift
// WRONG
switch result {
case let .success(value):
  // ...
case let .error(errorCode, errorReason):
  // ...
}

// WRONG
guard let case .success(value) else { 
  return 
}

// RIGHT
switch result {
case .success(let value):
  // ...
case .error(let errorCode, let errorReason):
  // ...
}

// RIGHT
guard case .success(let value) else {
  return
}
```

#### Reasoning

 1. **Consistency**: We should prefer to either _always_ inline the `let` keyworkd or _never_ inline the `let` keyword. In Airbnb's Swift codebase, we [observed](https://github.com/airbnb/swift/pull/126#discussion_r631979244) that inline `let` is used far more often in practice (especially when destructuring enum cases with a single associated value).

 2. **Clarity**: Inlining the `let` keyword makes it more clear which identifiers are part of the conditional check and which identifiers are binding new variables, since the `let` keyword is always adjacent to the variable identifier. 

```swift
// `let` is adjacent to the variable identifier, so it is immediately obvious 
// at a glance that these identifiers represent new variable bindings
case .enumCaseWithSingleAssociatedValue(let string):
case .enumCaseWithMultipleAssociatedValues(let string, let int):

// The `let` keyword is quite far from the variable identifiers, 
// so its less obvious that they represent new variable bindings
case let .enumCaseWithSingleAssociatedValue(string):
case let .enumCaseWithMultipleAssociatedValues(string, int):
```

_Please react with 👍/👎 if you agree or disagree with this proposal._
