### PR TITLE
Update airbnb.swiftformat to use version based on SwiftFormat 0.49.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -843,7 +843,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
-* <a id='multi-line-expression-braces'></a>(<a href='#multi-line-expression-braces'>link</a>) The opening brace following a multi-line expression should wrap to a new line. [![SwiftFormat: braces](https://img.shields.io/badge/SwiftFormat-braces-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#braces)
+* <a id='multi-line-expression-braces'></a>(<a href='#multi-line-expression-braces'>link</a>) The opening brace following a multi-line expression should wrap to a new line. [![SwiftFormat: wrapMultilineStatementBraces](https://img.shields.io/badge/SwiftFormat-wrapMultilineStatementBraces-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapMultilineStatementBraces)
 
   <details>
 

--- a/resources/airbnb.swiftformat
+++ b/resources/airbnb.swiftformat
@@ -1,5 +1,5 @@
 # Current version of SwiftFormat used at Airbnb: 
-# https://github.com/calda/SwiftFormat/releases/tag/0.50-beta-1
+# https://github.com/calda/SwiftFormat/releases/tag/0.49.10-beta-1
 
 # options
 --self remove # redundantSelf
@@ -55,6 +55,7 @@
 --rules trailingSpace
 --rules typeSugar
 --rules wrap
+--rules wrapMultilineStatementBraces
 --rules wrapArguments
 --rules wrapAttributes
 --rules braces


### PR DESCRIPTION
#### Summary

This PR updates us from a SwiftFormat build based on `0.49.4` (that had an Airbnb-specific change) to a build based on `0.49.9` (that only includes code that has been upstreamed to the mainline repo's `develop` branch).

For some historical context, last year I made a [SwiftFormat PR](https://github.com/nicklockwood/SwiftFormat/pull/1071) to fix some brace wrapping issues we were encountering. At the time this change was merged to `develop`, and is included in the SwiftFormat build we're currently using.

A few months after that change was merged, Nick reverted it because it was a breaking public API change (which he decided he didn't want to ship). Nick [merged a change yesterday](https://github.com/nicklockwood/SwiftFormat/commit/43aacf51a5502d3a43395abc83a08eee88a1f02e) that fixes the issue we were encountering without introducing any breaking changes.

So, tldr: now we are no longer using a version of SwiftFormat with Airbnb-specific changes. This will make it easier to adopt new versions of SwiftFormat moving forwards.