### PR TITLE
Bump SwiftFormat --swiftversion from 5.1 to 5.5

### DIFF
--- a/resources/airbnb.swiftformat
+++ b/resources/airbnb.swiftformat
@@ -25,7 +25,7 @@
 --extensionacl on-declarations # extensionAccessControl
 --patternlet inline # hoistPatternLet
 --redundanttype inferred # redundantType
---swiftversion 5.1
+--swiftversion 5.5
 
 # We recommend a max width of 100 but _strictly enforce_ a max width of 130
 --maxwidth 130 # wrap


### PR DESCRIPTION
This PR updates the `--swiftversion` in `airbnb.swiftformat` from 5.1 to 5.5, to reflect that we are now using Swift 5.5 at Airbnb.