### PR TITLE
Bump SwiftLint version to fix strange failure in Epoxy repo

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/realm/SwiftLint",
       "state" : {
-        "branch" : "e497f1f",
-        "revision" : "e497f1f5b161af96ba439049d21970c6204d06c6"
+        "branch" : "c5aa806",
+        "revision" : "c5aa8065d1acf0400443b110a339e79e0df5667c"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -12,8 +12,10 @@ let package = Package(
     .package(url: "https://github.com/calda/SwiftFormat", exact: "0.49.11-beta-2"),
     // The `SwiftLintFramework` target uses "unsafe build flags" so Xcode doesn't
     // allow us to reference a specific version number. To work around that,
-    // we can reference the specific commit for that version (0.47.1).
-    .package(url: "https://github.com/realm/SwiftLint", revision: "e497f1f"),
+    // we can reference the specific commit for that version.
+    //  - This is top-of-tree master from 7/22/22, because the most recent release version
+    //    (0.47.1) seems to have issues in some real-world projects like airbnb/epoxy-ios.
+    .package(url: "https://github.com/realm/SwiftLint", revision: "c5aa806"),
     .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.3"),
   ],
   targets: [


### PR DESCRIPTION
I'm working on integrating the new format tool in the Epoxy repo (https://github.com/airbnb/epoxy-ios/pull/112) and am hitting a strange SwiftLint failure (`error: unknownError(exitCode: 10)`) that I can't reproduce locally.  I tested the most recent commit from SwiftLint's master branch and it didn't encounter that error, so it must have been fixed recently. 