### PR TITLE
Update to SwiftFormat build based on 0.49.16

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -38,8 +38,8 @@ let package = Package(
 
     .binaryTarget(
       name: "SwiftFormat",
-      url: "https://github.com/calda/SwiftFormat/releases/download/0.50-beta-2/SwiftFormat.artifactbundle.zip",
-      checksum: "8b96c5237d47b398f3eda215713ee164bc28556ef849a73a32995dcc4f12d702"),
+      url: "https://github.com/calda/SwiftFormat/releases/download/0.50-beta-4/SwiftFormat.artifactbundle.zip",
+      checksum: "b7dfc4e623c1a6686d51904f74f7898194b950cd1db65f831bd3c0e0e6e70749"),
 
     .binaryTarget(
       name: "SwiftLintBinary",


### PR DESCRIPTION
This PR updates `Package.swift` to use a SwiftFormat build based on this week's 0.49.16 release: https://github.com/calda/SwiftFormat/releases/tag/0.50-beta-4