### PR TITLE
Add rule to use doc comments before declarations, and regular comments elsewhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -1041,6 +1041,50 @@ _You can enable the following settings in Xcode by running [this script](resourc
   }
   ```
 
+* <a id='doc-comments'></a>(<a href='#doc-comments'>link</a>) Use doc comments (`///`) before declarations, and regular comments (`//`) elsewhere. [![SwiftFormat: docComments](https://img.shields.io/badge/SwiftFormat-docComments-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#docComments)
+
+  <details>
+
+  ```swift
+  // WRONG
+
+  // A planet that exists somewhere in the universe.
+  class Planet {
+    // Properties of a planet that are important for life
+    let atmosphere: Atmosphere
+    let oceans: [Ocean]
+
+    // Terraforms the planet, by adding an atmosphere and ocean that is hospitable for life.
+    func terraform() {
+      /// This gas concentration has a pretty good track record so far
+      let configuration = AtmosphereConfiguration(nitrogen: 0.78, oxygen: 0.22)
+      
+      /// Generate the atmosphere first, then the oceans
+      generateAtmosphere(using: configuration)
+      generateOceans()
+    }
+  }
+
+  // RIGHT
+
+  /// A planet that exists somewhere in the universe.
+  class Planet {
+    /// Properties of a planet that are important for life
+    let atmosphere: Atmosphere
+    let oceans: [Ocean]
+
+    /// Terraforms the planet, by adding an atmosphere and ocean that is hospitable for life.
+    func terraform() {
+      // This gas concentration has a pretty good track record so far
+      let configuration = AtmosphereConfiguration(nitrogen: 0.78, oxygen: 0.22)
+      
+      // Generate the atmosphere first, then the oceans
+      generateAtmosphere(using: configuration)
+      generateOceans()
+    }
+  }
+  ```
+
   </details>
 
 * <a id='whitespace-around-comment-delimiters'></a>(<a href='#whitespace-around-comment-delimiters'>link</a>) Include spaces or newlines before and after comment delimiters (`//`, `///`, `/*`, and `*/`) [![SwiftFormat: spaceAroundComments](https://img.shields.io/badge/SwiftFormat-spaceAroundComments-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#spaceAroundComments) [![SwiftFormat: spaceInsideComments](https://img.shields.io/badge/SwiftFormat-spaceInsideComments-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#spaceInsideComments)

--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -69,6 +69,7 @@
 --rules spaceAroundParens
 --rules enumNamespaces
 --rules blockComments
+--rules docComments
 --rules spaceAroundComments
 --rules spaceInsideComments
 --rules blankLinesAtStartOfScope


### PR DESCRIPTION
#### Summary

This PR proposes a new rule to use doc comments (`///`) before declarations, and regular comments (`//`) elsewhere. 

This rule has autocomplete implemented by the new SwiftFormat `docComments` rule added in https://github.com/nicklockwood/SwiftFormat/pull/1266.

```swift
// WRONG

// A planet that exists somewhere in the universe.
class Planet {
  // Properties of a planet that are important for life
  let atmosphere: Atmosphere
  let oceans: [Ocean]

  // Terraforms the planet, by adding an atmosphere and ocean that is hospitable for life.
  func terraform() {
    /// This gas concentration has a pretty good track record so far
    let configuration = AtmosphereConfiguration(nitrogen: 0.78, oxygen: 0.22)
    
    /// Generate the atmosphere first, then the oceans
    generateAtmosphere(using: configuration)
    generateOceans()
  }
}

// RIGHT

/// A planet that exists somewhere in the universe.
class Planet {
  /// Properties of a planet that are important for life
  let atmosphere: Atmosphere
  let oceans: [Ocean]

  /// Terraforms the planet, by adding an atmosphere and ocean that is hospitable for life.
  func terraform() {
    // This gas concentration has a pretty good track record so far
    let configuration = AtmosphereConfiguration(nitrogen: 0.78, oxygen: 0.22)
    
    // Generate the atmosphere first, then the oceans
    generateAtmosphere(using: configuration)
    generateOceans()
  }
}
```

#### Reasoning

Doc comments show up in the Xcode summary of a declaration, so we should prefer using doc comments for declarations. 

When not associated with a declaration, doc comments have no special meaning, so we should prefer regular comments elsewhere.

_Please react with 👍/👎 if you agree or disagree with this proposal._
