### PR TITLE
Remove reference to type-names SwiftLint rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
 ## Naming
 
-* <a id='use-camel-case'></a>(<a href='#use-camel-case'>link</a>) **Use PascalCase for type and protocol names, and lowerCamelCase for everything else.** [![SwiftLint: type_name](https://img.shields.io/badge/SwiftLint-type__name-007A87.svg)](https://github.com/realm/SwiftLint/blob/master/Rules.md#type-name)
+* <a id='use-camel-case'></a>(<a href='#use-camel-case'>link</a>) **Use PascalCase for type and protocol names, and lowerCamelCase for everything else.**
 
   <details>
 

--- a/resources/swiftlint.yml
+++ b/resources/swiftlint.yml
@@ -13,7 +13,6 @@ only_rules:
   - redundant_string_enum_value
   - return_arrow_whitespace
   - trailing_newline
-  - type_name
   - unused_optional_binding
   - vertical_whitespace
   - void_return


### PR DESCRIPTION
This PR removes references to the `type-names` SwiftLint rule, which we don't use internally since it doesn't support autocorrect. This resolves #93.