### PR TITLE
Update SwiftFormat --swiftversion to 5.8

### DIFF
--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -2,7 +2,7 @@
 --exclude Carthage,Pods,.build
 
 # options
---swiftversion 5.7
+--swiftversion 5.8
 --self remove # redundantSelf
 --importgrouping testable-bottom # sortedImports
 --commas always # trailingCommas


### PR DESCRIPTION
This PR updates the `--swiftversion` in `airbnb.swiftformat` to Swift 5.8.

The Swift Package Plugin itself doesn't use this (it uses the Swift version specified in the `Package.swift` file), so I'm not sure we need to keep this around. Curious if anyone has any thoughts.

In the meantime while this is included in `airbnb.swiftformat`, we should keep it up to date.