### PR TITLE
Update SwiftFormat version to 0.50-beta-1

### DIFF
--- a/resources/airbnb.swiftformat
+++ b/resources/airbnb.swiftformat
@@ -1,5 +1,5 @@
 # Current version of SwiftFormat used at Airbnb: 
-# https://github.com/calda/SwiftFormat/releases/tag/0.49-beta-4
+# https://github.com/calda/SwiftFormat/releases/tag/0.50-beta-1
 
 # options
 --self remove # redundantSelf


### PR DESCRIPTION
#### Summary

This PR updates `airbnb.swiftformat` to reflect that we are now using [0.50-beta-1](https://github.com/calda/SwiftFormat/releases/tag/0.50-beta-1)