### PR TITLE
Bump SwiftFormat version to 0.48.17

### DIFF
--- a/resources/airbnb.swiftformat
+++ b/resources/airbnb.swiftformat
@@ -1,4 +1,4 @@
-# Current version of SwiftFormat used at Airbnb: 0.48.16
+# Current version of SwiftFormat used at Airbnb: 0.48.17
 
 # options
 --self remove # redundantSelf


### PR DESCRIPTION
#### Summary

We are now using SwiftFormat 0.48.17 at Airbnb.

This version includes https://github.com/nicklockwood/SwiftFormat/pull/1046, which fixes an issue with the `redundantArguments` rule that we adopted recently, in https://github.com/airbnb/swift/pull/136.
