### PR TITLE
Update rule for long function declarations to specify effects (`async`, `throws`) should be written on the line after the closing paren

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -38,8 +38,8 @@ let package = Package(
 
     .binaryTarget(
       name: "SwiftFormat",
-      url: "https://github.com/calda/SwiftFormat/releases/download/0.51-beta-3/SwiftFormat.artifactbundle.zip",
-      checksum: "4b0516d911258b55c3960949f4a516a246f35a1dc7647a6440c66e1f1fe1a32e"),
+      url: "https://github.com/calda/SwiftFormat/releases/download/0.51-beta-6/SwiftFormat.artifactbundle.zip",
+      checksum: "8583456d892c99f970787b4ed756a7e0c83a0d9645e923bb4dae10d581c59bc3"),
 
     .binaryTarget(
       name: "SwiftLintBinary",

--- a/README.md
+++ b/README.md
@@ -1152,7 +1152,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
-* <a id='long-function-declaration'></a>(<a href='#long-function-declaration'>link</a>) **Separate [long](https://github.com/airbnb/swift#column-width) function declarations with line breaks before each argument label and before the return signature.** Put the open curly brace on the next line so the first executable line doesn't look like it's another parameter. [![SwiftFormat: wrapArguments](https://img.shields.io/badge/SwiftFormat-wrapArguments-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapArguments) [![SwiftFormat: braces](https://img.shields.io/badge/SwiftFormat-braces-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#braces)
+* <a id='long-function-declaration'></a>(<a href='#long-function-declaration'>link</a>) **Separate [long](https://github.com/airbnb/swift#column-width) function declarations with line breaks before each argument label, and before the return signature or any effects (`async`, `throws`).** Put the open curly brace on the next line so the first executable line doesn't look like it's another parameter. [![SwiftFormat: wrapArguments](https://img.shields.io/badge/SwiftFormat-wrapArguments-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapArguments) [![SwiftFormat: braces](https://img.shields.io/badge/SwiftFormat-braces-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#braces)
 
   <details>
 
@@ -1192,6 +1192,17 @@ _You can enable the following settings in Xcode by running [this script](resourc
       populateUniverse() // this line blends in with the argument list
     }
 
+    // WRONG
+    func generateStars(
+      at location: Point,
+      count: Int,
+      color: StarColor,
+      withAverageDistance averageDistance: Float) async throws // these effects are easy to miss since they're visually associated with the last parameter
+      -> String 
+    {
+      populateUniverse()
+    }
+
     // RIGHT
     func generateStars(
       at location: Point,
@@ -1209,7 +1220,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
       count: Int,
       color: StarColor,
       withAverageDistance averageDistance: Float)
-      throws -> String
+      async throws -> String
     {
       populateUniverse()
     }

--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -12,7 +12,7 @@
 --wrapcollections before-first # wrapArguments
 --wrapconditions before-first # wrapArguments
 --wrapreturntype if-multiline #wrapArguments
---wrapeffects if-mutliline #wrapArguments
+--wrapeffects if-multiline #wrapArguments
 --closingparen same-line # wrapArguments
 --wraptypealiases before-first # wrapArguments
 --funcattributes prev-line # wrapAttributes

--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -12,6 +12,7 @@
 --wrapcollections before-first # wrapArguments
 --wrapconditions before-first # wrapArguments
 --wrapreturntype if-multiline #wrapArguments
+--effectsposition wrap #wrapArguments
 --closingparen same-line # wrapArguments
 --wraptypealiases before-first # wrapArguments
 --funcattributes prev-line # wrapAttributes

--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -12,7 +12,7 @@
 --wrapcollections before-first # wrapArguments
 --wrapconditions before-first # wrapArguments
 --wrapreturntype if-multiline #wrapArguments
---effectsposition wrap #wrapArguments
+--wrapeffects if-mutliline #wrapArguments
 --closingparen same-line # wrapArguments
 --wraptypealiases before-first # wrapArguments
 --funcattributes prev-line # wrapAttributes


### PR DESCRIPTION
#### Summary

This PR proposes an update to the rule for long function declarations, to specify that effects (`async`, `throws`) should be written on the line after the closing paren:

```swift
// WRONG
func generateStars(
  at location: Point,
  count: Int,
  color: StarColor,
  withAverageDistance averageDistance: Float) async throws // these effects are easy to miss since they're visually associated with the last parameter
  -> String 
{
  populateUniverse()
}

// RIGHT
func generateStars(
  at location: Point,
  count: Int,
  color: StarColor,
  withAverageDistance averageDistance: Float) 
  async throws -> String 
{
  populateUniverse()
}
```

This can be auto-formatted using the SwiftFormat `--effectsposition wrap` option, added in https://github.com/nicklockwood/SwiftFormat/pull/1301.

#### Reasoning

 1. Writing effects on the same line as the closing param makes them easier to miss, since they're visually associated with the last parameter
 2. Effects are more closely related to the return type than to the function parameters (e.g. `throws -> Universe` is effectively syntactic sugar for `-> Result<Universe, Error>`).

_Please react with 👍/👎 if you agree or disagree with this proposal._
