### PR TITLE
Add rule that else statements should start on the same line as previous closing brace

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -38,8 +38,8 @@ let package = Package(
 
     .binaryTarget(
       name: "SwiftFormat",
-      url: "https://github.com/calda/SwiftFormat/releases/download/0.52-beta-1/SwiftFormat.artifactbundle.zip",
-      checksum: "9061b1aa419bba4c990d5fbbd1e6a6dd61050e4b35669bc90f38535a5700ac32"),
+      url: "https://github.com/calda/SwiftFormat/releases/download/0.52-beta-2/SwiftFormat.artifactbundle.zip",
+      checksum: "0cfa2c39a1d5eb7dd5d129f1eb0d525971bedac47d2864022d4f29a54e3cd0aa"),
 
     .binaryTarget(
       name: "SwiftLintBinary",

--- a/README.md
+++ b/README.md
@@ -786,7 +786,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
   else { … }
   ```
 
-* <a id='else-on-same-line'></a>(<a href='#else-on-same-line'>link</a>) **Else statements should start on the same line as the previous condition's closing brace, unless the conditions are separated by a blank line or comments.  [![SwiftFormat: elseOnSameLine](https://img.shields.io/badge/SwiftFormat-elseOnSameLine-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#elseOnSameLine)
+* <a id='else-on-same-line'></a>(<a href='#else-on-same-line'>link</a>) **Else statements should start on the same line as the previous condition's closing brace, unless the conditions are separated by a blank line or comments. [![SwiftFormat: elseOnSameLine](https://img.shields.io/badge/SwiftFormat-elseOnSameLine-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#elseOnSameLine)
 
   <details>
 

--- a/README.md
+++ b/README.md
@@ -786,6 +786,60 @@ _You can enable the following settings in Xcode by running [this script](resourc
   else { … }
   ```
 
+* <a id='else-on-same-line'></a>(<a href='#else-on-same-line'>link</a>) **Else statements should start on the same line as the previous condition's closing brace, unless the conditions are separated by a blank line or comments.  [![SwiftFormat: elseOnSameLine](https://img.shields.io/badge/SwiftFormat-elseOnSameLine-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#elseOnSameLine)
+
+  <details>
+
+  ```swift
+  // WRONG
+  if let galaxy {
+    …
+  }
+  else if let bigBangService {
+    …
+  }
+  else {
+    …
+  }
+
+  // RIGHT
+  if let galaxy {
+    …
+  } else if let bigBangService {
+    …
+  } else {
+    …
+  }
+
+  // RIGHT, because there are comments between the conditions
+  if let galaxy {
+    …
+  }
+  // If the galaxy hasn't been created yet, create it using the big bang service
+  else if let bigBangService {
+    …
+  }
+  // If the big bang service doesn't exist, fail gracefully
+  else {
+    …
+  }
+
+  // RIGHT, because there are blank lines between the conditions
+  if let galaxy {
+    …
+  }
+
+  else if let bigBangService {
+    // If the galaxy hasn't been created yet, create it using the big bang service
+    …
+  }
+
+  else {
+    // If the big bang service doesn't exist, fail gracefully
+    …
+  }
+  ```
+
 * <a id='multi-line-conditions'></a>(<a href='#multi-line-conditions'>link</a>) **Multi-line conditional statements should break after the leading keyword.** Indent each individual statement by [2 spaces](https://github.com/airbnb/swift#spaces-over-tabs). [![SwiftFormat: wrapArguments](https://img.shields.io/badge/SwiftFormat-wrapArguments-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapArguments)
 
   <details>

--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -30,6 +30,8 @@
 --typeblanklines preserve # blankLinesAtStartOfScope, blankLinesAtEndOfScope
 --emptybraces spaced # emptyBraces
 --someAny disabled # opaqueGenericParameters
+--elseposition same-line #elseOnSameLine
+--elseblankline preserve #elseOnSameLine
 
 # We recommend a max width of 100 but _strictly enforce_ a max width of 130
 --maxwidth 130 # wrap
@@ -85,3 +87,4 @@
 --rules genericExtensions
 --rules trailingClosures
 --rules sortTypealiases
+--rules elseOnSameLine

--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -31,7 +31,6 @@
 --emptybraces spaced # emptyBraces
 --someAny disabled # opaqueGenericParameters
 --elseposition same-line #elseOnSameLine
---elseblankline preserve #elseOnSameLine
 
 # We recommend a max width of 100 but _strictly enforce_ a max width of 130
 --maxwidth 130 # wrap
@@ -86,5 +85,5 @@
 --rules opaqueGenericParameters
 --rules genericExtensions
 --rules trailingClosures
---rules sortTypealiases
 --rules elseOnSameLine
+--rules sortTypealiases


### PR DESCRIPTION
#### Summary

This PR proposes a new rule that `else` statements should start on the same line as the previous condition's closing brace, unless the conditions are separated by a blank line or comments.

```swift
// WRONG
if let galaxy {
  …
}
else if let bigBangService {
  …
}
else {
  …
}

// RIGHT
if let galaxy {
  …
} else if let bigBangService {
  …
} else {
  …
}

// RIGHT, because there are comments between the conditions
if let galaxy {
  …
}
// If the galaxy hasn't been created yet, create it using the big bang service
else if let bigBangService {
  …
}
// If the big bang service doesn't exist, fail gracefully
else {
  …
}

// RIGHT, because there are blank lines between the conditions
if let galaxy {
  …
}

else if let bigBangService {
  // If the galaxy hasn't been created yet, create it using the big bang service
  …
}

else {
  // If the big bang service doesn't exist, fail gracefully
  …
}
```

#### Reasoning

```swift
} else {
```

is more idiomatic than:

```swift
}
else {
```

Based on the current implementation of the SwiftFormat `elseOnSameLine` rule, this rule is required for us to also support https://github.com/airbnb/swift/pull/228.

_Please react with 👍/👎 if you agree or disagree with this proposal._
