### PR TITLE
Add Swift Package Index badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Note that brevity is not a primary goal. Code should be made more concise only i
 
 ## Swift Package Manager command plugin
 
+[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fairbnb%2Fswift%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/airbnb/swift) [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fairbnb%2Fswift%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/airbnb/swift)
+
 This repo includes a Swift Package Manager command plugin that you can use to automatically reformat or lint your package according to the style guide. To use this command plugin with your package, all you need to do is add this repo as a dependency:
 
 ```swift

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Airbnb Swift Style Guide
 
+[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fairbnb%2Fswift%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/airbnb/swift) [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fairbnb%2Fswift%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/airbnb/swift)
+
 ## Goals
 
 Following this style guide should:
@@ -22,8 +24,6 @@ Note that brevity is not a primary goal. Code should be made more concise only i
   * Exceptions to these rules should be rare and heavily justified.
 
 ## Swift Package Manager command plugin
-
-[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fairbnb%2Fswift%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/airbnb/swift) [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fairbnb%2Fswift%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/airbnb/swift)
 
 This repo includes a Swift Package Manager command plugin that you can use to automatically reformat or lint your package according to the style guide. To use this command plugin with your package, all you need to do is add this repo as a dependency:
 


### PR DESCRIPTION
This PR adds Swift Package Index badges that link to our package's [SPI listing](https://swiftpackageindex.com/airbnb/swift). 

I figured we could specifically add them to the section that discusses the package plugin. Alternatively we could put them at the very top of the page under the title.