### PR TITLE
Add rule to include spaces before and after comment delimiters

### DIFF
--- a/README.md
+++ b/README.md
@@ -967,7 +967,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
-* <a id='spaces-around-comment-delimiters'></a>(<a href='#spaces-around-comment-delimiters'>link</a>) Include spaces before and after comment delimiters (`//`, `///`, `/*`, and `*/`) [![SwiftFormat: spaceAroundComments](https://img.shields.io/badge/SwiftFormat-spaceAroundComments-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#spaceAroundComments) [![SwiftFormat: spaceInsideComments](https://img.shields.io/badge/SwiftFormat-spaceInsideComments-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#spaceInsideComments)
+* <a id='spaces-around-comment-delimiters'></a>(<a href='#spaces-around-comment-delimiters'>link</a>) Include spaces or newlines before and after comment delimiters (`//`, `///`, `/*`, and `*/`) [![SwiftFormat: spaceAroundComments](https://img.shields.io/badge/SwiftFormat-spaceAroundComments-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#spaceAroundComments) [![SwiftFormat: spaceInsideComments](https://img.shields.io/badge/SwiftFormat-spaceInsideComments-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#spaceInsideComments)
 
   <details>
 

--- a/README.md
+++ b/README.md
@@ -967,7 +967,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
-  * <a id='spaces-in-and-around-comments'></a>(<a href='#spaces-in-and-around-comments'>link</a>) Include spaces before and after comments [![SwiftFormat: spaceAroundComments](https://img.shields.io/badge/SwiftFormat-spaceAroundComments-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#spaceAroundComments) [![SwiftFormat: spaceInsideComments](https://img.shields.io/badge/SwiftFormat-spaceInsideComments-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#spaceInsideComments)
+* <a id='spaces-in-and-around-comments'></a>(<a href='#spaces-in-and-around-comments'>link</a>) Include spaces before and after comments [![SwiftFormat: spaceAroundComments](https://img.shields.io/badge/SwiftFormat-spaceAroundComments-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#spaceAroundComments) [![SwiftFormat: spaceInsideComments](https://img.shields.io/badge/SwiftFormat-spaceInsideComments-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#spaceInsideComments)
 
   <details>
 

--- a/README.md
+++ b/README.md
@@ -967,7 +967,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
-* <a id='spaces-in-and-around-comments'></a>(<a href='#spaces-in-and-around-comments'>link</a>) Include spaces before and after comments [![SwiftFormat: spaceAroundComments](https://img.shields.io/badge/SwiftFormat-spaceAroundComments-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#spaceAroundComments) [![SwiftFormat: spaceInsideComments](https://img.shields.io/badge/SwiftFormat-spaceInsideComments-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#spaceInsideComments)
+* <a id='spaces-around-comment-delimiters'></a>(<a href='#spaces-around-comment-delimiters'>link</a>) Include spaces before and after comment delimiters (`//`, `///`, `/*`, and `*/`) [![SwiftFormat: spaceAroundComments](https://img.shields.io/badge/SwiftFormat-spaceAroundComments-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#spaceAroundComments) [![SwiftFormat: spaceInsideComments](https://img.shields.io/badge/SwiftFormat-spaceInsideComments-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#spaceInsideComments)
 
   <details>
 

--- a/README.md
+++ b/README.md
@@ -967,6 +967,36 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
+  * <a id='spaces-in-and-around-comments'></a>(<a href='#spaces-in-and-around-comments'>link</a>) Include spaces before and after comments [![SwiftFormat: spaceAroundComments](https://img.shields.io/badge/SwiftFormat-spaceAroundComments-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#spaceAroundComments) [![SwiftFormat: spaceInsideComments](https://img.shields.io/badge/SwiftFormat-spaceInsideComments-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#spaceInsideComments)
+
+  <details>
+
+  ```swift
+  // WRONG
+
+  ///A spacecraft with incredible performance characteristics
+  struct Spaceship {
+
+    func travelFasterThanLight() {/*unimplemented*/}
+
+    func travelBackInTime() { }//TODO: research whether or not this is possible
+
+  }
+
+  // RIGHT
+
+  /// A spacecraft with incredible performance characteristics
+  struct Spaceship {
+
+    func travelFasterThanLight() { /* unimplemented */ }
+
+    func travelBackInTime() { } // TODO: research whether or not this is possible
+
+  }
+  ```
+
+  </details>
+
 ### Functions
 
 * <a id='omit-function-void-return'></a>(<a href='#omit-function-void-return'>link</a>) **Omit `Void` return types from function definitions.** [![SwiftFormat: redundantVoidReturnType](https://img.shields.io/badge/SwiftFormat-redundantVoidReturnType-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#redundantVoidReturnType)

--- a/README.md
+++ b/README.md
@@ -967,7 +967,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
-* <a id='spaces-around-comment-delimiters'></a>(<a href='#spaces-around-comment-delimiters'>link</a>) Include spaces or newlines before and after comment delimiters (`//`, `///`, `/*`, and `*/`) [![SwiftFormat: spaceAroundComments](https://img.shields.io/badge/SwiftFormat-spaceAroundComments-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#spaceAroundComments) [![SwiftFormat: spaceInsideComments](https://img.shields.io/badge/SwiftFormat-spaceInsideComments-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#spaceInsideComments)
+* <a id='whitespace-around-comment-delimiters'></a>(<a href='#spaces-around-comment-delimiters'>link</a>) Include spaces or newlines before and after comment delimiters (`//`, `///`, `/*`, and `*/`) [![SwiftFormat: spaceAroundComments](https://img.shields.io/badge/SwiftFormat-spaceAroundComments-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#spaceAroundComments) [![SwiftFormat: spaceInsideComments](https://img.shields.io/badge/SwiftFormat-spaceInsideComments-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#spaceInsideComments)
 
   <details>
 

--- a/resources/airbnb.swiftformat
+++ b/resources/airbnb.swiftformat
@@ -66,3 +66,5 @@
 --rules spaceAroundBraces
 --rules enumNamespaces
 --rules blockComments
+--rules spaceAroundComments
+--rules spaceInsideComments


### PR DESCRIPTION
#### Summary

This PR adds a rule to include spaces before and after comments, implemented by the SwiftFormat [`spaceAroundComments`](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#spacearoundcomments) and [`spaceInsideComments`](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#spaceinsidecomments) rules.

> Include spaces before and after comments

```swift
// WRONG

///A spacecraft with incredible performance characteristics
struct Spaceship {

  func travelFasterThanLight() {/*unimplemented*/}

  func travelBackInTime() { }//TODO: research whether or not this is possible

}

// RIGHT
  
/// A spacecraft with incredible performance characteristics
struct Spaceship {

  func travelFasterThanLight() { /* unimplemented */ }

  func travelBackInTime() { } // TODO: research whether or not this is possible

}
```

#### Reasoning

Automatically-formatted spacing is good for consistency and legibility.

_Please react with 👍/👎 if you agree or disagree with this proposal._
