### PR TITLE
Use SwiftFormat redundantPattern rule instead of SwiftLint empty_enum_arguments rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,7 +515,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
-* <a id='unnecessary-enum-arguments'></a> (<a href='#unnecessary-enum-arguments'>link</a>) **Omit enum associated values from case statements when all arguments are unlabeled.** [![SwiftLint: empty_enum_arguments](https://img.shields.io/badge/SwiftLint-empty__enum__arguments-007A87.svg)](https://github.com/realm/SwiftLint/blob/master/Rules.md#empty-enum-arguments)
+* <a id='unnecessary-enum-arguments'></a> (<a href='#unnecessary-enum-arguments'>link</a>) **Omit enum associated values from case statements when all arguments are unlabeled.** [![SwiftFormat: redundantPattern](https://img.shields.io/badge/SwiftFormat-redundantPattern-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#redundantPattern)
 
   <details>
 

--- a/resources/airbnb.swiftformat
+++ b/resources/airbnb.swiftformat
@@ -44,6 +44,7 @@
 --rules redundantReturn
 --rules redundantSelf
 --rules redundantType
+--rules redundantPattern
 --rules sortedImports
 --rules strongifiedSelf
 --rules trailingCommas

--- a/resources/swiftlint.yml
+++ b/resources/swiftlint.yml
@@ -1,7 +1,6 @@
 only_rules:
   - closure_spacing
   - colon
-  - empty_enum_arguments
   - fatal_error_message
   - force_cast
   - force_try


### PR DESCRIPTION
#### Summary

The PR adopts the SwiftFormat `redundantPattern` rule, instead of the SwiftLint `empty_enum_arguments` rule. 

#### Reasoning

Both of these rule implementations cover our existing [unnecessary-enum-arguments](https://github.com/airbnb/swift#unnecessary-enum-arguments) rule, but I noticed that the SwiftLint implementation misses some examples that the SwiftFormat implementation autocorrects properly.
