### PR TITLE
Clarify Rule: Use caseless enums for organizing public or internal constants and functions into namespaces.

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,7 +401,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
     func request(completion: () -> Void) {
       API.request() { [weak self] response in
         guard let strongSelf = self else { return }
-
+        // Do work
         completion()
       }
     }
@@ -1779,6 +1779,24 @@ _You can enable the following settings in Xcode by running [this script](resourc
   Caseless `enum`s work well as namespaces because they cannot be instantiated, which matches their intent.
 
   ```swift
+  // WRONG
+  struct Environment { 
+    static let earthGravity = 9.8 
+    static let moonGravity = 1.6 
+  }
+  
+  // WRONG
+  struct Environment {
+  
+    struct Earth {
+      static let gravity = 9.8
+    }
+  
+    struct Moon {
+      static let gravity = 1.6
+    }
+  }
+  
   // RIGHT
   enum Environment {
 

--- a/README.md
+++ b/README.md
@@ -401,7 +401,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
     func request(completion: () -> Void) {
       API.request() { [weak self] response in
         guard let strongSelf = self else { return }
-        // Do work
+
         completion()
       }
     }
@@ -1779,6 +1779,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
   Caseless `enum`s work well as namespaces because they cannot be instantiated, which matches their intent.
 
   ```swift
+  // RIGHT
   enum Environment {
 
     enum Earth {


### PR DESCRIPTION
#### Summary

I adjusted two rules's wording, ``Use caseless `enum`s for organizing `public` or `internal` constants and functions into namespaces`` and ``Bind to `self` when upgrading from a weak reference``, to reduce confusion. 

#### Reasoning

``Bind to `self` when upgrading from a weak reference``'s example of wrongdoing contains `do work` key word which confuses if the example is right or wrong. ``Use caseless `enum`s for organizing `public` or `internal` constants and functions into namespaces`` was not stating if the case was wrong or right, so I thought adding `RIGHT` keyword increase readability of the example.

_Please react with 👍/👎 if you agree or disagree with this proposal._
