### PR TITLE
Enable SwiftFormat wrap rule with an enforced max width of 130 characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,12 @@ Note that brevity is not a primary goal. Code should be made more concise only i
 
 _You can enable the following settings in Xcode by running [this script](resources/xcode_settings.bash), e.g. as part of a "Run Script" build phase._
 
-* <a id='column-width'></a>(<a href='#column-width'>link</a>) **Each line should have a maximum column width of 100 characters.**
+* <a id='column-width'></a>(<a href='#column-width'>link</a>) **Each line should have a maximum column width of 130 characters.** [![SwiftFormat: wrap](https://img.shields.io/badge/SwiftFormat-wrap-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrap)
 
   <details>
 
   #### Why?
-  Due to larger screen sizes, we have opted to choose a page guide greater than 80
+  Due to larger screen sizes, and since we are _enforcing_ the maximum using a linter, we have opted to choose a page guide greater than 100.
 
   </details>
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
   #### Why?
   Due to larger screen sizes, we have opted to choose a page guide greater than 80. 
   
-  We currently only "strictly enforce" (lint / auto-format) a maximum column width of 130 characters.
+  We currently only "strictly enforce" (lint / auto-format) a maximum column width of 130 characters to limit the cases where manual clean up is required for reformatted lines that fall slightly above the threshold.
 
   </details>
 

--- a/README.md
+++ b/README.md
@@ -39,12 +39,14 @@ Note that brevity is not a primary goal. Code should be made more concise only i
 
 _You can enable the following settings in Xcode by running [this script](resources/xcode_settings.bash), e.g. as part of a "Run Script" build phase._
 
-* <a id='column-width'></a>(<a href='#column-width'>link</a>) **Each line should have a maximum column width of 130 characters.** [![SwiftFormat: wrap](https://img.shields.io/badge/SwiftFormat-wrap-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrap)
+* <a id='column-width'></a>(<a href='#column-width'>link</a>) **Each line should have a maximum column width of 100 characters.** [![SwiftFormat: wrap](https://img.shields.io/badge/SwiftFormat-wrap-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrap)
 
   <details>
 
   #### Why?
-  Due to larger screen sizes, and since we are _enforcing_ the maximum using a linter, we have opted to choose a page guide greater than 100.
+  Due to larger screen sizes, we have opted to choose a page guide greater than 80. 
+  
+  We currently only "strictly enforce" (lint / auto-format) a maximum column width of 130 characters.
 
   </details>
 

--- a/resources/airbnb.swiftformat
+++ b/resources/airbnb.swiftformat
@@ -20,8 +20,10 @@
 --organizetypes class,struct,enum,extension # organizeDeclarations
 --extensionacl on-declarations # extensionAccessControl
 --patternlet inline # hoistPatternLet
---maxwidth 130 # wrap
 --swiftversion 5.1
+
+# We recommend a max width of 100 but _strictly enforce_ a max width of 130
+--maxwidth 130 # wrap
 
 # rules
 --rules anyObjectProtocol,redundantParens,redundantReturn,redundantSelf,sortedImports,strongifiedSelf,trailingCommas,trailingSpace,wrapArguments,wrapMultilineStatementBraces,indent,wrapAttributes,organizeDeclarations,markTypes,extensionAccessControl,duplicateImports,redundantType,hoistPatternLet,consecutiveSpaces,typeSugar,wrap

--- a/resources/airbnb.swiftformat
+++ b/resources/airbnb.swiftformat
@@ -20,7 +20,8 @@
 --organizetypes class,struct,enum,extension # organizeDeclarations
 --extensionacl on-declarations # extensionAccessControl
 --patternlet inline # hoistPatternLet
+--maxwidth 130 # wrap
 --swiftversion 5.1
 
 # rules
---rules anyObjectProtocol,redundantParens,redundantReturn,redundantSelf,sortedImports,strongifiedSelf,trailingCommas,trailingSpace,wrapArguments,wrapMultilineStatementBraces,indent,wrapAttributes,organizeDeclarations,markTypes,extensionAccessControl,duplicateImports,redundantType,hoistPatternLet,consecutiveSpaces,typeSugar
+--rules anyObjectProtocol,redundantParens,redundantReturn,redundantSelf,sortedImports,strongifiedSelf,trailingCommas,trailingSpace,wrapArguments,wrapMultilineStatementBraces,indent,wrapAttributes,organizeDeclarations,markTypes,extensionAccessControl,duplicateImports,redundantType,hoistPatternLet,consecutiveSpaces,typeSugar,wrap

--- a/resources/xcode_settings.bash
+++ b/resources/xcode_settings.bash
@@ -8,5 +8,4 @@ defaults write com.apple.dt.Xcode DVTTextEditorTrimWhitespaceOnlyLines -bool YES
 defaults write com.apple.dt.Xcode DVTTextIndentTabWidth -int 2
 defaults write com.apple.dt.Xcode DVTTextIndentWidth -int 2
 
-defaults write com.apple.dt.Xcode DVTTextShowPageGuide -bool true
-defaults write com.apple.dt.Xcode DVTTextPageGuideLocation -int 130
+defaults write com.apple.dt.Xcode DVTTextPageGuideLocation -int 100

--- a/resources/xcode_settings.bash
+++ b/resources/xcode_settings.bash
@@ -8,4 +8,5 @@ defaults write com.apple.dt.Xcode DVTTextEditorTrimWhitespaceOnlyLines -bool YES
 defaults write com.apple.dt.Xcode DVTTextIndentTabWidth -int 2
 defaults write com.apple.dt.Xcode DVTTextIndentWidth -int 2
 
-defaults write com.apple.dt.Xcode DVTTextPageGuideLocation -int 100
+defaults write com.apple.dt.Xcode DVTTextShowPageGuide -bool true
+defaults write com.apple.dt.Xcode DVTTextPageGuideLocation -int 130


### PR DESCRIPTION
#### Summary

This PR enables the SwiftFormat [`wrap`](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrap) rule in `airbnb.swiftformat`. We would begin enforcing a maximum line width of _130 characters_, and automatically wrap code to sit within the max line width. We would continue _recommending_ (but not enforcing) a maximum line width of 100 characters.

#### Reasoning

We should begin enforcing our maximum column width rule with a linter (_"We strive to make every rule lintable"_).

SwiftFormat's `wrap` rule is not perfect, but it follows our style guide / existing informal style preferences a large majority of the time (in general, it is more successful at wrapping longer lines). 100 characters seems [too strict](https://github.com/airbnb/swift/pull/132#issuecomment-905693965) to enforce with the SwiftFormat `wrap` rule at this time, given its current behavior. Enforcing a "more generous" maximum width of 130 characters results in a fewer cases of "weird" wrapping, and is better than the status quo (where we make a recommendation, but enforce nothing).

_Please react with 👍/👎 if you agree or disagree with this proposal._
