### PR TITLE
Adopt SwiftFormat 0.49 beta

### DIFF
--- a/resources/airbnb.swiftformat
+++ b/resources/airbnb.swiftformat
@@ -1,4 +1,5 @@
-# Current version of SwiftFormat used at Airbnb: 0.48.16
+# Current version of SwiftFormat used at Airbnb: 
+# https://github.com/calda/SwiftFormat/releases/tag/0.49-beta-1
 
 # options
 --self remove # redundantSelf
@@ -20,6 +21,7 @@
 --organizetypes class,struct,enum,extension # organizeDeclarations
 --extensionacl on-declarations # extensionAccessControl
 --patternlet inline # hoistPatternLet
+--redundanttype inferred # redundantType
 --swiftversion 5.1
 
 # We recommend a max width of 100 but _strictly enforce_ a max width of 130


### PR DESCRIPTION
#### Summary

This PR updates `airbnb.swiftformat` to reflect that we've adopted a [beta build](https://github.com/calda/SwiftFormat/releases/tag/0.49-beta-1) of Swift Format `0.49`.
