### PR TITLE
Add rule that there should be no spaces before or inside the parentheses of function calls / declarations

### DIFF
--- a/README.md
+++ b/README.md
@@ -915,6 +915,22 @@ _You can enable the following settings in Xcode by running [this script](resourc
   }
   ```
 
+* <a id='no-spaces-around-parens'></a>(<a href='#no-spaces-around-parens'>link</a>) For function calls and declarations, there should be no spaces before or inside the parentheses of the argument list. [![SwiftFormat: spaceInsideParens](https://img.shields.io/badge/SwiftFormat-spaceInsideParens-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#spaceInsideParens) [![SwiftFormat: spaceAroundParens](https://img.shields.io/badge/SwiftFormat-spaceAroundParens-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#spaceAroundParens)
+
+  <details>
+
+  ```swift
+  // WRONG
+  func install ( _ engine: Engine ) { }
+
+  install ( AnimatterDrive( ) )
+
+  // RIGHT
+  func install(_ engine: Engine) { }
+
+  install(AnimatterDrive())
+  ```
+
   </details>
 
 * <a id='single-line-comments'></a>(<a href='#single-line-comments'>link</a>) **Comment blocks should use single-line comments (`//` for code comments and `///` for documentation comments)**, rather than multi-line comments (`/* ... */` and `/** ... */`). [![SwiftFormat: blockComments](https://img.shields.io/badge/SwiftFormat-blockComments-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#blockComments)

--- a/README.md
+++ b/README.md
@@ -923,12 +923,12 @@ _You can enable the following settings in Xcode by running [this script](resourc
   // WRONG
   func install ( _ engine: Engine ) { }
 
-  install ( AnimatterDrive( ) )
+  install ( AntimatterDrive( ) )
 
   // RIGHT
   func install(_ engine: Engine) { }
 
-  install(AnimatterDrive())
+  install(AntimatterDrive())
   ```
 
   </details>

--- a/README.md
+++ b/README.md
@@ -915,7 +915,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
   }
   ```
 
-* <a id='no-spaces-around-parens'></a>(<a href='#no-spaces-around-parens'>link</a>) For function calls and declarations, there should be no spaces before or inside the parentheses of the argument list. [![SwiftFormat: spaceInsideParens](https://img.shields.io/badge/SwiftFormat-spaceInsideParens-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#spaceInsideParens) [![SwiftFormat: spaceAroundParens](https://img.shields.io/badge/SwiftFormat-spaceAroundParens-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#spaceAroundParens)
+* <a id='no-spaces-around-function-parens'></a>(<a href='#no-spaces-around-parens'>link</a>) For function calls and declarations, there should be no spaces before or inside the parentheses of the argument list. [![SwiftFormat: spaceInsideParens](https://img.shields.io/badge/SwiftFormat-spaceInsideParens-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#spaceInsideParens) [![SwiftFormat: spaceAroundParens](https://img.shields.io/badge/SwiftFormat-spaceAroundParens-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#spaceAroundParens)
 
   <details>
 

--- a/resources/airbnb.swiftformat
+++ b/resources/airbnb.swiftformat
@@ -65,5 +65,7 @@
 --rules unusedArguments
 --rules spaceInsideBraces
 --rules spaceAroundBraces
+--rules spaceInsideParens
+--rules spaceAroundParens
 --rules enumNamespaces
 --rules blockComments


### PR DESCRIPTION
#### Summary

This PR adds a new rule that there should be no spaces before or inside the parentheses of function calls / declarations. This is implemented by SwiftFormat's [`spaceAroundParens`](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#spacearoundparens) and [`spaceInsideParens`](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#spaceInsideParens) rules.

```swift
// WRONG
func install ( _ engine: Engine ) { }

install ( AntimatterDrive( ) )

// RIGHT
func install(_ engine: Engine) { }

install(AntimatterDrive())
```

#### Reasoning

Automatically-formatted spacing is good for consistency and legibility.

<!--- required --->

_Please react with 👍/👎 if you agree or disagree with this proposal._
