### PR TITLE
Include a missing space after some comment delimiters

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
   <details>
 
   ```swift
-  //WRONG
+  // WRONG
   class MyClass {
 
     func request(completion: () -> Void) {
@@ -1642,7 +1642,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
   <details>
 
   ```swift
-  //WRONG
+  // WRONG
   class MyClass {
 
     func request(completion: () -> Void) {
@@ -2330,7 +2330,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   import Foundation
 
-  //RIGHT
+  // RIGHT
 
   //  Copyright © 2018 Airbnb. All rights reserved.
   //
@@ -2359,7 +2359,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
   import Nimble
   import Quick
 
-  //RIGHT
+  // RIGHT
 
   //  Copyright © 2018 Airbnb. All rights reserved.
   //


### PR DESCRIPTION
#### Summary

- Included a missing space after some comment delimiters. 😃 

#### Reasoning

- By the rule: [Include spaces or newlines before and after comment delimiters](https://github.com/airbnb/swift#whitespace-around-comment-delimiters)

#### Reviewers
cc. @calda

_Please react with 👍/👎 if you agree or disagree with this proposal._