### PR TITLE
Add rule to prefer simplified generic extension syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -1528,7 +1528,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
-* <a id='generic-extensions'></a>(<a href='#generic-extensions'>link</a>) When extending generic types, prefer using generic bracket syntax (or sugared syntax for applicable standard library types) instead of generic type constraints. [![SwiftFormat: genericExtensions](https://img.shields.io/badge/SwiftFormat-genericExtensions-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#genericExtensions)
+* <a id='prefer-bound-generic-extension-shorthand'></a>(<a href='#prefer-bound-generic-extension-shorthand'>link</a>) When extending bound generic types, prefer using generic bracket syntax (`extension Collection<Planet>`), or sugared syntax for applicable standard library types (`extension [Planet]`) instead of generic type constraints. [![SwiftFormat: genericExtensions](https://img.shields.io/badge/SwiftFormat-genericExtensions-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#genericExtensions)
 
   <details>
 
@@ -1546,6 +1546,11 @@ _You can enable the following settings in Xcode by running [this script](resourc
   extension [Moon: Planet] { … }
   extension Collection<Universe> { … }
   extension StateStore<SpaceshipState, SpaceshipAction> { … }
+
+  // ALSO RIGHT -- there are multiple types that could satifsy this constraint
+  // (e.g. [Planet], [Moon]), so this is not a "bound generic type" and isn't
+  // eligible for the generic bracket syntax.
+  extension Array where Element: PlanetaryBody { }
   ```
 
   </details>

--- a/README.md
+++ b/README.md
@@ -1476,6 +1476,28 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
+* <a id='generic-extensions'></a>(<a href='#generic-extensions'>link</a>) When extending generic types, prefer using generic bracket syntax (or sugared syntax for applicable standard library types) instead of generic type constraints. [![SwiftFormat: genericExtensions](https://img.shields.io/badge/SwiftFormat-genericExtensions-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#genericExtensions)
+
+  <details>
+
+  ```swift
+  // WRONG
+  extension Array where Element == Star { … }
+  extension Optional where Wrapped == Spaceship { … }
+  extension Dictionary where Key == Moon, Element == Planet { … }
+  extension Collection where Element == Universe { … }
+  extension StateStore where State == SpaceshipState, Action == Spaceship { … }
+
+  // RIGHT
+  extension [Star] { … }
+  extension Spaceship? { … }
+  extension [Moon: Planet] { … }
+  extension Collection<Universe> { … }
+  extension StateStore<SpaceshipState, SpaceshipAction> { … }
+  ```
+
+  </details>
+
 **[⬆ back to top](#table-of-contents)**
 
 ## Patterns

--- a/README.md
+++ b/README.md
@@ -1538,7 +1538,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
   extension Optional where Wrapped == Spaceship { … }
   extension Dictionary where Key == Moon, Element == Planet { … }
   extension Collection where Element == Universe { … }
-  extension StateStore where State == SpaceshipState, Action == Spaceship { … }
+  extension StateStore where State == SpaceshipState, Action == SpaceshipAction { … }
 
   // RIGHT
   extension [Star] { … }

--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -75,3 +75,4 @@
 --rules blankLinesAtEndOfScope
 --rules emptyBraces
 --rules andOperator
+--rules genericExtensions


### PR DESCRIPTION
#### Summary

This PR proposes a new rule to prefer simplified generic extension syntax, using bracket syntax or sugared type syntax for applicable standard library types, instead of generic type constraints.

```swift
// WRONG
extension Array where Element == Star { … }
extension Optional where Wrapped == Spaceship { … }
extension Dictionary where Key == Moon, Element == Planet { … }
extension Collection where Element == Universe { … }
extension StateStore where State == SpaceshipState, Action == Spaceship { … }

// RIGHT
extension [Star] { … }
extension Spaceship? { … }
extension [Moon: Planet] { … }
extension Collection<Universe> { … }
extension StateStore<SpaceshipState, SpaceshipAction> { … }
```

#### Reasoning

We are adopting Swift 5.7 soon, so we should adopt guidance for its new language features.

This simplified generic extension syntax is less verbose and easier to understand. Auto-formatting for this rule is implemented in https://github.com/nicklockwood/SwiftFormat/pull/1223.

_Please react with 👍/👎 if you agree or disagree with this proposal._
