### PR TITLE
Add rule that protocol composition type aliases should be sorted alphabetically

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         ]),
       dependencies: [
         "AirbnbSwiftFormatTool",
-        "swiftformat",
+        "SwiftFormat",
         "SwiftLintBinary",
       ]),
 
@@ -37,9 +37,9 @@ let package = Package(
       ]),
 
     .binaryTarget(
-      name: "swiftformat",
-      url: "https://github.com/nicklockwood/SwiftFormat/releases/download/0.51.8/SwiftFormat.artifactbundle.zip",
-      checksum: "69dcca93d5f9e8104c35e5091a77b30551d1e01dd80473d1a8ac7b40196ad31d"),
+      name: "SwiftFormat",
+      url: "https://github.com/calda/SwiftFormat/releases/download/0.52-beta-1/SwiftFormat.artifactbundle.zip",
+      checksum: "9061b1aa419bba4c990d5fbbd1e6a6dd61050e4b35669bc90f38535a5700ac32"),
 
     .binaryTarget(
       name: "SwiftLintBinary",

--- a/README.md
+++ b/README.md
@@ -734,7 +734,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   #### Why?
 
-  Type aliases are an unordered list with no natural ordering. Sorting alphabetically keeps these lists more organized, which is especially valuable for long protocol compositions.
+  Protocol composition type aliases are an unordered list with no natural ordering. Sorting alphabetically keeps these lists more organized, which is especially valuable for long protocol compositions.
 
   ```swift
   // WRONG (not sorted)

--- a/README.md
+++ b/README.md
@@ -706,14 +706,40 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   ```swift
   // WRONG (too long)
-  public typealias Dependencies = UniverseBuilderProviding & LawsOfPhysicsProviding & UniverseSimulatorServiceProviding & PlanetBuilderProviding & CivilizationServiceProviding
+  public typealias Dependencies = CivilizationServiceProviding & LawsOfPhysicsProviding & PlanetBuilderProviding & UniverseBuilderProviding & UniverseSimulatorServiceProviding
 
   // WRONG (naive wrapping)
-  public typealias Dependencies = UniverseBuilderProviding & LawsOfPhysicsProviding & UniverseSimulatorServiceProviding &
-    PlanetBuilderProviding & CivilizationServiceProviding
+  public typealias Dependencies = CivilizationServiceProviding & LawsOfPhysicsProviding & PlanetBuilderProviding &
+    UniverseBuilderProviding & UniverseSimulatorServiceProviding
 
   // WRONG (unbalanced)
-  public typealias Dependencies = UniverseBuilderProviding
+  public typealias Dependencies = CivilizationServiceProviding
+    & LawsOfPhysicsProviding
+    & PlanetBuilderProviding
+    & UniverseBuilderProviding
+    & UniverseSimulatorServiceProviding
+
+  // RIGHT
+  public typealias Dependencies
+    = CivilizationServiceProviding
+    & LawsOfPhysicsProviding
+    & PlanetBuilderProviding
+    & UniverseBuilderProviding
+    & UniverseSimulatorServiceProviding
+  ```
+
+* <a id='sort-typealiases'></a>(<a href='#sort-typealiases'>link</a>) **Sort protocol composition type aliases alphabetically.** [![SwiftFormat: sortTypealiases](https://img.shields.io/badge/SwiftFormat-sortTypealiases-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#sortTypealiases)
+
+  <details>
+
+  #### Why?
+
+  Type aliases are an unordered list with no natural ordering. Sorting alphabetically keeps these lists more organized, which is especially valuable for long protocol compositions.
+
+  ```swift
+  // WRONG (not sorted)
+  public typealias Dependencies
+    = UniverseBuilderProviding
     & LawsOfPhysicsProviding
     & UniverseSimulatorServiceProviding
     & PlanetBuilderProviding
@@ -721,11 +747,11 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   // RIGHT
   public typealias Dependencies
-    = UniverseBuilderProviding
+    = CivilizationServiceProviding
     & LawsOfPhysicsProviding
-    & UniverseSimulatorServiceProviding
     & PlanetBuilderProviding
-    & CivilizationServiceProviding
+    & UniverseBuilderProviding
+    & UniverseSimulatorServiceProviding
   ```
 
 * <a id='prefer-if-let-shorthand'></a>(<a href='#prefer-if-let-shorthand'>link</a>) Omit the right-hand side of the expression when unwrapping an optional property to a non-optional property with the same name. [![SwiftFormat: redundantOptionalBinding](https://img.shields.io/badge/SwiftFormat-redundantOptionalBinding-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#redundantOptionalBinding)

--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -84,3 +84,4 @@
 --rules opaqueGenericParameters
 --rules genericExtensions
 --rules trailingClosures
+--rules sortTypealiases


### PR DESCRIPTION
#### Summary

This PR proposes a new rule that protocol composition type aliases should be sorted alphabetically.

Autocorrect is implemented in the SwiftFormat `sortTypealiases` rule, added in https://github.com/nicklockwood/SwiftFormat/pull/1445.

```swift
// WRONG (not sorted)
public typealias Dependencies
  = UniverseBuilderProviding
  & LawsOfPhysicsProviding
  & UniverseSimulatorServiceProviding
  & PlanetBuilderProviding
  & CivilizationServiceProviding

// RIGHT
public typealias Dependencies
  = CivilizationServiceProviding
  & LawsOfPhysicsProviding
  & PlanetBuilderProviding
  & UniverseBuilderProviding
  & UniverseSimulatorServiceProviding
```

#### Reasoning

Type aliases are an unordered list with no natural ordering. Sorting alphabetically keeps these lists more organized, which is especially valuable for long protocol compositions.

_Please react with 👍/👎 if you agree or disagree with this proposal._
