### PR TITLE
Update SwiftFormat version in airbnb.swiftformat

### DIFF
--- a/resources/airbnb.swiftformat
+++ b/resources/airbnb.swiftformat
@@ -1,4 +1,4 @@
-# Current version of SwiftFormat used at Airbnb: 0.48.4
+# Current version of SwiftFormat used at Airbnb: 0.48.16
 
 # options
 --self remove # redundantSelf


### PR DESCRIPTION
This PR updates `airbnb.swiftformat` to reflect that we are now using SwiftFormat `0.48.16` at Airbnb.
