### PR TITLE
Fix broken SE-0156 link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2114,7 +2114,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   #### Why?
 
-  [SE-0156](https://github.com/apple/swift-evolution/blob/master/proposals/0156-subclass-existentials.md]), which introduced support for using the `AnyObject` keyword as a protocol constraint, recommends preferring `AnyObject` over `class`:
+  [SE-0156](https://github.com/apple/swift-evolution/blob/master/proposals/0156-subclass-existentials.md), which introduced support for using the `AnyObject` keyword as a protocol constraint, recommends preferring `AnyObject` over `class`:
 
   > This proposal merges the concepts of `class` and `AnyObject`, which now have the same meaning: they represent an existential for classes. To get rid of the duplication, we suggest only keeping `AnyObject` around. To reduce source-breakage to a minimum, `class` could be redefined as `typealias class = AnyObject` and give a deprecation warning on class for the first version of Swift this proposal is implemented in. Later, `class` could be removed in a subsequent version of Swift.
 


### PR DESCRIPTION
#### Summary

* Fixed the broken SE-0156 link which is due to a Markdown format typo.

#### Reasoning

* For doc readability.

_Please react with 👍/👎 if you agree or disagree with this proposal._
