### PR TITLE
Add rule to add a linebreak before the else keyword in a multi-line guard statement

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -38,8 +38,8 @@ let package = Package(
 
     .binaryTarget(
       name: "SwiftFormat",
-      url: "https://github.com/calda/SwiftFormat/releases/download/0.52-beta-1/SwiftFormat.artifactbundle.zip",
-      checksum: "9061b1aa419bba4c990d5fbbd1e6a6dd61050e4b35669bc90f38535a5700ac32"),
+      url: "https://github.com/calda/SwiftFormat/releases/download/0.52-beta-2/SwiftFormat.artifactbundle.zip",
+      checksum: "0cfa2c39a1d5eb7dd5d129f1eb0d525971bedac47d2864022d4f29a54e3cd0aa"),
 
     .binaryTarget(
       name: "SwiftLintBinary",

--- a/README.md
+++ b/README.md
@@ -843,18 +843,18 @@ _You can enable the following settings in Xcode by running [this script](resourc
   }
   ```
 
-* <a id='wrap-guard-else'></a>(<a href='#wrap-guard-else'>link</a>) **Break before the `else` keyword in a multi-line guard statement.** [![SwiftFormat: elseOnSameLine](https://img.shields.io/badge/SwiftFormat-elseOnSameLine-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#elseOnSameLine )
+* <a id='wrap-guard-else'></a>(<a href='#wrap-guard-else'>link</a>) **Add a line break before the `else` keyword in a multi-line guard statement.** For single-line guard statements, keep the `else` keyword on the same line as the `guard` keyword. The open brace should immediately follow the `else` keyword. [![SwiftFormat: elseOnSameLine](https://img.shields.io/badge/SwiftFormat-elseOnSameLine-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#elseOnSameLine )
 
   <details>
 
   ```swift
-  // WRONG -- else should be on its own line for multi-line guard statements
+  // WRONG (else should be on its own line for multi-line guard statements)
   guard
     let galaxy,
     galaxy.name == "Milky Way" else
   { … }
 
-  // WRONG -- else should be on the same line for single-line guard statements
+  // WRONG (else should be on the same line for single-line guard statements)
   guard let galaxy
   else { … }
 
@@ -1610,7 +1610,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
   extension Collection<Universe> { … }
   extension StateStore<SpaceshipState, SpaceshipAction> { … }
 
-  // ALSO RIGHT -- there are multiple types that could satisfy this constraint
+  // ALSO RIGHT. There are multiple types that could satisfy this constraint
   // (e.g. [Planet], [Moon]), so this is not a "bound generic type" and isn't
   // eligible for the generic bracket syntax.
   extension Array where Element: PlanetaryBody { }

--- a/README.md
+++ b/README.md
@@ -817,6 +817,33 @@ _You can enable the following settings in Xcode by running [this script](resourc
   }
   ```
 
+* <a id='wrap-guard-else'></a>(<a href='#wrap-guard-else'>link</a>) **Break before the `else` keyword in a multi-line guard statement.** [![SwiftFormat: elseOnSameLine](https://img.shields.io/badge/SwiftFormat-elseOnSameLine-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#elseOnSameLine )
+
+  <details>
+
+  ```swift
+  // WRONG -- else should be on its own line for multi-line guard statements
+  guard
+    let galaxy,
+    galaxy.name == "Milky Way" else
+  { … }
+
+  // WRONG -- else should be on the same line for single-line guard statements
+  guard let galaxy
+  else { … }
+
+  // RIGHT
+  guard
+    let galaxy,
+    galaxy.name == "Milky Way"
+  else { … }
+
+  // RIGHT
+  guard let galaxy else {
+    …
+  }
+  ```
+
 * <a id='indent-multiline-string-literals'></a>(<a href='#indent-multiline-string-literals'>link</a>) **Indent the body and closing triple-quote of multiline string literals**, unless the string literal begins on its own line in which case the string literal contents and closing triple-quote should have the same indentation as the opening triple-quote. [![SwiftFormat: indent](https://img.shields.io/badge/SwiftFormat-indent-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#indent)
 
   <details>

--- a/README.md
+++ b/README.md
@@ -897,7 +897,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
   }
   ```
 
-* <a id='wrap-guard-else'></a>(<a href='#wrap-guard-else'>link</a>) **Add a line break before the `else` keyword in a multi-line guard statement.** For single-line guard statements, keep the `else` keyword on the same line as the `guard` keyword. The open brace should immediately follow the `else` keyword. [![SwiftFormat: elseOnSameLine](https://img.shields.io/badge/SwiftFormat-elseOnSameLine-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#elseOnSameLine )
+* <a id='wrap-guard-else'></a>(<a href='#wrap-guard-else'>link</a>) **Add a line break before the `else` keyword in a multi-line guard statement.** For single-line guard statements, keep the `else` keyword on the same line as the `guard` keyword. The open brace should immediately follow the `else` keyword. [![SwiftFormat: elseOnSameLine](https://img.shields.io/badge/SwiftFormat-elseOnSameLine-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#elseOnSameLine)
 
   <details>
 

--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -30,6 +30,7 @@
 --typeblanklines preserve # blankLinesAtStartOfScope, blankLinesAtEndOfScope
 --emptybraces spaced # emptyBraces
 --someAny disabled # opaqueGenericParameters
+--guardelse next-line #elseOnSameLine
 
 # We recommend a max width of 100 but _strictly enforce_ a max width of 130
 --maxwidth 130 # wrap
@@ -84,3 +85,4 @@
 --rules opaqueGenericParameters
 --rules genericExtensions
 --rules trailingClosures
+--rules elseOnSameLine


### PR DESCRIPTION
#### Summary

This PR proposes a new rule to add a linebreak before the else keyword in a multi-line guard statement.


```swift
// WRONG -- else should be on its own line for multi-line guard statements
guard
  let galaxy,
  galaxy.name == "Milky Way" else
{ … }

// WRONG -- else should be on the same line for single-line guard statements
guard let galaxy
else { … }

// RIGHT
guard
  let galaxy,
  galaxy.name == "Milky Way"
else { … }

// RIGHT
guard let galaxy else {
  …
}
```

#### Reasoning

This was first suggested back in https://github.com/airbnb/swift/pull/108#issuecomment-715479492. This is also how the examples in the "wrap multi-line conditionals" rule description are formatted.

Placing the `else` on its own line makes it more visually distinct, and prevents it from blending in with the last statement.

We previously didn't enforce this through the formatter since the SwiftFormat rule for this didn't match our requirements very well. As of https://github.com/nicklockwood/SwiftFormat/pull/1447 the SwiftFormat rule implementation works well for us.

_Please react with 👍/👎 if you agree or disagree with this proposal._
