### PR TITLE
Add rule that the opening brace following a single-line statement should be on the same line as the statement itself

### DIFF
--- a/README.md
+++ b/README.md
@@ -839,7 +839,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
-* <a id='multi-line-expression-braces'></a>(<a href='#multi-line-expression-braces'>link</a>) The opening brace following a multi-line expression should wrap to a new line. [![SwiftFormat: wrapMultilineStatementBraces](https://img.shields.io/badge/SwiftFormat-wrapMultilineStatementBraces-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapMultilineStatementBraces)
+* <a id='multi-line-expression-braces'></a>(<a href='#multi-line-expression-braces'>link</a>) The opening brace following a multi-line expression should wrap to a new line. [![SwiftFormat: braces](https://img.shields.io/badge/SwiftFormat-braces-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#braces)
 
   <details>
 
@@ -901,7 +901,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
-* <a id='long-function-declaration'></a>(<a href='#long-function-declaration'>link</a>) **Separate [long](https://github.com/airbnb/swift#column-width) function declarations with line breaks before each argument label and before the return signature.** Put the open curly brace on the next line so the first executable line doesn't look like it's another parameter. [![SwiftFormat: wrapArguments](https://img.shields.io/badge/SwiftFormat-wrapArguments-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapArguments) [![SwiftFormat: wrapMultilineStatementBraces](https://img.shields.io/badge/SwiftFormat-wrapMultilineStatementBraces-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapMultilineStatementBraces)
+* <a id='long-function-declaration'></a>(<a href='#long-function-declaration'>link</a>) **Separate [long](https://github.com/airbnb/swift#column-width) function declarations with line breaks before each argument label and before the return signature.** Put the open curly brace on the next line so the first executable line doesn't look like it's another parameter. [![SwiftFormat: wrapArguments](https://img.shields.io/badge/SwiftFormat-wrapArguments-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapArguments) [![SwiftFormat: braces](https://img.shields.io/badge/SwiftFormat-braces-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#braces)
 
   <details>
 

--- a/README.md
+++ b/README.md
@@ -804,6 +804,83 @@ _You can enable the following settings in Xcode by running [this script](resourc
   let universe = Universe()
   ```
 
+* <a id='single-line-expression-braces'></a>(<a href='#single-line-expression-braces'>link</a>) The opening brace following a single-line expression should be on the same line as the rest of the statement. [![SwiftFormat: braces](https://img.shields.io/badge/SwiftFormat-braces-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#braces)
+
+  <details>
+
+  ```swift
+  // WRONG
+  if !planet.isHabitable
+  {
+    planet.terraform()
+  }
+
+  class Planet
+  {
+    func terraform()
+    {
+      generateAtmosphere()
+      generateOceans()
+    }
+  }
+
+  // RIGHT
+  if !planet.isHabitable {
+    planet.terraform()
+  }
+
+  class Planet {
+    func terraform() {
+      generateAtmosphere()
+      generateOceans()
+    }
+  }
+  ```
+
+  </details>
+
+* <a id='multi-line-expression-braces'></a>(<a href='#multi-line-expression-braces'>link</a>) The opening brace following a multi-line expression should wrap to a new line. [![SwiftFormat: wrapMultilineStatementBraces](https://img.shields.io/badge/SwiftFormat-wrapMultilineStatementBraces-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapMultilineStatementBraces)
+
+  <details>
+
+  ```swift
+  // WRONG
+  if
+    let star = planet.nearestStar(),
+    planet.isInHabitableZone(of: star) {
+    planet.terraform()
+  }
+
+  class Planet {
+    func terraform(
+      atmosphereOptions: AtmosphereOptions = .default,
+      oceanOptions: OceanOptions = .default) {
+      generateAtmosphere(atmosphereOptions)
+      generateOceans(oceanOptions)
+    }
+  }
+
+  // RIGHT
+  if
+    let star = planet.nearestStar(),
+    planet.isInHabitableZone(of: star)
+  {
+    planet.terraform()
+  }
+
+  class Planet {
+    func terraform(
+      atmosphereOptions: AtmosphereOptions = .default,
+      oceanOptions: OceanOptions = .default) 
+    {
+      generateAtmosphere(atmosphereOptions)
+      generateOceans(oceanOptions)
+    }
+  }
+  ```
+
+  </details>
+
 ### Functions
 
 * <a id='omit-function-void-return'></a>(<a href='#omit-function-void-return'>link</a>) **Omit `Void` return types from function definitions.** [![SwiftLint: redundant_void_return](https://img.shields.io/badge/SwiftLint-redundant__void__return-007A87.svg)](https://github.com/realm/SwiftLint/blob/master/Rules.md#redundant-void-return)

--- a/resources/airbnb.swiftformat
+++ b/resources/airbnb.swiftformat
@@ -1,5 +1,5 @@
 # Current version of SwiftFormat used at Airbnb: 
-# https://github.com/calda/SwiftFormat/releases/tag/0.49-beta-2
+# https://github.com/calda/SwiftFormat/releases/tag/0.49-beta-4
 
 # options
 --self remove # redundantSelf
@@ -52,7 +52,7 @@
 --rules wrap
 --rules wrapArguments
 --rules wrapAttributes
---rules wrapMultilineStatementBraces
+--rules braces
 --rules redundantClosure
 --rules redundantInit
 --rules unusedArguments


### PR DESCRIPTION
#### Summary

This PR proposes a new rule that the opening brace following a single-line statement should be on the same line as the statement itself:

  ```swift
  // WRONG
  if !planet.isHabitable
  {
    planet.terraform()
  }

  class Planet
  {
    func terraform()
    {
      generateAtmosphere()
      generateOceans()
    }
  }

  // RIGHT
  if !planet.isHabitable {
    planet.terraform()
  }

  class Planet {
    func terraform() {
      generateAtmosphere()
      generateOceans()
    }
  }
  ```

#### Multi-line statements <a id='multi-line-statement-braces'></a>(<a href='#multi-line-statement-braces'>link</a>)

This PR also adds a prose rule for the multi-line case:

> The opening brace following a multi-line statement should wrap to a new line.

It felt like a good idea to add an explicit prose rule for this, to compliment the new rule for the single-statement case. This specific style is already mentioned in other rules, and we already lint for this automatically using the `wrapMultilineStatementBraces` SwiftFormat rule. 

  ```swift
  // WRONG
  if
    let star = planet.nearestStar(),
    planet.isInHabitableZone(of: star) {
    planet.terraform()
  }

  class Planet {
    func terraform(
      atmosphereOptions: AtmosphereOptions = .default,
      oceanOptions: OceanOptions = .default) {
      generateAtmosphere(atmosphereOptions)
      generateOceans(oceanOptions)
    }
  }

  // RIGHT
  if
    let star = planet.nearestStar(),
    planet.isInHabitableZone(of: star)
  {
    planet.terraform()
  }

  class Planet {
    func terraform(
      atmosphereOptions: AtmosphereOptions = .default,
      oceanOptions: OceanOptions = .default) 
    {
      generateAtmosphere(atmosphereOptions)
      generateOceans(oceanOptions)
    }
  }
  ```

_Please react with 👍/👎 if you agree or disagree with this proposal._
