### PR TITLE
Add enumNamespaces SwiftFormat rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -1461,7 +1461,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
-* <a id='namespace-using-enums'></a>(<a href='#namespace-using-enums'>link</a>) **Use caseless `enum`s for organizing `public` or `internal` constants and functions into namespaces.**
+* <a id='namespace-using-enums'></a>(<a href='#namespace-using-enums'>link</a>) **Use caseless `enum`s for organizing `public` or `internal` constants and functions into namespaces.** [![SwiftFormat: enumNamespaces](https://img.shields.io/badge/SwiftFormat-enumNamespaces-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#enumNamespaces)
   * Avoid creating non-namespaced global constants and functions.
   * Feel free to nest namespaces where it adds clarity.
   * `private` globals are permitted, since they are scoped to a single file and do not pollute the global namespace. Consider placing private globals in an `enum` namespace to match the guidelines for other declaration types.

--- a/resources/airbnb.swiftformat
+++ b/resources/airbnb.swiftformat
@@ -64,3 +64,4 @@
 --rules unusedArguments
 --rules spaceInsideBraces
 --rules spaceAroundBraces
+--rules enumNamespaces


### PR DESCRIPTION
#### Summary

This PR adds the [enumNamespaces SwiftFormat rule](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#enumnamespaces).

#### Reasoning

This aligns with [an existing prose rule](https://github.com/airbnb/swift#namespace-using-enums).

_Please react with 👍/👎 if you agree or disagree with this proposal._
