### PR TITLE
Include a single space in a set of empty braces (`{ }`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1027,6 +1027,34 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
+* <a id='space-in-empty-braces'></a>(<a href='#space-in-empty-braces'>link</a>) Include a single space in an empty set of braces (`{ }`). [![SwiftFormat: emptyBraces](https://img.shields.io/badge/SwiftFormat-emptyBraces-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#emptyBraces)
+
+  <details>
+
+  ```swift
+  // WRONG
+  extension Spaceship: Trackable {}
+
+  extension SpaceshipView {
+    var accessibilityIdentifier: String {
+      get { spaceship.name }
+      set {}
+    }
+  }
+
+  // RIGHT
+  extension Spaceship: Trackable { }
+
+  extension SpaceshipView {
+    var accessibilityIdentifier: String {
+      get { spaceship.name }
+      set { }
+    }
+  }
+  ```
+
+  </details>
+
 ### Functions
 
 * <a id='omit-function-void-return'></a>(<a href='#omit-function-void-return'>link</a>) **Omit `Void` return types from function definitions.** [![SwiftFormat: redundantVoidReturnType](https://img.shields.io/badge/SwiftFormat-redundantVoidReturnType-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#redundantVoidReturnType)

--- a/resources/airbnb.swiftformat
+++ b/resources/airbnb.swiftformat
@@ -26,6 +26,7 @@
 --patternlet inline # hoistPatternLet
 --redundanttype inferred # redundantType
 --typeblanklines preserve # blankLinesAtStartOfScope, blankLinesAtEndOfScope
+--emptybraces spaced # emptyBraces
 --swiftversion 5.5
 
 # We recommend a max width of 100 but _strictly enforce_ a max width of 130
@@ -75,3 +76,4 @@
 --rules spaceInsideComments
 --rules blankLinesAtStartOfScope
 --rules blankLinesAtEndOfScope
+--rules emptyBraces


### PR DESCRIPTION
#### Summary

This PR proposes a new rule to include a single space in a set of empty braces (`{ }`).

```swift
// WRONG
extension Spaceship: Trackable {}

extension SpaceshipView {
  override var accessibilityIdentifier: String {
    get { spaceship.name }
    set {}
  }
}

// RIGHT
extension Spaceship: Trackable { }

extension SpaceshipView {
  override var accessibilityIdentifier: String {
    get { spaceship.name }
    set { }
  }
}
```

#### Reasoning

We should either always or never include a space between empty braces. When testing the different options in our codebase,
 - using `--emptybraces spaced` (this PR) results in a +4500/-5300 diff across 2600 files
 - using `--emptybraces no-space` results in a +6100/-6848 diff across 3700 files

This suggests there is a slight preference for `--emptybraces spaced` in our existing codebase, since adopting it results in a smaller diff.

_Please react with 👍/👎 if you agree or disagree with this proposal._
