### PR TITLE
Add `package` keyword to list of declaration categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -2681,6 +2681,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
   * `// MARK: Lifecycle` for `init` and `deinit` methods.
   * `// MARK: Open` for `open` properties and methods.
   * `// MARK: Public` for `public` properties and methods.
+  * `// MARK: Package` for `package` properties and methods.
   * `// MARK: Internal` for `internal` properties and methods.
   * `// MARK: Fileprivate` for `fileprivate` properties and methods.
   * `// MARK: Private` for `private` properties and methods.


### PR DESCRIPTION
#### Summary

Swift 5.9 adds support for `package`-level declarations ([SE-0386](https://github.com/apple/swift-evolution/blob/main/proposals/0386-package-access-modifier.md)). We should mention this in the rule discussing how to organize declarations.

Should we merge this now or wait until Swift 5.9 is released? Either seems ok to me
