### PR TITLE
Update xcode_settings.sh script to enable Xcode spell check

### DIFF
--- a/resources/xcode_settings.bash
+++ b/resources/xcode_settings.bash
@@ -2,6 +2,8 @@
 
 set -e
 
+defaults write com.apple.dt.Xcode AutomaticallyCheckSpellingWhileTyping -bool YES
+
 defaults write com.apple.dt.Xcode DVTTextEditorTrimTrailingWhitespace -bool YES
 defaults write com.apple.dt.Xcode DVTTextEditorTrimWhitespaceOnlyLines -bool YES
 


### PR DESCRIPTION
This PR updates the `xcode_settings.sh` script to enable spell check in Xcode. It works really well (e.g. handles camel case properly), but isn't enabled by default for some reason. 

<img src="https://user-images.githubusercontent.com/1811727/180044860-4bd018de-b783-44ad-836f-f5b7c318fc32.gif" width=500>