### PR TITLE
Remove `AirbnbSwiftFormatTool` as product

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,6 @@ let package = Package(
   name: "AirbnbSwift",
   platforms: [.macOS(.v10_13)],
   products: [
-    .executable(name: "AirbnbSwiftFormatTool", targets: ["AirbnbSwiftFormatTool"]),
     .plugin(name: "FormatSwift", targets: ["FormatSwift"]),
   ],
   dependencies: [


### PR DESCRIPTION
#### Summary

We view the `AirbnbSwiftFormatTool` as an implementation detail of our SPM plugin. Accordingly we are removing this tool as a "public" product of our SPM package.

One reason we made this choice is that the `AirbnbSwiftFormatTool` has an associated bundle that contains the config files for SwiftLint and SwiftFormat.
<img width="845" alt="Screen_Shot_2022-07-27_at_9_23_13_AM" src="https://user-images.githubusercontent.com/1791049/181299192-6627efdd-4be2-4ea0-a623-f69681bfbaac.png">

My understanding is that the associated bundle make this tool less portable, since we're by default looking for files in that bundle.

https://github.com/airbnb/swift/blob/1d8bb91f317a5f48be9a26e77558cae7398da385/Sources/AirbnbSwiftFormatTool/AirbnbSwiftFormatTool.swift#L34-L38

#### Testing

I made edits to the source code of the plugin that violated the style guide. Then I ran `swift package format` in the root of the repo and noticed that those violations were corrected.

#### Revewiers

@calda @airbnb/swift-styleguide-maintainers 
