### PR TITLE
Improve handling of `--swift-format` and `--exclude` arguments

### DIFF
--- a/Plugins/FormatSwift/Plugin.swift
+++ b/Plugins/FormatSwift/Plugin.swift
@@ -46,7 +46,7 @@ struct AirbnbSwiftFormatPlugin {
 
     if arguments.contains("--log") {
       // swiftlint:disable:next no_direct_standard_out_logs
-      print(launchPath, arguments.joined(separator: " "))
+      print("[Plugin]", launchPath, arguments.joined(separator: " "))
     }
 
     let process = Process()

--- a/Sources/AirbnbSwiftFormatTool/AirbnbSwiftFormatTool.swift
+++ b/Sources/AirbnbSwiftFormatTool/AirbnbSwiftFormatTool.swift
@@ -121,7 +121,7 @@ struct AirbnbSwiftFormatTool: ParsableCommand {
 
   private func log(_ string: String) {
     // swiftlint:disable:next no_direct_standard_out_logs
-    print(string)
+    print("[AibnbSwiftFormatTool]", string)
   }
 
 }


### PR DESCRIPTION
This PR makes changes changes based on feedback from @bachand:
 - Updated plugin to not pass multiple `--swift-format` arguments to underlying tool (https://github.com/airbnb/swift/pull/180#discussion_r932780947)
 - Updated `XcodeCommandPlugin` to support `--exclude` arguments (https://github.com/airbnb/swift/pull/181#discussion_r932785998)
