### PR TITLE
Add rule that comment blocks should use single-line comments (// and ///)

### DIFF
--- a/README.md
+++ b/README.md
@@ -917,6 +917,62 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
+* <a id='comments'></a>(<a href='#comments'>link</a>) **Comment blocks should use single-line comments (`//` and `///`)**, rather than multi-line comments (`/* ... */` and `/** ... */`). [![SwiftFormat: blockComments](https://img.shields.io/badge/SwiftFormat-blockComments-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#blockComments)
+
+  <details>
+
+  ```swift
+  // WRONG
+
+  /**
+  * A planet that exists somnewhere in the universe.
+  *
+  * Planets have many properties. For example, the best planets
+  * have atmospheres and bodies of water to support life.
+  */
+  class Planet {
+    /**
+      Terraforms the planet, by adding an atmosphere and ocean
+      that is hospitable for life.
+      - Precondition: the planet does not already have an atmosphere.
+        Adding another atmosphere to a planet that already has one is a very bad idea.
+    */
+    func terraform() {
+      /* 
+      Generate the atmosphere first, before generating the ocean.
+      Otherwise, the water will just boil off immediately.
+      */
+      generateAtmosphere()
+
+      /* Now that we have an atmosphere, it's safe to generate the ocean */
+      generateOceans()
+    }
+  }
+
+  // RIGHT
+
+  /// A planet that exists somnewhere in the universe.
+  ///
+  /// Planets have many properties. For example, the best planets
+  /// have atmospheres and bodies of water to support life.
+  class Planet {
+    /// Terraforms the planet, by adding an atmosphere and ocean
+    /// that is hospitable for life.
+    ///  - Precondition: the planet does not already have an atmosphere.
+    ///    Adding another atmosphere to a planet that already has one is a very bad idea.
+    func terraform() {
+      // Generate the atmosphere first, before generating the ocean.
+      // Otherwise, the water will just boil off immediately.
+      generateAtmosphere()
+
+      // Now that we have an atmosphere, it's safe to generate the ocean
+      generateOceans()
+    }
+  }
+  ```
+
+  </details>
+
 ### Functions
 
 * <a id='omit-function-void-return'></a>(<a href='#omit-function-void-return'>link</a>) **Omit `Void` return types from function definitions.** [![SwiftFormat: redundantVoidReturnType](https://img.shields.io/badge/SwiftFormat-redundantVoidReturnType-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#redundantVoidReturnType)

--- a/README.md
+++ b/README.md
@@ -925,7 +925,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
   // WRONG
 
   /**
-  * A planet that exists somnewhere in the universe.
+  * A planet that exists somewhere in the universe.
   *
   * Planets have many properties. For example, the best planets
   * have atmospheres and bodies of water to support life.
@@ -951,7 +951,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   // RIGHT
 
-  /// A planet that exists somnewhere in the universe.
+  /// A planet that exists somewhere in the universe.
   ///
   /// Planets have many properties. For example, the best planets
   /// have atmospheres and bodies of water to support life.

--- a/README.md
+++ b/README.md
@@ -917,7 +917,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
-* <a id='comments'></a>(<a href='#comments'>link</a>) **Comment blocks should use single-line comments (`//` and `///`)**, rather than multi-line comments (`/* ... */` and `/** ... */`). [![SwiftFormat: blockComments](https://img.shields.io/badge/SwiftFormat-blockComments-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#blockComments)
+* <a id='comments'></a>(<a href='#comments'>link</a>) **Comment blocks should use single-line comments (`//` for code comments and `///` for documentation comments)**, rather than multi-line comments (`/* ... */` and `/** ... */`). [![SwiftFormat: blockComments](https://img.shields.io/badge/SwiftFormat-blockComments-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#blockComments)
 
   <details>
 

--- a/README.md
+++ b/README.md
@@ -917,7 +917,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
-* <a id='comments'></a>(<a href='#comments'>link</a>) **Comment blocks should use single-line comments (`//` for code comments and `///` for documentation comments)**, rather than multi-line comments (`/* ... */` and `/** ... */`). [![SwiftFormat: blockComments](https://img.shields.io/badge/SwiftFormat-blockComments-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#blockComments)
+* <a id='single-line-comments'></a>(<a href='#single-line-comments'>link</a>) **Comment blocks should use single-line comments (`//` for code comments and `///` for documentation comments)**, rather than multi-line comments (`/* ... */` and `/** ... */`). [![SwiftFormat: blockComments](https://img.shields.io/badge/SwiftFormat-blockComments-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#blockComments)
 
   <details>
 
@@ -932,10 +932,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
   */
   class Planet {
     /**
-      Terraforms the planet, by adding an atmosphere and ocean
-      that is hospitable for life.
-      - Precondition: the planet does not already have an atmosphere.
-        Adding another atmosphere to a planet that already has one is a very bad idea.
+      Terraforms the planet, by adding an atmosphere and ocean that is hospitable for life.
     */
     func terraform() {
       /* 
@@ -956,10 +953,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
   /// Planets have many properties. For example, the best planets
   /// have atmospheres and bodies of water to support life.
   class Planet {
-    /// Terraforms the planet, by adding an atmosphere and ocean
-    /// that is hospitable for life.
-    ///  - Precondition: the planet does not already have an atmosphere.
-    ///    Adding another atmosphere to a planet that already has one is a very bad idea.
+    /// Terraforms the planet, by adding an atmosphere and ocean that is hospitable for life.
     func terraform() {
       // Generate the atmosphere first, before generating the ocean.
       // Otherwise, the water will just boil off immediately.

--- a/resources/airbnb.swiftformat
+++ b/resources/airbnb.swiftformat
@@ -65,3 +65,4 @@
 --rules spaceInsideBraces
 --rules spaceAroundBraces
 --rules enumNamespaces
+--rules blockComments


### PR DESCRIPTION
#### Summary

This PR proposes a new rule that comment blocks should use single-line comments (`//` and `///`) rather than multi-line comments (`/* ... */` and `/** ... */`). This is implemented by SwiftFormat's [`blockComments`](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#blockComments) rule.

```swift
// WRONG

/**
* A planet that exists somewhere in the universe.
*
* Planets have many properties. For example, the best planets
* have atmospheres and bodies of water to support life.
*/
class Planet {
  /**
    Terraforms the planet, by adding an atmosphere and ocean
    that is hospitable for life.
    - Precondition: the planet does not already have an atmosphere.
      Adding another atmosphere to a planet that already has one is a very bad idea.
  */
  func terraform() {
    /* 
    Generate the atmosphere first, before generating the ocean.
    Otherwise, the water will just boil off immediately.
    */
    generateAtmosphere()

    /* Now that we have an atmosphere, it's safe to generate the ocean */
    generateOceans()
  }
}

// RIGHT

/// A planet that exists somewhere in the universe.
///
/// Planets have many properties. For example, the best planets
/// have atmospheres and bodies of water to support life.
class Planet {
  /// Terraforms the planet, by adding an atmosphere and ocean
  /// that is hospitable for life.
  ///  - Precondition: the planet does not already have an atmosphere.
  ///    Adding another atmosphere to a planet that already has one is a very bad idea.
  func terraform() {
    // Generate the atmosphere first, before generating the ocean.
    // Otherwise, the water will just boil off immediately.
    generateAtmosphere()

    // Now that we have an atmosphere, it's safe to generate the ocean
    generateOceans()
  }
}
```

#### Reasoning

 - In general, when there are multiple equivalent ways to express something, we introduce a style guide rule that prefers one over the other. These two forms of writing comments are equivalent, so it makes sense for us to have a rule that explicitly prefers one over the other.

 - In our codebase, single-line comments are significantly more common than multi-line comments (I don't have any firm data for this but could figure out a way to analyze this quantitatively if necessary). 

 - Single-line comments are the default in Xcode:
   - when using Xcode's "Comment selection" command (`⌘/`), it inserts single-line comments (`//`)
   - when using Xcode's "Generate documentation" command (`⌘-option-/`), it inserts single-line doc comments (`///`)

      <img src="https://user-images.githubusercontent.com/1811727/153103713-5a816839-5172-406f-af59-227408ac537c.gif" width=350>

   - Xcode also automatically inserts single-line comments when adding a new line to a comment block. (I think one potential reason to prefer mutli-line comments is that it reduces the need to do comment bookkeeping when adding newlines, but this isn't a problem in modern versions of Xcode).
  
      <img src="https://user-images.githubusercontent.com/1811727/153104364-656113ad-6d33-4601-9390-e42edd57ffdb.gif" width=350>

 - There are many different ways to structure / indent comments using `/* ... */`, but only one way to structure / indent comments using `//` (so these are easier to use and better for consistency):
      ```swift
      // this is a single-line comment
      ```

      ```swift
      /* this is a multi-line comment */

      /* 
      this is a multi-line comment 
      */

      /* 
       * this is a multi-line comment 
       */

      /* 
        this is a multi-line comment 
       */
      ``` 



_Please react with 👍/👎 if you agree or disagree with this proposal._
