### PR TITLE
Update `prefer-opaque-generic-parameters` XCTest example to pass through `file` and `line` 

### DIFF
--- a/README.md
+++ b/README.md
@@ -2269,16 +2269,24 @@ _You can enable the following settings in Xcode by running [this script](resourc
     Fully-unconstrained generic parameters are somewhat uncommon, but are equivalent to `some Any`. For example:
 
     ```swift
-    func assertFailure<Value>(_ result: Result<Value, Error>) {
+    func assertFailure<Value>(
+      _ result: Result<Value, Error>,
+      file: StaticString = #filePath,
+      line: UInt = #line)
+    {
       if case .failure(let error) = result {
-        XCTFail(error.localizedDescription)
+        XCTFail(error.localizedDescription, file: file, line: line)
       }
     }
 
     // is equivalent to:
-    func assertFailure(_ result: Result<some Any, Error>) {
+    func assertFailure(
+      _ result: Result<some Any, Error>,
+      file: StaticString = #filePath,
+      line: UInt = #line)
+    {
       if case .failure(let error) = result {
-        XCTFail(error.localizedDescription)
+        XCTFail(error.localizedDescription, file: file, line: line)
       }
     }
     ```


### PR DESCRIPTION
#### Summary

It is a best practice when writing assertion helpers to pass through the file and line from the caller's context. This ensures that errors surfaced by XCTest are most helpful. Here I update the code example in our style guide to follow that practice.

#### Reasoning

We strive to have our code examples follow known best practices.

@airbnb/swift-styleguide-maintainers 