### PR TITLE
Adopt redundantFileprivate SwiftFormat rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -1382,7 +1382,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   ```swift
   // WRONG
-  struct Spaceship {
+  public struct Spaceship {
     // WRONG: `engine` is used in `extension Spaceship` below,
     // but extensions in the same file can access `private` members.
     fileprivate let engine: AntimatterEngine
@@ -1396,13 +1396,13 @@ _You can enable the following settings in Xcode by running [this script](resourc
   }
 
   extension Spaceship {
-    func blastOff() {
+    public func blastOff() {
       engine.start()
     }
   }
 
   extension Pilot {
-    func chartCourse() {
+    public func chartCourse() {
       spaceship.navigation.course = .andromedaGalaxy
       spaceship.blastOff()
     }
@@ -1411,20 +1411,20 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   ```swift
   // RIGHT
-  struct Spaceship {
+  public struct Spaceship {
     fileprivate let navigation: SpecialRelativityNavigationService
     private let engine: AntimatterEngine
     private let hull: Hull
   }
 
   extension Spaceship {
-    func blastOff() {
+    public func blastOff() {
       engine.start()
     }
   }
   
   extension Pilot {
-    func chartCourse() {
+    public func chartCourse() {
       spaceship.navigation.course = .andromedaGalaxy
       spaceship.blastOff()
     }

--- a/README.md
+++ b/README.md
@@ -1376,7 +1376,60 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
-* <a id='limit-access-control'></a>(<a href='#limit-access-control'>link</a>) **Access control should be at the strictest level possible.** Prefer `public` to `open` and `private` to `fileprivate` unless you need that behavior.
+* <a id='limit-access-control'></a>(<a href='#limit-access-control'>link</a>) **Access control should be at the strictest level possible.** Prefer `public` to `open` and `private` to `fileprivate` unless you need that behavior. [![SwiftFormat: redundantFileprivate](https://img.shields.io/badge/SwiftFormat-redundantFileprivate-008489.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#redundantFileprivate)
+
+  <details>
+
+  ```swift
+  // WRONG
+  struct Spaceship {
+    // WRONG: `engine` is used in `extension Spaceship` below,
+    // but extensions in the same file can access `private` members.
+    fileprivate let engine: AntimatterEngine
+
+    // WRONG: `hull` is not used by any other type, so `fileprivate` is unnecessary. 
+    fileprivate let hull: Hull
+
+    // RIGHT: `navigation` is used in `extension Pilot` below,
+    // so `fileprivate` is necessary here.
+    fileprivate let navigation: SpecialRelativityNavigationService
+  }
+
+  extension Spaceship {
+    func blastOff() {
+      engine.start()
+    }
+  }
+
+  extension Pilot {
+    func chartCourse() {
+      spaceship.navigation.course = .andromedaGalaxy
+      spaceship.blastOff()
+    }
+  }
+  ```
+
+  ```swift
+  // RIGHT
+  struct Spaceship {
+    fileprivate let navigation: SpecialRelativityNavigationService
+    private let engine: AntimatterEngine
+    private let hull: Hull
+  }
+
+  extension Spaceship {
+    func blastOff() {
+      engine.start()
+    }
+  }
+  
+  extension Pilot {
+    func chartCourse() {
+      spaceship.navigation.course = .andromedaGalaxy
+      spaceship.blastOff()
+    }
+  }
+  ```
 
 * <a id='avoid-global-functions'></a>(<a href='#avoid-global-functions'>link</a>) **Avoid global functions whenever possible.** Prefer methods within type definitions.
 
@@ -2081,42 +2134,6 @@ _You can enable the following settings in Xcode by running [this script](resourc
   var atmosphere: Atmosphere {
     didSet {
       print("oh my god, the atmosphere changed")
-    }
-  }
-  ```
-
-  </details>
-
-* <a id='redundant-fileprivate'></a>(<a href='#redundant-fileprivate'>link</a>) **Prefer using `private` over `fileprivate`,** when `fileprivate` is not necessary. [![SwiftFormat: redundantFileprivate](https://img.shields.io/badge/SwiftFormat-redundantFileprivate-008489.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#redundantFileprivate)
-
-  <details>
-
-  ```swift
-  struct Spaceship {
-    // WRONG: `engine` is used in `extension Spaceship` below,
-    // but extensions in the same file can access `private` members.
-    // This should be `private` instead.
-    fileprivate let engine: AntimatterEngine
-
-    // WRONG: `hull` is not used by any other type, so `fileprivate` is unnecessary. 
-    // This should be `private` instead.
-    fileprivate let hull: Hull
-
-    // RIGHT: `navigation` is used in `extension Pilot` below,
-    // so `fileprivate` is necessary here.
-    fileprivate let navigation: SpecialRelativityNavigationService
-  }
-
-  extension Spaceship {
-    func blastOff() {
-      engine.start()
-    }
-  }
-
-  extension Pilot {
-    func chartCourse() {
-      spaceship.navigation.course = .andromedaGalaxy
-      spaceship.blastOff()
     }
   }
   ```

--- a/README.md
+++ b/README.md
@@ -2087,6 +2087,42 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
+* <a id='redundant-fileprivate'></a>(<a href='#redundant-fileprivate'>link</a>) **Prefer using `private` over `fileprivate`,** when `fileprivate` is not necessary. [![SwiftFormat: redundantFileprivate](https://img.shields.io/badge/SwiftFormat-redundantFileprivate-008489.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#redundantFileprivate)
+
+  <details>
+
+  ```swift
+  struct Spaceship {
+    // WRONG: `engine` is used in `extension Spaceship` below,
+    // but extensions in the same file can access `private` members.
+    // This should be `private` instead.
+    fileprivate let engine: AntimatterEngine
+
+    // WRONG: `hull` is not used by any other type, so `fileprivate` is unnecessary. 
+    // This should be `private` instead.
+    fileprivate let hull: Hull
+
+    // RIGHT: `navigation` is used in `extension Pilot` below,
+    // so `fileprivate` is necessary here.
+    fileprivate let navigation: SpecialRelativityNavigationService
+  }
+
+  extension Spaceship {
+    func blastOff() {
+      engine.start()
+    }
+  }
+
+  extension Pilot {
+    func chartCourse() {
+      spaceship.navigation.course = .andromedaGalaxy
+      spaceship.blastOff()
+    }
+  }
+  ```
+
+  </details>
+
 **[⬆ back to top](#table-of-contents)**
 
 ## Objective-C Interoperability

--- a/resources/airbnb.swiftformat
+++ b/resources/airbnb.swiftformat
@@ -45,6 +45,7 @@
 --rules redundantSelf
 --rules redundantType
 --rules redundantPattern
+--rules redundantFileprivate
 --rules sortedImports
 --rules sortDeclarations
 --rules strongifiedSelf


### PR DESCRIPTION
#### Summary

This PR enables the [`redundantFileprivate`](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#redundantFileprivate) SwiftFormat rule.

#### Reasoning

We already have a prose rule for this in the style guide ([_"Access control should be at the strictest level possible: prefer `private` to `fileprivate`"_](https://github.com/airbnb/swift#limit-access-control)), so this just adds autocorrect.
