### PR TITLE
Update `Package.swift` to explicitly not support Linux

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -46,3 +46,9 @@ let package = Package(
       url: "https://github.com/realm/SwiftLint/releases/download/0.48.0/SwiftLintBinary-macos.artifactbundle.zip",
       checksum: "9c255e797260054296f9e4e4cd7e1339a15093d75f7c4227b9568d63edddba50"),
   ])
+
+// Emit an error on Linux, so Swift Package Manager's platform support detection doesn't say this package supports Linux
+// https://github.com/airbnb/swift/discussions/197#discussioncomment-4055303
+#if os(Linux)
+#error("Linux is currently not supported")
+#endif


### PR DESCRIPTION
Our Swift Package Index badge in the README currently says this package supports Linux:

<img width="476" alt="image" src="https://user-images.githubusercontent.com/1811727/199988688-efde4092-26bd-49bc-975e-5b05806157f3.png">

The package builds correctly on Linux, which is what SPI currently uses to detect platform compatibility. The plugin fails at runtime on Linux, though, because we have binary dependencies that only support macOS: https://github.com/airbnb/swift/discussions/197

The maintainer of Swift Package Index suggested this workaround (https://github.com/airbnb/swift/discussions/197#discussioncomment-4055303).