### PR TITLE
Add rule that there should be no spaces inside brackets of collection literals

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,20 @@ _You can enable the following settings in Xcode by running [this script](resourc
   ]
   ```
 
+* <a id='no-space-inside-brackets'></a>(<a href='#no-space-inside-brackets'>link</a>) **There should be no spaces inside the brackets of collection literals.** [![SwiftFormat: spaceInsideBrackets](https://img.shields.io/badge/SwiftFormat-spaceInsideBrackets-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#spaceInsideBrackets)
+
+  <details>
+
+  ```swift
+  // WRONG
+  let innerPlanets = [ mercury, venus, earth, mars ]
+  let largestObjects = [ .star: sun, .planet: jupiter  ]
+
+  // RIGHT
+  let innerPlanets = [mercury, venus, earth, mars]
+  let largestObjects = [.star: sun, .planet: jupiter]
+  ```
+
   </details>
 
 * <a id='name-tuple-elements'></a>(<a href='#name-tuple-elements'>link</a>) **Name members of tuples for extra clarity.** Rule of thumb: if you've got more than 3 fields, you should probably be using a struct.

--- a/resources/airbnb.swiftformat
+++ b/resources/airbnb.swiftformat
@@ -63,6 +63,7 @@
 --rules redundantInit
 --rules redundantVoidReturnType
 --rules unusedArguments
+--rules spaceInsideBrackets
 --rules spaceInsideBraces
 --rules spaceAroundBraces
 --rules enumNamespaces


### PR DESCRIPTION
#### Summary

This PR adds a new rule that there should be no spaces inside the brackets of collection literals. This is implemented by SwiftFormat's [`spaceInsideBrackets`](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#spaceinsidebrackets) rule.

```swift
// WRONG
let innerPlanets = [ mercury, venus, earth, mars ]
let largestObjects = [ .star: sun, .planet: jupiter  ]

// RIGHT
let innerPlanets = [mercury, venus, earth, mars]
let largestObjects = [.star: sun, .planet: jupiter]
```

#### Reasoning

Automatically-formatted spacing is good for consistency and legibility.

_Please react with 👍/👎 if you agree or disagree with this proposal._
