### PR TITLE
Add rule for how to wrap long ternary operator expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -714,6 +714,31 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
+* <a id='long-ternary-operator-expressions'></a>(<a href='#long-ternary-operator-expressions'>link</a>) **[Long](https://github.com/airbnb/swift#column-width) ternary operator expressions should wrap before the `?` and before the `:`**, putting each conditional branch on a separate line. [![SwiftFormat: wrap](https://img.shields.io/badge/SwiftFormat-wrap-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrap)
+
+  <details>
+
+  ```swift
+  // WRONG (too long)
+  let destinationPlanet = solarSystem.hasPlanetsInHabitableZone ? solarSystem.planetsInHabitableZone.first : solarSystem.uninhabitablePlanets.first
+
+  // WRONG (naive wrapping)
+  let destinationPlanet = solarSystem.hasPlanetsInHabitableZone ? solarSystem.planetsInHabitableZone.first :
+    solarSystem.uninhabitablePlanets.first
+
+  // WRONG (unbalanced operators)
+  let destinationPlanet = solarSystem.hasPlanetsInHabitableZone ?
+    solarSystem.planetsInHabitableZone.first :
+    solarSystem.uninhabitablePlanets.first
+
+  // RIGHT
+  let destinationPlanet = solarSystem.hasPlanetsInHabitableZone
+    ? solarSystem.planetsInHabitableZone.first
+    : solarSystem.uninhabitablePlanets.first
+   ```
+
+  </details>
+
 * <a id='standard-library-type-shorthand'></a>(<a href='#standard-library-type-sugar'>link</a>) **For standard library types with a canonical shorthand form (`Optional`, `Array`, `Dictionary`), prefer using the shorthand form over the full generic form.** [![SwiftFormat: typeSugar](https://img.shields.io/badge/SwiftFormat-typeSugar-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#typeSugar)
 
   <details>

--- a/README.md
+++ b/README.md
@@ -714,31 +714,6 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
-* <a id='long-ternary-operator-expressions'></a>(<a href='#long-ternary-operator-expressions'>link</a>) **[Long](https://github.com/airbnb/swift#column-width) ternary operator expressions should wrap before the `?` and before the `:`**, putting each conditional branch on a separate line. [![SwiftFormat: wrap](https://img.shields.io/badge/SwiftFormat-wrap-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrap)
-
-  <details>
-
-  ```swift
-  // WRONG (too long)
-  let destinationPlanet = solarSystem.hasPlanetsInHabitableZone ? solarSystem.planetsInHabitableZone.first : solarSystem.uninhabitablePlanets.first
-
-  // WRONG (naive wrapping)
-  let destinationPlanet = solarSystem.hasPlanetsInHabitableZone ? solarSystem.planetsInHabitableZone.first :
-    solarSystem.uninhabitablePlanets.first
-
-  // WRONG (unbalanced operators)
-  let destinationPlanet = solarSystem.hasPlanetsInHabitableZone ?
-    solarSystem.planetsInHabitableZone.first :
-    solarSystem.uninhabitablePlanets.first
-
-  // RIGHT
-  let destinationPlanet = solarSystem.hasPlanetsInHabitableZone
-    ? solarSystem.planetsInHabitableZone.first
-    : solarSystem.uninhabitablePlanets.first
-   ```
-
-  </details>
-
 * <a id='standard-library-type-shorthand'></a>(<a href='#standard-library-type-sugar'>link</a>) **For standard library types with a canonical shorthand form (`Optional`, `Array`, `Dictionary`), prefer using the shorthand form over the full generic form.** [![SwiftFormat: typeSugar](https://img.shields.io/badge/SwiftFormat-typeSugar-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#typeSugar)
 
   <details>
@@ -1040,6 +1015,31 @@ _You can enable the following settings in Xcode by running [this script](resourc
   let capacity = newCapacity
   let latitude = region.center.latitude - (region.span.latitudeDelta / 2.0)
   ```
+
+  </details>
+
+* <a id='long-ternary-operator-expressions'></a>(<a href='#long-ternary-operator-expressions'>link</a>) **[Long](https://github.com/airbnb/swift#column-width) ternary operator expressions should wrap before the `?` and before the `:`**, putting each conditional branch on a separate line. [![SwiftFormat: wrap](https://img.shields.io/badge/SwiftFormat-wrap-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrap)
+
+  <details>
+
+  ```swift
+  // WRONG (too long)
+  let destinationPlanet = solarSystem.hasPlanetsInHabitableZone ? solarSystem.planetsInHabitableZone.first : solarSystem.uninhabitablePlanets.first
+
+  // WRONG (naive wrapping)
+  let destinationPlanet = solarSystem.hasPlanetsInHabitableZone ? solarSystem.planetsInHabitableZone.first :
+    solarSystem.uninhabitablePlanets.first
+
+  // WRONG (unbalanced operators)
+  let destinationPlanet = solarSystem.hasPlanetsInHabitableZone ?
+    solarSystem.planetsInHabitableZone.first :
+    solarSystem.uninhabitablePlanets.first
+
+  // RIGHT
+  let destinationPlanet = solarSystem.hasPlanetsInHabitableZone
+    ? solarSystem.planetsInHabitableZone.first
+    : solarSystem.uninhabitablePlanets.first
+   ```
 
   </details>
 

--- a/resources/airbnb.swiftformat
+++ b/resources/airbnb.swiftformat
@@ -1,4 +1,4 @@
-# Current version of SwiftFormat used at Airbnb: 0.48.16
+# Current version of SwiftFormat used at Airbnb: 0.49.0
 
 # options
 --self remove # redundantSelf
@@ -15,6 +15,7 @@
 --closingparen same-line # wrapArguments
 --funcattributes prev-line # wrapAttributes
 --typeattributes prev-line # wrapAttributes
+--wrapternary before-operators # wrap
 --structthreshold 20 # organizeDeclarations
 --enumthreshold 20 # organizeDeclarations
 --organizetypes class,struct,enum,extension # organizeDeclarations

--- a/resources/airbnb.swiftformat
+++ b/resources/airbnb.swiftformat
@@ -1,5 +1,5 @@
 # Current version of SwiftFormat used at Airbnb: 
-# https://github.com/calda/SwiftFormat/releases/tag/0.49-beta-1
+# https://github.com/calda/SwiftFormat/releases/tag/0.49-beta-2
 
 # options
 --self remove # redundantSelf


### PR DESCRIPTION
#### Summary

This PR adds a rule for how to indent long ternary operator expressions, using the new `--wrapternary before-operators` option added to SwiftFormat in https://github.com/nicklockwood/SwiftFormat/pull/1048.

> **[Long](https://github.com/airbnb/swift#column-width) ternary operator expressions should wrap before the `?` and before the `:`**, putting each conditional branch on a separate line.

```swift
// WRONG (too long)
let destinationPlanet = solarSystem.hasPlanetsInHabitableZone ? solarSystem.planetsInHabitableZone.first : solarSystem.uninhabitablePlanets.first

// WRONG (naive wrapping)
let destinationPlanet = solarSystem.hasPlanetsInHabitableZone ? solarSystem.planetsInHabitableZone.first :
  solarSystem.uninhabitablePlanets.first

// WRONG (unbalanced operators)
let destinationPlanet = solarSystem.hasPlanetsInHabitableZone ?
  solarSystem.planetsInHabitableZone.first :
  solarSystem.uninhabitablePlanets.first

// RIGHT
let destinationPlanet = solarSystem.hasPlanetsInHabitableZone
  ? solarSystem.planetsInHabitableZone.first
  : solarSystem.uninhabitablePlanets.first
```

#### Reasoning

SwiftFormat's `wrap` rule, which we have enabled for our codebase, wraps long ternary operator expressions naively by default:

```swift
// How a long ternary operator expression is currently wrapped by our linter:
let destinationPlanet = solarSystem.hasPlanetsInHabitableZone ? solarSystem.planetsInHabitableZone.first :
  solarSystem.uninhabitablePlanets.first
```

I think most folks naturally wrap ternary operator expressions at both the `?` and `:`, so this change should improve the quality of our linter's auto-wrapping implementation.

_Please react with 👍/👎 if you agree or disagree with this proposal._
