### PR TITLE
Fix redundantRawValues example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1582,13 +1582,13 @@ _You can enable the following settings in Xcode by running [this script](resourc
   }
 
   /// These are written to a logging service. Explicit values ensure they're consistent across binaries.
-  // swiftformat:disable redundantEnumValues
+  // swiftformat:disable redundantRawValues
   enum UserType: String {
     case owner = "owner"
     case manager = "manager"
     case member = "member"
   }
-  // swiftformat:enable redundantEnumValues
+  // swiftformat:enable redundantRawValues
 
   enum Planet: Int {
     case mercury


### PR DESCRIPTION
#### Summary

Fixes example code

#### Reasoning

Should be `redundantRawValues` instead of `redundantEnumValues`. 
https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#redundantRawValues

_Please react with 👍/👎 if you agree or disagree with this proposal._
