### PR TITLE
Add rule to omit get clause from computed property declarations when unnecessary

### DIFF
--- a/README.md
+++ b/README.md
@@ -1113,6 +1113,32 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
     </details>
 
+* <a id='redundant-get'></a>(<a href='#redundant-get'>link</a>) **Omit the `get` clause from a variable declaration that doesn't also have a `set`, `willSet`, or `didSet` clause.** [![SwiftFormat: redundantGet](https://img.shields.io/badge/SwiftFormat-redundantGet-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#redundantGet)
+
+    <details>
+
+    ```
+    // WRONG
+    var universe: Universe {
+      get {
+        Universe()
+      }
+    }
+
+    // RIGHT
+    var universe: Universe {
+      Universe()
+    }
+
+    // RIGHT
+    var universe: Universe {
+      get { multiverseService.current }
+      set { multiverseService.current = newValue }
+    }
+    ```
+
+    </details>
+
 ### Closures
 
 * <a id='favor-void-closure-return'></a>(<a href='#favor-void-closure-return'>link</a>) **Favor `Void` return types over `()` in closure declarations.** If you must specify a `Void` return type in a function declaration, use `Void` rather than `()` to improve readability. [![SwiftLint: void_return](https://img.shields.io/badge/SwiftLint-void__return-007A87.svg)](https://github.com/realm/SwiftLint/blob/master/Rules.md#void-return)

--- a/README.md
+++ b/README.md
@@ -1113,7 +1113,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
     </details>
 
-* <a id='redundant-get'></a>(<a href='#redundant-get'>link</a>) **Omit the `get` clause from a computed variable declaration that doesn't also have a `set`, `willSet`, or `didSet` clause.** [![SwiftFormat: redundantGet](https://img.shields.io/badge/SwiftFormat-redundantGet-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#redundantGet)
+* <a id='redundant-get'></a>(<a href='#redundant-get'>link</a>) **Omit the `get` clause from a computed property declaration that doesn't also have a `set`, `willSet`, or `didSet` clause.** [![SwiftFormat: redundantGet](https://img.shields.io/badge/SwiftFormat-redundantGet-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#redundantGet)
 
     <details>
 

--- a/README.md
+++ b/README.md
@@ -1117,7 +1117,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
     <details>
 
-    ```
+    ```swift
     // WRONG
     var universe: Universe {
       get {

--- a/README.md
+++ b/README.md
@@ -1113,32 +1113,6 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
     </details>
 
-* <a id='redundant-get'></a>(<a href='#redundant-get'>link</a>) **Omit the `get` clause from a computed property declaration that doesn't also have a `set`, `willSet`, or `didSet` clause.** [![SwiftFormat: redundantGet](https://img.shields.io/badge/SwiftFormat-redundantGet-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#redundantGet)
-
-    <details>
-
-    ```swift
-    // WRONG
-    var universe: Universe {
-      get {
-        Universe()
-      }
-    }
-
-    // RIGHT
-    var universe: Universe {
-      Universe()
-    }
-
-    // RIGHT
-    var universe: Universe {
-      get { multiverseService.current }
-      set { multiverseService.current = newValue }
-    }
-    ```
-
-    </details>
-
 ### Closures
 
 * <a id='favor-void-closure-return'></a>(<a href='#favor-void-closure-return'>link</a>) **Favor `Void` return types over `()` in closure declarations.** If you must specify a `Void` return type in a function declaration, use `Void` rather than `()` to improve readability. [![SwiftLint: void_return](https://img.shields.io/badge/SwiftLint-void__return-007A87.svg)](https://github.com/realm/SwiftLint/blob/master/Rules.md#void-return)
@@ -1871,6 +1845,32 @@ _You can enable the following settings in Xcode by running [this script](resourc
   ```
 
   </details>
+
+* <a id='redundant-get'></a>(<a href='#redundant-get'>link</a>) **Omit the `get` clause from a computed property declaration that doesn't also have a `set`, `willSet`, or `didSet` clause.** [![SwiftFormat: redundantGet](https://img.shields.io/badge/SwiftFormat-redundantGet-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#redundantGet)
+
+    <details>
+
+    ```swift
+    // WRONG
+    var universe: Universe {
+      get {
+        Universe()
+      }
+    }
+
+    // RIGHT
+    var universe: Universe {
+      Universe()
+    }
+
+    // RIGHT
+    var universe: Universe {
+      get { multiverseService.current }
+      set { multiverseService.current = newValue }
+    }
+    ```
+
+    </details>
 
 **[⬆ back to top](#table-of-contents)**
 

--- a/README.md
+++ b/README.md
@@ -1113,7 +1113,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
     </details>
 
-* <a id='redundant-get'></a>(<a href='#redundant-get'>link</a>) **Omit the `get` clause from a variable declaration that doesn't also have a `set`, `willSet`, or `didSet` clause.** [![SwiftFormat: redundantGet](https://img.shields.io/badge/SwiftFormat-redundantGet-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#redundantGet)
+* <a id='redundant-get'></a>(<a href='#redundant-get'>link</a>) **Omit the `get` clause from a computed variable declaration that doesn't also have a `set`, `willSet`, or `didSet` clause.** [![SwiftFormat: redundantGet](https://img.shields.io/badge/SwiftFormat-redundantGet-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#redundantGet)
 
     <details>
 

--- a/resources/airbnb.swiftformat
+++ b/resources/airbnb.swiftformat
@@ -45,6 +45,7 @@
 --rules redundantSelf
 --rules redundantType
 --rules redundantPattern
+--rules redundantGet
 --rules sortedImports
 --rules sortDeclarations
 --rules strongifiedSelf


### PR DESCRIPTION
#### Summary

This PR adds a new rule to omit the `get` clause from computed property declarations that don't also have a `set`, `willSet`, or `didSet` clause.

```swift
// WRONG
var universe: Universe {
   get {
     Universe()
  }
}

// RIGHT
var universe: Universe {
  Universe() 
}
    
// RIGHT
var universe: Universe {
  get { multiverseService.current }
  set { multiverseService.current = newValue }
}
```

#### Reasoning

A standalone `get { }` clause is redundant and can be removed without affecting the behavior of the code.

_Please react with 👍/👎 if you agree or disagree with this proposal._
