### PR TITLE
Add rule to remove blank lines from the top and bottom of scopes (excluding type bodies)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2185,6 +2185,44 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
+* <a id='no-blank-lines-at-start-or-end-of-non-type-scopes'></a>(<a href='#no-blank-lines-at-start-or-end-of-non-type-scopes'>link</a>) **Remove blank lines at the top and bottom of scopes**, excluding type bodies which can optionally include blank lines. [![SwiftFormat: blankLinesAtStartOfScope](https://img.shields.io/badge/SwiftFormat-blankLinesAtStartOfScope-008489.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#blankLinesAtStartOfScope) [![SwiftFormat: blankLinesAtEndOfScope](https://img.shields.io/badge/SwiftFormat-blankLinesAtEndOfScope-008489.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#blankLinesAtEndOfScope)
+
+  <details>
+
+  ```swift
+  // WRONG
+  class Planet {
+
+    func terraform() {
+
+      generateAtmosphere()
+      generateOceans()
+
+    }
+
+  }
+
+  // RIGHT
+  class Planet {
+
+    func terraform() {
+      generateAtmosphere()
+      generateOceans()
+    }
+    
+  }
+
+  // Also fine!
+  class Planet {
+    func terraform() {
+      generateAtmosphere()
+      generateOceans()
+    }
+  }
+  ```
+
+  </details>
+
 
 * <a id='mark-types-and-extensions'></a>(<a href='#mark-types-and-extensions'>link</a>) **Each type and extension which implements a conformance should be preceded by a `MARK` comment.** [![SwiftFormat: markTypes](https://img.shields.io/badge/SwiftFormat-markTypes-008489.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#markTypes)
   * Types should be preceded by a `// MARK: - TypeName` comment.

--- a/resources/airbnb.swiftformat
+++ b/resources/airbnb.swiftformat
@@ -25,6 +25,7 @@
 --extensionacl on-declarations # extensionAccessControl
 --patternlet inline # hoistPatternLet
 --redundanttype inferred # redundantType
+--typeblanklines preserve # blankLinesAtStartOfScope, blankLinesAtEndOfScope
 --swiftversion 5.5
 
 # We recommend a max width of 100 but _strictly enforce_ a max width of 130
@@ -72,3 +73,5 @@
 --rules blockComments
 --rules spaceAroundComments
 --rules spaceInsideComments
+--rules blankLinesAtStartOfScope
+--rules blankLinesAtEndOfScope

--- a/resources/airbnb.swiftformat
+++ b/resources/airbnb.swiftformat
@@ -1,5 +1,5 @@
 # Current version of SwiftFormat used at Airbnb: 
-# https://github.com/calda/SwiftFormat/releases/tag/0.49.10-beta-1
+# https://github.com/calda/SwiftFormat/releases/tag/0.49.11-beta-2
 
 # options
 --self remove # redundantSelf


### PR DESCRIPTION
#### Summary

This PR proposes a new rule to remove blank lines from the top and bottom of scopes (excluding type bodies, where we continue to permit blank lines):

```swift

// WRONG
class Planet {

  func terraform() {

    generateAtmosphere()
    generateOceans()

  }

}

// RIGHT
class Planet {

  func terraform() {
    generateAtmosphere()
    generateOceans()
  }

}

// Also fine!
class Planet {
  func terraform() {
    generateAtmosphere()
    generateOceans()
  }
}
```

#### Reasoning

Blank lines at the top and bottom of methods are unnecessary, since the indentation and braces already provide sufficient visual spacing.

_Please react with 👍/👎 if you agree or disagree with this proposal._
