### PR TITLE
Add files argument to only lint specific paths

### DIFF
--- a/Plugins/FormatSwift/Plugin.swift
+++ b/Plugins/FormatSwift/Plugin.swift
@@ -21,19 +21,17 @@ struct AirbnbSwiftFormatPlugin: CommandPlugin {
     let inputTargets = argumentExtractor.extractOption(named: "target")
 
     // Only lint the paths passed to `--paths`
-    let strictPaths = argumentExtractor.extractOption(named: "paths")
+    let paths = argumentExtractor.extractOption(named: "paths")
 
-    var inputPaths: [String]
+    var inputPaths: [String] = paths
     if !inputTargets.isEmpty {
       // If a set of input targets were given, lint/format the directory for each of them
-      inputPaths = try context.package.targets(named: inputTargets).map { $0.directory.string }
+      inputPaths += try context.package.targets(named: inputTargets).map { $0.directory.string }
     } else if strictPaths.isEmpty {
       // Otherwise if no targets or paths listed we default to linting/formatting
       // the entire package directory.
       inputPaths = try self.inputPaths(for: context.package)
     }
-
-    inputPaths += strictPaths
 
     // Filter out any excluded paths passed in with `--exclude`
     let excludedPaths = argumentExtractor.extractOption(named: "exclude")

--- a/Plugins/FormatSwift/Plugin.swift
+++ b/Plugins/FormatSwift/Plugin.swift
@@ -20,10 +20,9 @@ struct AirbnbSwiftFormatPlugin: CommandPlugin {
     // specifying the targets selected in the plugin dialog.
     let inputTargets = argumentExtractor.extractOption(named: "target")
 
-    // Only lint the paths passed to `--paths`
-    let paths = argumentExtractor.extractOption(named: "paths")
+    // If given, lint only the paths passed to `--paths`
+    var inputPaths = argumentExtractor.extractOption(named: "paths")
 
-    var inputPaths: [String] = paths
     if !inputTargets.isEmpty {
       // If a set of input targets were given, lint/format the directory for each of them
       inputPaths += try context.package.targets(named: inputTargets).map { $0.directory.string }

--- a/Plugins/FormatSwift/Plugin.swift
+++ b/Plugins/FormatSwift/Plugin.swift
@@ -28,7 +28,7 @@ struct AirbnbSwiftFormatPlugin: CommandPlugin {
       // If a set of input targets were given, lint/format the directory for each of them
       inputPaths = try context.package.targets(named: inputTargets).map { $0.directory.string }
     } else if inputFiles.isEmpty {
-      // Otherwise if no targets we listed we default to linting/formatting
+      // Otherwise if no targets or files listed we default to linting/formatting
       // the entire package directory.
       inputPaths = try self.inputPaths(for: context.package)
     }

--- a/Plugins/FormatSwift/Plugin.swift
+++ b/Plugins/FormatSwift/Plugin.swift
@@ -20,11 +20,14 @@ struct AirbnbSwiftFormatPlugin: CommandPlugin {
     // specifying the targets selected in the plugin dialog.
     let inputTargets = argumentExtractor.extractOption(named: "target")
 
-    var inputPaths: [String]
+    // Only lint the files passed to `--files`
+    let inputFiles = argumentExtractor.extractOption(named: "files")
+
+    var inputPaths: [String] = inputFiles
     if !inputTargets.isEmpty {
       // If a set of input targets were given, lint/format the directory for each of them
       inputPaths = try context.package.targets(named: inputTargets).map { $0.directory.string }
-    } else {
+    } else if inputFiles.isEmpty {
       // Otherwise if no targets we listed we default to linting/formatting
       // the entire package directory.
       inputPaths = try self.inputPaths(for: context.package)

--- a/Plugins/FormatSwift/Plugin.swift
+++ b/Plugins/FormatSwift/Plugin.swift
@@ -26,7 +26,7 @@ struct AirbnbSwiftFormatPlugin: CommandPlugin {
     if !inputTargets.isEmpty {
       // If a set of input targets were given, lint/format the directory for each of them
       inputPaths += try context.package.targets(named: inputTargets).map { $0.directory.string }
-    } else if strictPaths.isEmpty {
+    } else if inputPaths.isEmpty {
       // Otherwise if no targets or paths listed we default to linting/formatting
       // the entire package directory.
       inputPaths = try self.inputPaths(for: context.package)

--- a/Plugins/FormatSwift/Plugin.swift
+++ b/Plugins/FormatSwift/Plugin.swift
@@ -20,18 +20,20 @@ struct AirbnbSwiftFormatPlugin: CommandPlugin {
     // specifying the targets selected in the plugin dialog.
     let inputTargets = argumentExtractor.extractOption(named: "target")
 
-    // Only lint the files passed to `--files`
-    let inputFiles = argumentExtractor.extractOption(named: "files")
+    // Only lint the paths passed to `--paths`
+    let strictPaths = argumentExtractor.extractOption(named: "paths")
 
-    var inputPaths: [String] = inputFiles
+    var inputPaths: [String]
     if !inputTargets.isEmpty {
       // If a set of input targets were given, lint/format the directory for each of them
       inputPaths = try context.package.targets(named: inputTargets).map { $0.directory.string }
-    } else if inputFiles.isEmpty {
-      // Otherwise if no targets or files listed we default to linting/formatting
+    } else if strictPaths.isEmpty {
+      // Otherwise if no targets or paths listed we default to linting/formatting
       // the entire package directory.
       inputPaths = try self.inputPaths(for: context.package)
     }
+
+    inputPaths += strictPaths
 
     // Filter out any excluded paths passed in with `--exclude`
     let excludedPaths = argumentExtractor.extractOption(named: "exclude")


### PR DESCRIPTION
#### Summary

<!--- required --->

This adds a `--files` parameter to the Swift package plugin so that you can choose to _only_ format specific files that you wish rather than entire targets or packages.

#### Reasoning

<!--- required --->

In some situations it's useful to only format specific files. For example you might want to set up a pre-commit git hook to format _only_ staged swift files before committing them. 

_Please react with 👍/👎 if you agree or disagree with this proposal._
