### PR TITLE
Fix typo and broken type annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -854,7 +854,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
-* <a id='omit-explicit-init'></a>(<a href='#omit-explicit-init'>link</a>) **Omit explicit `.init` when not reqired.** [![SwiftFormat: redundantInit](https://img.shields.io/badge/SwiftFormat-redundantInit-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#redundantInit)
+* <a id='omit-explicit-init'></a>(<a href='#omit-explicit-init'>link</a>) **Omit explicit `.init` when not required.** [![SwiftFormat: redundantInit](https://img.shields.io/badge/SwiftFormat-redundantInit-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#redundantInit)
 
   <details>
 
@@ -1655,7 +1655,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   ```swift
   // WRONG
-  func age(of person, bornAt timeInterval) -> Int {
+  func age(of person: Person, bornAt: TimeInterval) -> Int {
     // ...
   }
 


### PR DESCRIPTION
#### Summary

- Fixes a typo and example method's type annotations.

#### Reasoning

- "reqired" is definitely a typo.
- broken type annotations can be confusing to read.

#### Reviewers
cc. @calda @airbnb/swift-styleguide-maintainers

_Please react with 👍/👎 if you agree or disagree with this proposal._