### PR TITLE
Add rule to omit Void return types from closure definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1056,7 +1056,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
-* <a id='omit-closure-void-return'></a>(<a href='#omit-closure-void-return'>link</a>) **Omit `Void` return types from closure definitions.** [![SwiftFormat: redundantVoidReturnType](https://img.shields.io/badge/SwiftFormat-redundantVoidReturnType-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#redundantVoidReturnType)
+* <a id='omit-closure-void-return'></a>(<a href='#omit-closure-void-return'>link</a>) **Omit `Void` return types from closure expressions.** [![SwiftFormat: redundantVoidReturnType](https://img.shields.io/badge/SwiftFormat-redundantVoidReturnType-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#redundantVoidReturnType)
 
   <details>
 

--- a/README.md
+++ b/README.md
@@ -806,7 +806,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
 ### Functions
 
-* <a id='omit-function-void-return'></a>(<a href='#omit-function-void-return'>link</a>) **Omit `Void` return types from function definitions.** [![SwiftLint: redundant_void_return](https://img.shields.io/badge/SwiftLint-redundant__void__return-007A87.svg)](https://github.com/realm/SwiftLint/blob/master/Rules.md#redundant-void-return)
+* <a id='omit-function-void-return'></a>(<a href='#omit-function-void-return'>link</a>) **Omit `Void` return types from function definitions.** [![SwiftFormat: redundantVoidReturnType](https://img.shields.io/badge/SwiftFormat-redundantVoidReturnType-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#redundantVoidReturnType)
 
   <details>
 
@@ -1055,6 +1055,22 @@ _You can enable the following settings in Xcode by running [this script](resourc
   ```
 
   </details>
+
+* <a id='omit-closure-void-return'></a>(<a href='#omit-closure-void-return'>link</a>) **Omit `Void` return types from closure definitions.** [![SwiftFormat: redundantVoidReturnType](https://img.shields.io/badge/SwiftFormat-redundantVoidReturnType-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#redundantVoidReturnType)
+
+  <details>
+
+  ```swift
+  // WRONG
+  someAsyncThing() { argument -> Void in
+    ...
+  }
+
+  // RIGHT
+  someAsyncThing() { argument in
+    ...
+  }
+  ```
 
 ### Operators
 

--- a/resources/airbnb.swiftformat
+++ b/resources/airbnb.swiftformat
@@ -55,4 +55,5 @@
 --rules wrapMultilineStatementBraces
 --rules redundantClosure
 --rules redundantInit
+--rules redundantVoidReturnType
 --rules unusedArguments

--- a/resources/swiftlint.yml
+++ b/resources/swiftlint.yml
@@ -13,7 +13,6 @@ only_rules:
   - legacy_nsgeometry_functions
   - operator_usage_whitespace
   - redundant_string_enum_value
-  - redundant_void_return
   - return_arrow_whitespace
   - trailing_newline
   - type_name


### PR DESCRIPTION
#### Summary

This PR adds a new rule to omit `Void` return types from closure definitions. 

```swift
// WRONG
someAsyncThing() { argument -> Void in
  ...
}
  
// RIGHT
someAsyncThing() { argument in
  ...
}
```

#### Reasoning

This was previously present in our style guide, but was removed because it was missing autocorrect (Fixes #50). As of nicklockwood/SwiftFormat#1056, this is the default behavior of the SwiftFormat `redundantVoidReturnType` rule.

This also follows pretty naturally from the [existing rule](https://github.com/airbnb/swift#omit-function-void-return) that says to omit `Void` return types from function definitions.

_Please react with 👍/👎 if you agree or disagree with this proposal._
