### PR TITLE
Update airbnb.swiftformat to reflect that we have enabled the sortDeclarations rule

### DIFF
--- a/resources/airbnb.swiftformat
+++ b/resources/airbnb.swiftformat
@@ -1,5 +1,5 @@
 # Current version of SwiftFormat used at Airbnb: 
-# https://github.com/calda/SwiftFormat/releases/tag/0.49-beta-2
+# https://github.com/calda/SwiftFormat/releases/tag/0.49-beta-3
 
 # options
 --self remove # redundantSelf
@@ -45,6 +45,7 @@
 --rules redundantSelf
 --rules redundantType
 --rules sortedImports
+--rules sortDeclarations
 --rules strongifiedSelf
 --rules trailingCommas
 --rules trailingSpace


### PR DESCRIPTION
This PR updates `airbnb.swiftformat` to reflect that we have enabled the `sortDeclarations` rule, added in https://github.com/nicklockwood/SwiftFormat/pull/1068. 

By itself, enabling this rule has no effect. This rule just must be enabled for the new `// swiftformat:sort` directives to work, since that support is implemented in this rule.