### PR TITLE
Add rule for how to indent multiline string literals

### DIFF
--- a/README.md
+++ b/README.md
@@ -698,7 +698,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
   }
   ```
 
-* <a id='indent-multiline-string-literals'></a>(<a href='#indent-multiline-string-literals'>link</a>) **Indent the body of multi-line string literals**, unless the string literal begins on its own line in which case the string literal contents and closing triple-quote should have the same indentation as the opening triple-quote. [![SwiftFormat: indent](https://img.shields.io/badge/SwiftFormat-indent-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#indent)
+* <a id='indent-multiline-string-literals'></a>(<a href='#indent-multiline-string-literals'>link</a>) **Indent the body and closing triple-quote of multiline string literals**, unless the string literal begins on its own line in which case the string literal contents and closing triple-quote should have the same indentation as the opening triple-quote. [![SwiftFormat: indent](https://img.shields.io/badge/SwiftFormat-indent-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#indent)
 
   <details>
 

--- a/README.md
+++ b/README.md
@@ -698,6 +698,40 @@ _You can enable the following settings in Xcode by running [this script](resourc
   }
   ```
 
+* <a id='indent-multiline-string-literals'></a>(<a href='#indent-multiline-string-literals'>link</a>) **Indent the body of multi-line string literals**, unless the string literal begins on its own line. [![SwiftFormat: indent](https://img.shields.io/badge/SwiftFormat-indent-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#indent)
+
+  <details>
+
+  ```swift
+  // WRONG
+  var spaceQuote = """
+  “Space,” it says, “is big. Really big. You just won’t believe how vastly, hugely, mindbogglingly big it is.
+  I mean, you may think it’s a long way down the road to the chemist’s, but that’s just peanuts to space.”
+  """
+
+  // RIGHT
+  var spaceQuote = """
+    “Space,” it says, “is big. Really big. You just won’t believe how vastly, hugely, mindbogglingly big it is.
+    I mean, you may think it’s a long way down the road to the chemist’s, but that’s just peanuts to space.”
+    """
+
+  // WRONG
+  var universeQuote: String {
+    """
+      In the beginning the Universe was created.
+      This has made a lot of people very angry and been widely regarded as a bad move.
+      """
+  }
+
+  // RIGHT
+  var universeQuote: String {
+    """
+    In the beginning the Universe was created.
+    This has made a lot of people very angry and been widely regarded as a bad move.
+    """
+  }
+  ```
+
   </details>
 
 * <a id='favor-constructors'></a>(<a href='#favor-constructors'>link</a>) **Use constructors instead of Make() functions for NSRange and others.** [![SwiftLint: legacy_constructor](https://img.shields.io/badge/SwiftLint-legacy__constructor-007A87.svg)](https://github.com/realm/SwiftLint/blob/master/Rules.md#legacy-constructor)

--- a/README.md
+++ b/README.md
@@ -698,7 +698,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
   }
   ```
 
-* <a id='indent-multiline-string-literals'></a>(<a href='#indent-multiline-string-literals'>link</a>) **Indent the body of multi-line string literals**, unless the string literal begins on its own line. [![SwiftFormat: indent](https://img.shields.io/badge/SwiftFormat-indent-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#indent)
+* <a id='indent-multiline-string-literals'></a>(<a href='#indent-multiline-string-literals'>link</a>) **Indent the body of multi-line string literals**, unless the string literal begins on its own line in which case the string literal contents and closing triple-quote should have the same indentation as the opening triple-quote. [![SwiftFormat: indent](https://img.shields.io/badge/SwiftFormat-indent-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#indent)
 
   <details>
 

--- a/resources/airbnb.swiftformat
+++ b/resources/airbnb.swiftformat
@@ -1,4 +1,4 @@
-# Current version of SwiftFormat used at Airbnb: 0.48.16
+# Current version of SwiftFormat used at Airbnb: 0.49.0
 
 # options
 --self remove # redundantSelf
@@ -7,6 +7,7 @@
 --trimwhitespace always # trailingSpace
 --indent 2 #indent
 --ifdef no-indent #indent
+--indentstrings true #indent
 --wraparguments before-first # wrapArguments
 --wrapparameters before-first # wrapArguments
 --wrapcollections before-first # wrapArguments


### PR DESCRIPTION
#### Summary

This PR adds a rule for how to indent multiline string literals, using the new `--indentstrings true` option added to SwiftFormat in https://github.com/nicklockwood/SwiftFormat/pull/1049

> **Indent the body of multi-line string literals**, unless the string literal begins on its own line.

```swift
// WRONG
var spaceQuote = """
“Space,” it says, “is big. Really big. You just won’t believe how vastly, hugely, mindbogglingly big it is.
I mean, you may think it’s a long way down the road to the chemist’s, but that’s just peanuts to space.”
"""

// RIGHT
var spaceQuote = """
  “Space,” it says, “is big. Really big. You just won’t believe how vastly, hugely, mindbogglingly big it is.
  I mean, you may think it’s a long way down the road to the chemist’s, but that’s just peanuts to space.”
  """

// WRONG
var universeQuote: String {
  """
    In the beginning the Universe was created.
    This has made a lot of people very angry and been widely regarded as a bad move.
    """
}

// RIGHT
var universeQuote: String {
  """
  In the beginning the Universe was created.
  This has made a lot of people very angry and been widely regarded as a bad move.
  """
}
```

#### Reasoning

Since we use SwiftFormat's `indent` rule, all lines of code in our codebase is automatically indented by the linter.

The linter is currently not indenting multi-line string literals, which I've found surprising. This wasn't really an intentional choice we made -- it was just a consequence of when we adopted the `indent` rule.

```swift
// The indentation style that is currently enforced in our codebase:
var spaceQuote = """
“Space,” it says, “is big. Really big. You just won’t believe how vastly, hugely, mindbogglingly big it is.
I mean, you may think it’s a long way down the road to the chemist’s, but that’s just peanuts to space.”
"""
```

_Please react with 👍/👎 if you agree or disagree with this proposal._
