### PR TITLE
Use SwiftFormat redundantRawValues instead of SwiftLint redundant_string_enum_value

### DIFF
--- a/README.md
+++ b/README.md
@@ -1486,7 +1486,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
-* <a id='auto-enum-values'></a>(<a href='#auto-enum-values'>link</a>) **Use Swift's automatic enum values unless they map to an external source.** Add a comment explaining why explicit values are defined. [![SwiftLint: redundant_string_enum_value](https://img.shields.io/badge/SwiftLint-redundant__string__enum__value-007A87.svg)](https://realm.github.io/SwiftLint/redundant_string_enum_value)
+* <a id='auto-enum-values'></a>(<a href='#auto-enum-values'>link</a>) **Use Swift's automatic enum values unless they map to an external source.** Add a comment explaining why explicit values are defined. [![SwiftFormat: redundantRawValues](https://img.shields.io/badge/SwiftFormat-redundantRawValues-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#redundantRawValues)
 
   <details>
 
@@ -1532,13 +1532,13 @@ _You can enable the following settings in Xcode by running [this script](resourc
   }
 
   /// These are written to a logging service. Explicit values ensure they're consistent across binaries.
-  // swiftlint:disable redundant_string_enum_value
+  // swiftformat:disable redundantEnumValues
   enum UserType: String {
     case owner = "owner"
     case manager = "manager"
     case member = "member"
   }
-  // swiftlint:enable redundant_string_enum_value
+  // swiftformat:enable redundantEnumValues
 
   enum Planet: Int {
     case mercury

--- a/resources/airbnb.swiftformat
+++ b/resources/airbnb.swiftformat
@@ -46,6 +46,7 @@
 --rules redundantType
 --rules redundantPattern
 --rules redundantFileprivate
+--rules redundantRawValues
 --rules sortedImports
 --rules sortDeclarations
 --rules strongifiedSelf

--- a/resources/swiftlint.yml
+++ b/resources/swiftlint.yml
@@ -10,7 +10,6 @@ only_rules:
   - legacy_constructor
   - legacy_nsgeometry_functions
   - operator_usage_whitespace
-  - redundant_string_enum_value
   - return_arrow_whitespace
   - trailing_newline
   - unused_optional_binding


### PR DESCRIPTION
This PR removes the SwiftLint [`redundant_string_enum_value`](https://realm.github.io/SwiftLint/redundant_string_enum_value.html) rule (which doesn't support autocorrect) in favor of the SwiftFormat [`redundantRawValues`](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#redundantrawvalues) rule (which does support autocorrect).