### PR TITLE
Clarify Rule: Never use the default case when switching over an enum

### DIFF
--- a/README.md
+++ b/README.md
@@ -2027,19 +2027,19 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   ```swift
   // WRONG
-  switch anEnum {
-  case .a:
-    // Do something
+  switch trafficLight {
+  case .greenLight:
+    // Move your vehicle
   default:
-    // Do something else.
+    // Stop your vehicle
   }
 
   // RIGHT
   switch anEnum {
-  case .a:
-    // Do something
-  case .b, .c:
-    // Do something else.
+  case .greenLight:
+    // Move your vehicle
+  case .yellowLight, .redLight:
+    // Stop your vehicle
   }
   ```
 

--- a/README.md
+++ b/README.md
@@ -2035,7 +2035,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
   }
 
   // RIGHT
-  switch anEnum {
+  switch trafficLight {
   case .greenLight:
     // Move your vehicle
   case .yellowLight, .redLight:


### PR DESCRIPTION
#### Summary
This PR proposes clarifying the rule of "Never use the default case when switching over an enum" to be more specific.

#### Reasoning
I clarified rule with "real world" example and to follow clear and understandable examples that the guide is providing. (such as universe, weather and etc.)

Please review. Thanks! 😄

Reviewers
cc. @calda

_Please react with 👍/👎 if you agree or disagree with this proposal._
