### PR TITLE
Improve error handling, add support for `--exclude` flag

### DIFF
--- a/Plugins/FormatSwift/Plugin.swift
+++ b/Plugins/FormatSwift/Plugin.swift
@@ -46,9 +46,9 @@ struct AirbnbSwiftFormatPlugin: CommandPlugin {
     case EXIT_SUCCESS:
       break
     case EXIT_FAILURE:
-      throw Error.lintFailure
+      throw CommandError.lintFailure
     default:
-      throw Error.unknownError(exitCode: Int(process.terminationStatus))
+      throw CommandError.unknownError(exitCode: process.terminationStatus)
     }
   }
 
@@ -89,9 +89,9 @@ struct AirbnbSwiftFormatPlugin: CommandPlugin {
 
 }
 
-// MARK: - Error
+// MARK: - CommandError
 
-enum Error: Swift.Error {
-  case unknownError(exitCode: Int)
+enum CommandError: Error {
   case lintFailure
+  case unknownError(exitCode: Int32)
 }

--- a/Sources/AirbnbSwiftFormatTool/AirbnbSwiftFormatTool.swift
+++ b/Sources/AirbnbSwiftFormatTool/AirbnbSwiftFormatTool.swift
@@ -51,9 +51,11 @@ struct AirbnbSwiftFormatTool: ParsableCommand {
       log("SwiftLint ended with exit code \(swiftLint.terminationStatus)")
     }
 
-    // SwiftFormat ends with exit code 1 on lint failure, and SwiftLint ends with exit code 2
-    if swiftFormat.terminationStatus == 1 || swiftLint.terminationStatus == 2 {
-      throw ExitCode(EXIT_FAILURE)
+    if
+      swiftFormat.terminationStatus == SwiftFormatExitCode.lintFailure ||
+      swiftLint.terminationStatus == SwiftLintExitCode.lintFailure
+    {
+      throw ExitCode.failure
     }
 
     // Any other non-success exit code is an unknown failure
@@ -123,4 +125,18 @@ extension Process {
     let arguments = arguments ?? []
     return "\(launchPath) \(arguments.joined(separator: " "))"
   }
+}
+
+// MARK: - SwiftFormatExitCode
+
+/// Known exit codes used by SwiftFormat
+enum SwiftFormatExitCode {
+  static let lintFailure: Int32 = 1
+}
+
+// MARK: - SwiftLintExitCode
+
+/// Known exit codes used by SwiftLint
+enum SwiftLintExitCode {
+  static let lintFailure: Int32 = 2
 }

--- a/Sources/AirbnbSwiftFormatTool/AirbnbSwiftFormatTool.swift
+++ b/Sources/AirbnbSwiftFormatTool/AirbnbSwiftFormatTool.swift
@@ -47,8 +47,8 @@ struct AirbnbSwiftFormatTool: ParsableCommand {
     if log {
       log(swiftFormat.shellCommand)
       log(swiftLint.shellCommand)
-      print("SwiftFormat ended with exit code \(swiftFormat.terminationStatus)")
-      print("SwiftLint ended with exit code \(swiftLint.terminationStatus)")
+      log("SwiftFormat ended with exit code \(swiftFormat.terminationStatus)")
+      log("SwiftLint ended with exit code \(swiftLint.terminationStatus)")
     }
 
     // SwiftFormat ends with exit code 1 on lint failure, and SwiftLint ends with exit code 2
@@ -111,7 +111,7 @@ struct AirbnbSwiftFormatTool: ParsableCommand {
   }()
 
   private func log(_ string: String) {
-    
+    // swiftlint:disable:next no_direct_standard_out_logs
     print(string)
   }
 


### PR DESCRIPTION
This PR improves error handling for the format plugin, and adds support for an `--exclude` flag.

I'm adopting the plugin in the Lottie and Epoxy repos, and noticed that it was outputting a `lintFailure` even in cases where SwiftLint / SwiftFormat were failing due to reasons unrelated to the lint configuration. Now we clarify between an expected failure (a `lintFailure`) and an unknown / unexpected failure that we cannot recover from.

Epoxy specifically doesn't lint its `Tests` subdirectory, so we needed a way to configure the directories that are formatted / linted by the plugin. I figured we can use an `--exclude` flag for this, to compliment the exclude configurations in `airbnb.swiftformat` / `swiftlint.yml`.