### PR TITLE
Add rule to prefer shorthand `if let` optional unwrapping syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,7 +413,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
     func request(completion: () -> Void) {
       API.request() { [weak self] response in
-        guard let self = self else { return }
+        guard let self else { return }
         // Do work
         completion()
       }
@@ -729,6 +729,38 @@ _You can enable the following settings in Xcode by running [this script](resourc
     & CivilizationServiceProviding
   ```
 
+* <a id='if-let-shorthand'></a>(<a href='#if-let-shorthand'>link</a>) Omit the right-hand side of the expression when unwrapping an optional property to a non-optional property with the same name. [![SwiftFormat: redundantOptionalBinding](https://img.shields.io/badge/SwiftFormat-redundantOptionalBinding-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#redundantOptionalBinding)
+
+  <details>
+
+  #### Why?
+
+  Following the rationale in [SE-0345](https://github.com/apple/swift-evolution/blob/main/proposals/0345-if-let-shorthand.md), this shorthand syntax removes unnecessary boilerplate while retaining clarity.
+
+  ```swift
+  // WRONG
+  if
+    let galaxy = galaxy,
+    galaxy.name == "Milky Way"
+  { … }
+
+  guard
+    let galaxy = galaxy,
+    galaxy.name == "Milky Way"
+  else { … }
+
+  // RIGHT
+  if
+    let galaxy,
+    galaxy.name == "Milky Way"
+  { … }
+
+  guard
+    let galaxy,
+    galaxy.name == "Milky Way"
+  else { … }
+  ```
+
 * <a id='multi-line-conditions'></a>(<a href='#multi-line-conditions'>link</a>) **Multi-line conditional statements should break after the leading keyword.** Indent each individual statement by [2 spaces](https://github.com/airbnb/swift#spaces-over-tabs). [![SwiftFormat: wrapArguments](https://img.shields.io/badge/SwiftFormat-wrapArguments-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapArguments)
 
   <details>
@@ -739,12 +771,12 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   ```swift
   // WRONG
-  if let galaxy = galaxy,
+  if let galaxy,
     galaxy.name == "Milky Way" // Indenting by two spaces fights Xcode's ^+I indentation behavior
   { … }
 
   // WRONG
-  guard let galaxy = galaxy,
+  guard let galaxy,
         galaxy.name == "Milky Way" // Variable width indentation (6 spaces)
   else { … }
 
@@ -757,13 +789,13 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   // RIGHT
   if
-    let galaxy = galaxy,
+    let galaxy,
     galaxy.name == "Milky Way"
   { … }
 
   // RIGHT
   guard
-    let galaxy = galaxy,
+    let galaxy,
     galaxy.name == "Milky Way"
   else { … }
 
@@ -776,12 +808,12 @@ _You can enable the following settings in Xcode by running [this script](resourc
   else { … }
 
   // RIGHT
-  if let galaxy = galaxy {
+  if let galaxy {
     …
   }
 
   // RIGHT
-  guard let galaxy = galaxy else {
+  guard let galaxy else {
     …
   }
   ```
@@ -1558,7 +1590,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
     func request(completion: () -> Void) {
       API.request() { [weak self] response in
-        if let self = self {
+        if let self {
           // Processing and side effects
         }
         completion()
@@ -1571,7 +1603,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
     func request(completion: () -> Void) {
       API.request() { [weak self] response in
-        guard let self = self else { return }
+        guard let self else { return }
         self.doSomething(with: self.property, response: response)
         completion()
       }

--- a/README.md
+++ b/README.md
@@ -729,7 +729,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
     & CivilizationServiceProviding
   ```
 
-* <a id='if-let-shorthand'></a>(<a href='#if-let-shorthand'>link</a>) Omit the right-hand side of the expression when unwrapping an optional property to a non-optional property with the same name. [![SwiftFormat: redundantOptionalBinding](https://img.shields.io/badge/SwiftFormat-redundantOptionalBinding-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#redundantOptionalBinding)
+* <a id='prefer-if-let-shorthand'></a>(<a href='#prefer-if-let-shorthand'>link</a>) Omit the right-hand side of the expression when unwrapping an optional property to a non-optional property with the same name. [![SwiftFormat: redundantOptionalBinding](https://img.shields.io/badge/SwiftFormat-redundantOptionalBinding-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#redundantOptionalBinding)
 
   <details>
 

--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -76,4 +76,3 @@
 --rules blankLinesAtEndOfScope
 --rules emptyBraces
 --rules andOperator
-\

--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -1,5 +1,5 @@
 # options
---swiftversion 5.6
+--swiftversion 5.7
 --self remove # redundantSelf
 --importgrouping testable-bottom # sortedImports
 --commas always # trailingCommas
@@ -61,6 +61,7 @@
 --rules redundantClosure
 --rules redundantInit
 --rules redundantVoidReturnType
+--rules redundantOptionalBinding
 --rules unusedArguments
 --rules spaceInsideBrackets
 --rules spaceInsideBraces
@@ -75,3 +76,4 @@
 --rules blankLinesAtEndOfScope
 --rules emptyBraces
 --rules andOperator
+\


### PR DESCRIPTION
#### Summary

This PR proposes a new rule to prefer the shorthand `if let` optional unwrapping syntax added in Swift 5.7:

> Omit the right-hand side of the expression when unwrapping an optional property to a non-optional property with the same name.

```swift
// WRONG
if
  let galaxy = galaxy,
  galaxy.name == "Milky Way"
{ … }

guard
  let galaxy = galaxy,
  galaxy.name == "Milky Way"
else { … }

// RIGHT
if
  let galaxy,
  galaxy.name == "Milky Way"
{ … }

guard
  let galaxy,
  galaxy.name == "Milky Way"
else { … }
```

#### Reasoning

We are adopting Swift 5.7 soon, so we should adopt guidance for its new language features.

As discussed in the Motivation section of [SE-0345](https://github.com/apple/swift-evolution/blob/main/proposals/0345-if-let-shorthand.md), the new shorthand optional unwrapping syntax removes unnecessary boilerplate while retaining clarity. Auto-formatting for this rule is implemented in https://github.com/nicklockwood/SwiftFormat/pull/1165.

_Please react with 👍/👎 if you agree or disagree with this proposal._
