### PR TITLE
Update: ignore Rule OpenSource Library

### DIFF
--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -1,5 +1,5 @@
 # Exclude checkout directories for common package managers
---exclude Carthage,Pods
+--exclude Carthage,Pods,.build
 
 # options
 --swiftversion 5.7

--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -1,3 +1,6 @@
+# Exclude checkout directories for common package managers
+--exclude Carthage,Pods
+
 # options
 --swiftversion 5.7
 --self remove # redundantSelf

--- a/Sources/AirbnbSwiftFormatTool/swiftlint.yml
+++ b/Sources/AirbnbSwiftFormatTool/swiftlint.yml
@@ -17,6 +17,7 @@ only_rules:
 excluded:
   - Carthage
   - Pods
+  - .build
 
 colon:
   apply_to_dictionaries: false


### PR DESCRIPTION
#### Summary

I have added code to two source files excluding external libraries such as Carthage, Pods, and SourcePackages (SPM).

#### Reasoning

I added code to enforce the Airbnb style rules only on the code we wrote, as I believe it is the intended behavior to apply the rules only to our own code when using the command "swiftFormat .", which also modifies external libraries.

_Please react with 👍/👎 if you agree or disagree with this proposal._
