### PR TITLE
Use commas instead of `&&` operators in conditional statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1368,6 +1368,40 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
+* <a id='and-conditions'></a>(<a href='#and-conditions'>link</a>) In conditional statements (`if`, `guard`, `while`), separate boolean conditions using commas (`,`) instead of `&&` operators.  [![SwiftFormat: andOperator](https://img.shields.io/badge/SwiftFormat-andOperator-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#andOperator)
+
+  <details>
+
+  ```swift
+  // WRONG
+  if let star = planet.star, !planet.isHabitable && planet.isInHabitableZone(of: star) {
+    planet.terraform()
+  }
+
+  if
+    let star = planet.star, 
+    !planet.isHabitable 
+    && planet.isInHabitableZone(of: star)
+  {
+    planet.terraform()
+  }
+
+  // RIGHT
+  if let star = planet.star, !planet.isHabitable, planet.isInHabitableZone(of: star) {
+    planet.terraform()
+  }
+
+  if
+    let star = planet.star,
+    !planet.isHabitable,
+    planet.isInHabitableZone(of: star)
+  {
+    planet.terraform()
+  }
+  ```
+
+  </details>
+
 **[⬆ back to top](#table-of-contents)**
 
 ## Patterns

--- a/README.md
+++ b/README.md
@@ -1368,7 +1368,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
-* <a id='and-conditions'></a>(<a href='#and-conditions'>link</a>) In conditional statements (`if`, `guard`, `while`), separate boolean conditions using commas (`,`) instead of `&&` operators.  [![SwiftFormat: andOperator](https://img.shields.io/badge/SwiftFormat-andOperator-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#andOperator)
+* <a id='use-commas-in-and-conditions'></a>(<a href='#use-commas-in-and-conditions'>link</a>) In conditional statements (`if`, `guard`, `while`), separate boolean conditions using commas (`,`) instead of `&&` operators.  [![SwiftFormat: andOperator](https://img.shields.io/badge/SwiftFormat-andOperator-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#andOperator)
 
   <details>
 

--- a/resources/airbnb.swiftformat
+++ b/resources/airbnb.swiftformat
@@ -75,3 +75,4 @@
 --rules spaceInsideComments
 --rules blankLinesAtStartOfScope
 --rules blankLinesAtEndOfScope
+--rules andOperator


### PR DESCRIPTION
#### Summary

This PR proposes a new rule to use commas instead of `&&` operators in conditional statements.

```swift
// WRONG
if let star = planet.star, !planet.isHabitable && planet.isInHabitableZone(of: star) {
  planet.terraform()
}

if
  let star = planet.star, 
  !planet.isHabitable 
  && planet.isInHabitableZone(of: star)
{
  planet.terraform()
}

// RIGHT
if let star = planet.star, !planet.isHabitable, planet.isInHabitableZone(of: star) {
  planet.terraform()
}

if
  let star = planet.star,
  !planet.isHabitable,
  planet.isInHabitableZone(of: star)
{
  planet.terraform()
}
```

#### Reasoning

This syntax is more idiomatic, and increases consistency when mixed with optional unwrapping conditions.

_Please react with 👍/👎 if you agree or disagree with this proposal._
