### PR TITLE
Test multiple Xcode versions in CI

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,12 @@
+name: Setup
+description: Setup the airbnb/swift CI Environment
+inputs:
+  xcode:
+    description: The version of Xcode to select
+runs:
+  using: composite
+  steps:
+  - name: Select Xcode ${{ inputs.xcode }}
+    run: sudo xcode-select --switch /Applications/Xcode_${{ inputs.xcode }}.app
+    if: ${{ inputs.xcode }}
+    shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,9 +7,28 @@ on:
     branches: [ master ]
 
 jobs:
-  test-package-plugin:
+  test-package-plugin-macos-12:
     name: Test Package Plugin
     runs-on: macos-12
+    strategy:
+      fail-fast: false
+      matrix:
+        xcode:
+        - '13.4.1' # Swift 5.6
+    steps:
+      - uses: actions/checkout@v2
+      - name: Test Package Plugin
+        run: swift package --allow-writing-to-package-directory format --lint
+
+  test-package-plugin-macos-13:
+    name: Test Package Plugin
+    runs-on: macos-13
+    strategy:
+      fail-fast: false
+      matrix:
+        xcode:
+        - '14.2' # Swift 5.7
+        - '14.3' # Swift 5.8
     steps:
       - uses: actions/checkout@v2
       - name: Test Package Plugin


### PR DESCRIPTION
This PR updates CI to test multiple Xcode versions.

Currently we use the Xcode 12 runner, which defaults to Xcode 14.2 / Swift 5.7.

This PR additionally adds tests for Xcode 13.4.1 (Swift 5.6) and Xcode 14.3 (Swift 5.8).

<img width="494" alt="image" src="https://user-images.githubusercontent.com/1811727/236535848-e7c89623-6778-41e2-b024-1421a311664d.png">
