### PR TITLE
Use `swift-tools-version` from `Package.swift` as minimum Swift version by default

### DIFF
--- a/Plugins/FormatSwift/Plugin.swift
+++ b/Plugins/FormatSwift/Plugin.swift
@@ -84,10 +84,17 @@ extension AirbnbSwiftFormatPlugin: CommandPlugin {
       })
     }
 
+    // When running on a SPM package we infer the minimum Swift version from the
+    // `swift-tools-version` in `Package.swift`
+    let additionalArguments = [
+      "--swift-version",
+      "\(context.package.toolsVersion.major).\(context.package.toolsVersion.minor)",
+    ] + argumentExtractor.remainingArguments
+
     try performCommand(
       context: context,
       inputPaths: inputPaths,
-      additionalArguments: argumentExtractor.remainingArguments)
+      additionalArguments: additionalArguments)
   }
 
   // MARK: Private

--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ $ swift package format --exclude Tests
 # Alternatively you can explicitly list the set of paths and/or SPM targets:
 $ swift package format --paths Sources Tests Package.swift
 $ swift package format --targets AirbnbSwiftFormatTool
+
+# The plugin infers your package's minimum Swift version from the `swift-tools-version`
+# in your `Package.swift`, but you can provide a custom value with `--swift-version`:
+$ swift package format --swift-version 5.3
 ```
 
 </details>

--- a/Sources/AirbnbSwiftFormatTool/AirbnbSwiftFormatTool.swift
+++ b/Sources/AirbnbSwiftFormatTool/AirbnbSwiftFormatTool.swift
@@ -37,6 +37,9 @@ struct AirbnbSwiftFormatTool: ParsableCommand {
   @Option(help: "The absolute path to the SwiftLint config file")
   var swiftLintConfig = Bundle.module.path(forResource: "swiftlint", ofType: "yml")!
 
+  @Option(help: "The project's minimum Swift version")
+  var swiftVersion: String?
+
   mutating func run() throws {
     try swiftFormat.run()
     swiftFormat.waitUntilExit()
@@ -81,6 +84,10 @@ struct AirbnbSwiftFormatTool: ParsableCommand {
 
     if lint {
       arguments += ["--lint"]
+    }
+
+    if let swiftVersion = swiftVersion {
+      arguments += ["--swiftversion", swiftVersion]
     }
 
     let swiftFormat = Process()


### PR DESCRIPTION
This PR updates the package plugin to use the `swift-tools-version` specified in `Package.swift` as the minimum Swift version by default. This can also be customized manually by passing in a `--swift-version` option.

Previously the SwiftFormat `--swiftversion` was included in `airbnb.swiftformat` and was not overridable. We listed 5.6, but Lottie for example has a minimum supported Swift version of 5.3. To override the default `--swiftversion 5.6` option, I set up a `.swift-version` file at the repo root to specify `5.3`. This file is conflicting with Cocoapods (airbnb/lottie-ios#1672), so turned out to not be a good approach.