### PR TITLE
Clarify Rule: Use Swift's automatic enum values unless they map to an external source.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1804,10 +1804,12 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   ```swift
   // WRONG
+  // swiftformat:disable redundantRawValues
   enum ErrorType: String {
     case error = "error"
     case warning = "warning"
   }
+  // swiftformat:enable redundantRawValues
 
   // WRONG
   enum UserType: String {
@@ -1854,7 +1856,6 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   // RIGHT
   // Relying on Swift's automatic enum values
-  // swiftformat:disable redundantRawValues
   enum Planet: Int {
     case mercury
     case venus
@@ -1865,7 +1866,6 @@ _You can enable the following settings in Xcode by running [this script](resourc
     case uranus
     case neptune
   }
-  // swiftformat:enable redundantRawValues
 
   // RIGHT
   /// These values come from the server, so we set them here explicitly to match those values.


### PR DESCRIPTION
#### Summary

This PR fixes placement of `swiftformat:disable redundantRawValues` and `swiftformat:enable redundantRawValues`.

#### Reasoning

[As discussed here](https://github.com/airbnb/swift/pull/215#discussion_r1143742872), enum `ErrorType: String'  in WRONG is the one that needs to be implemented with `swiftformat:disable redundantRawValues` and `swiftformat:enable redundantRawValues` as it needs to be excepted from swiftformat rules.
And `enum Planet: Int` needs to be reverted as before, because it is straightly following Swift's automatic enum values, and it does not contain any redundant raw values.

_Please react with 👍/👎 if you agree or disagree with this proposal._
