### PR TITLE
Clarify Rule: Use Swift's automatic enum values unless they map to an external source.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1854,6 +1854,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   // RIGHT
   // Relying on Swift's automatic enum values
+  // swiftformat:disable redundantRawValues
   enum Planet: Int {
     case mercury
     case venus
@@ -1864,6 +1865,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
     case uranus
     case neptune
   }
+  // swiftformat:enable redundantRawValues
 
   // RIGHT
   /// These values come from the server, so we set them here explicitly to match those values.

--- a/README.md
+++ b/README.md
@@ -1809,12 +1809,14 @@ _You can enable the following settings in Xcode by running [this script](resourc
     case warning = "warning"
   }
 
+  // WRONG
   enum UserType: String {
     case owner
     case manager
     case member
   }
 
+  // WRONG
   enum Planet: Int {
     case mercury = 0
     case venus = 1
@@ -1826,6 +1828,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
     case neptune = 7
   }
 
+  // WRONG
   enum ErrorCode: Int {
     case notEnoughMemory
     case invalidResource
@@ -1833,20 +1836,22 @@ _You can enable the following settings in Xcode by running [this script](resourc
   }
 
   // RIGHT
+  // Relying on Swift's automatic enum values
   enum ErrorType: String {
     case error
     case warning
   }
 
+  // RIGHT
   /// These are written to a logging service. Explicit values ensure they're consistent across binaries.
-  // swiftformat:disable redundantRawValues
   enum UserType: String {
     case owner = "owner"
     case manager = "manager"
     case member = "member"
   }
-  // swiftformat:enable redundantRawValues
 
+  // RIGHT
+  // Relying on Swift's automatic enum values
   enum Planet: Int {
     case mercury
     case venus
@@ -1858,6 +1863,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
     case neptune
   }
 
+  // RIGHT
   /// These values come from the server, so we set them here explicitly to match those values.
   enum ErrorCode: Int {
     case notEnoughMemory = 0

--- a/README.md
+++ b/README.md
@@ -1843,6 +1843,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
   }
 
   // RIGHT
+  // swiftformat:disable redundantRawValues
   /// These are written to a logging service. Explicit values ensure they're consistent across binaries.
   enum UserType: String {
     case owner = "owner"
@@ -1851,6 +1852,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
   }
 
   // RIGHT
+  // swiftformat:enable redundantRawValues
   // Relying on Swift's automatic enum values
   enum Planet: Int {
     case mercury

--- a/README.md
+++ b/README.md
@@ -1843,16 +1843,16 @@ _You can enable the following settings in Xcode by running [this script](resourc
   }
 
   // RIGHT
-  // swiftformat:disable redundantRawValues
   /// These are written to a logging service. Explicit values ensure they're consistent across binaries.
+  // swiftformat:disable redundantRawValues
   enum UserType: String {
     case owner = "owner"
     case manager = "manager"
     case member = "member"
   }
+  // swiftformat:enable redundantRawValues
 
   // RIGHT
-  // swiftformat:enable redundantRawValues
   // Relying on Swift's automatic enum values
   enum Planet: Int {
     case mercury


### PR DESCRIPTION
#### Summary

This PR proposes to clarify comment of the "Use Swift's automatic enum values unless they map to an external source." 

#### Reasoning

1) I indicated whether the examples are wrong or right like other rules in the guide to increase readability.
2) The origin comment was not being specific as it only said "swiftformat:enable redundantRawValues" and "swiftformat:disable redundantRawValues". The heading of rule provides link to swiftformat, so I thought it was better to directly indicate that the examples are right for relying on Swift's automatic enum values.

_Please react with 👍/👎 if you agree or disagree with this proposal._
