### PR TITLE
Add rule to prefer opaque generic parameter syntax

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -38,8 +38,8 @@ let package = Package(
 
     .binaryTarget(
       name: "SwiftFormat",
-      url: "https://github.com/calda/SwiftFormat/releases/download/0.50-beta-4/SwiftFormat.artifactbundle.zip",
-      checksum: "b7dfc4e623c1a6686d51904f74f7898194b950cd1db65f831bd3c0e0e6e70749"),
+      url: "https://github.com/calda/SwiftFormat/releases/download/0.51-beta-2/SwiftFormat.artifactbundle.zip",
+      checksum: "77066735bb56a2f2f37d8bfbd7606612b206d99c15ec3250e712c6a842c823a2"),
 
     .binaryTarget(
       name: "SwiftLintBinary",

--- a/README.md
+++ b/README.md
@@ -2143,6 +2143,40 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
     </details>
 
+* <a id='opaque-generic-parameters'></a>(<a href='#opaque-generic-parameters'>link</a>) Prefer using opaque generic parameters (with `some`) over verbose named generic parameter syntax where possible. [![SwiftFormat: opaqueGenericParameters](https://img.shields.io/badge/SwiftFormat-opaqueGenericParameters-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#opaqueGenericParameters)
+
+    <details>
+
+    #### Why?
+
+    Opaque generic parameter syntax is significantly less verbose and thus more legible than the full named generic parameter syntax.
+
+    ```swift
+    // WRONG
+    func spaceshipDashboard<WarpDriveView: View, CaptainsLogView: View>(
+      warpDrive: WarpDriveView,
+      captainsLogView: CaptainsLogView)
+      -> some View
+    { … }
+
+    func generate<Planets>(_ planets: Planets) where Planets: Collection, Planets.Element == Planet {
+      …
+    }
+
+    // RIGHT
+    func spaceshipDashboard(
+      warpDrive: some View,
+      captainsLogView: some View)
+      -> some View
+    { … }
+
+    func generate(_ planets: some Collection<Planet>) {
+      …
+    }
+    ```
+
+    </details>
+
 **[⬆ back to top](#table-of-contents)**
 
 ## File Organization

--- a/README.md
+++ b/README.md
@@ -2143,7 +2143,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
     </details>
 
-* <a id='opaque-generic-parameters'></a>(<a href='#opaque-generic-parameters'>link</a>) **Prefer using opaque generic parameters (with `some`) over verbose named generic parameter syntax where possible.**  [![SwiftFormat: opaqueGenericParameters](https://img.shields.io/badge/SwiftFormat-opaqueGenericParameters-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#opaqueGenericParameters)
+* <a id='prefer-opaque-generic-parameters'></a>(<a href='#prefer-opaque-generic-parameters'>link</a>) **Prefer using opaque generic parameters (with `some`) over verbose named generic parameter syntax where possible.**  [![SwiftFormat: opaqueGenericParameters](https://img.shields.io/badge/SwiftFormat-opaqueGenericParameters-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#opaqueGenericParameters)
 
     <details>
 

--- a/README.md
+++ b/README.md
@@ -2173,6 +2173,17 @@ _You can enable the following settings in Xcode by running [this script](resourc
     func generate(_ planets: some Collection<Planet>) {
       …
     }
+    
+    // Also fine, since there isn't an equivalent opaque parameter syntax for expressing
+    // that two parameters in the type signature are of the same type:
+    func terraform<Body: PlanetaryBody>(_ planetaryBody: Body, into terraformedBody: Body) {
+      …
+    }
+    
+    // Also fine, since the generic patameter name is referenced in the function body so can't be removed:
+    func terraform<Body: PlanetaryBody>(_ planetaryBody: Body)  {
+      plataryBody.generateAtmosphere(Body.idealAtmosphere)
+    }
     ```
 
     #### `some Any`

--- a/README.md
+++ b/README.md
@@ -2155,7 +2155,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
     // WRONG
     func spaceshipDashboard<WarpDriveView: View, CaptainsLogView: View>(
       warpDrive: WarpDriveView,
-      captainsLogView: CaptainsLogView)
+      captainsLog: CaptainsLogView)
       -> some View
     { … }
 
@@ -2166,7 +2166,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
     // RIGHT
     func spaceshipDashboard(
       warpDrive: some View,
-      captainsLogView: some View)
+      captainsLog: some View)
       -> some View
     { … }
 

--- a/README.md
+++ b/README.md
@@ -2143,7 +2143,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
     </details>
 
-* <a id='opaque-generic-parameters'></a>(<a href='#opaque-generic-parameters'>link</a>) Prefer using opaque generic parameters (with `some`) over verbose named generic parameter syntax where possible. [![SwiftFormat: opaqueGenericParameters](https://img.shields.io/badge/SwiftFormat-opaqueGenericParameters-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#opaqueGenericParameters)
+* <a id='opaque-generic-parameters'></a>(<a href='#opaque-generic-parameters'>link</a>) **Prefer using opaque generic parameters (with `some`) over verbose named generic parameter syntax where possible.**  [![SwiftFormat: opaqueGenericParameters](https://img.shields.io/badge/SwiftFormat-opaqueGenericParameters-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#opaqueGenericParameters)
 
     <details>
 
@@ -2174,6 +2174,27 @@ _You can enable the following settings in Xcode by running [this script](resourc
       …
     }
     ```
+
+    #### `some Any`
+
+    Fully-unconstrained generic parameters are somewhat uncommon, but are equivalent to `some Any`. For example:
+
+    ```swift
+    func assertFailure<Value>(_ result: Result<Value, Error>) {
+      if case .failure(let error) = result {
+        XCTFail(error.localizedDescription)
+      }
+    }
+
+    // is equivalent to:
+    func assertFailure(_ result: Result<some Any, Error>) {
+      if case .failure(let error) = result {
+        XCTFail(error.localizedDescription)
+      }
+    }
+    ```
+
+    `some Any` is somewhat unintuitive, and the named generic parameter is useful in this situation to compensate for the weak type information. Because of this, prefer using named generic parameters instead of `some Any`.
 
     </details>
 

--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -1,5 +1,5 @@
 # options
---swiftversion 5.6
+--swiftversion 5.7
 --self remove # redundantSelf
 --importgrouping testable-bottom # sortedImports
 --commas always # trailingCommas
@@ -75,3 +75,4 @@
 --rules blankLinesAtEndOfScope
 --rules emptyBraces
 --rules andOperator
+--rules opaqueGenericParameters

--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -25,6 +25,7 @@
 --redundanttype inferred # redundantType
 --typeblanklines preserve # blankLinesAtStartOfScope, blankLinesAtEndOfScope
 --emptybraces spaced # emptyBraces
+--someAny disabled # opaqueGenericParameters
 
 # We recommend a max width of 100 but _strictly enforce_ a max width of 130
 --maxwidth 130 # wrap


### PR DESCRIPTION
#### Summary

This PR proposes a rule to prefer opaque generic parameter syntax (using `some`) over the more-verbose named generic parameter syntax where equivalent.

```swift
// WRONG
func spaceshipDashboard<WarpDriveView: View, CaptainsLogView: View>(
  warpDrive: WarpDriveView,
  captainsLog: CaptainsLogView)
  -> some View
{ … }

func generate<Planets>(_ planets: Planets) where Planets: Collection, Planets.Element == Planet {
  …
}

// RIGHT
func spaceshipDashboard(
  warpDrive: some View,
  captainsLog: some View)
  -> some View
{ … }

func generate(_ planets: some Collection<Planet>) {
  …
}
```

#### Reasoning

We are adopting Swift 5.7 soon, so we should adopt guidance for its new language features.

Opaque generic parameter syntax is significantly less verbose and thus more legible than the full named generic parameter syntax. Auto-formatting for this rule is implemented in https://github.com/nicklockwood/SwiftFormat/pull/1206.

#### `some Any`

Fully-unconstrained generic parameters are somewhat uncommon, but are equivalent to `some Any`. For example:

```swift
func assertFailure<Value>(_ result: Result<Value, Error>) {
  if case .failure(let error) = result {
    XCTFail(error.localizedDescription)
  }
}

// is equivalent to:
func assertFailure(_ result: Result<some Any, Error>) {
  if case .failure(let error) = result {
    XCTFail(error.localizedDescription)
  }
}
```

`some Any` is somewhat unintuitive, and the named generic parameter is useful in this situation to compensate for the weak type information. Because of this, prefer using named generic parameters instead of `some Any`. 

With `--someAny disabled` (https://github.com/nicklockwood/SwiftFormat/pull/1261), the SwiftFormat rule never automatically converts generic functions to use `some Any`. This isn't outright banned, however, since we don't have an auto-formatting implementation that converts `some Any` _to_ named generic parameter syntax.

_Please react with 👍/👎 if you agree or disagree with this proposal._
