### PR TITLE
Clarify Rule: Multi-line arrays should have each bracket on a separate line.

### DIFF
--- a/README.md
+++ b/README.md
@@ -664,7 +664,6 @@ _You can enable the following settings in Xcode by running [this script](resourc
   }
 
   // RIGHT
-
   @objc
   class Spaceship {
 
@@ -685,7 +684,8 @@ _You can enable the following settings in Xcode by running [this script](resourc
   let rowContent = [listingUrgencyDatesRowContent(),
                     listingUrgencyBookedRowContent(),
                     listingUrgencyBookedShortRowContent()]
-
+  
+  // WRONG
   let rowContent = [
     listingUrgencyDatesRowContent(),
     listingUrgencyBookedRowContent(),


### PR DESCRIPTION
#### Summary

This PR proposes to indicate `// WRONG` mark to the rule example.

#### Reasoning

As one of the rule example is not stating whether the example is right or wrong, it is confusing to understand the rule. Thus, I indicated that the example is wrong by following [Rule: Add a trailing comma on the last element of a multi-line array.](https://github.com/airbnb/swift#trailing-comma-array) to clarify the rule. 

_Please react with 👍/👎 if you agree or disagree with this proposal._
