### PR TITLE
Add rule to omit `internal` keyword from declarations with internal access control

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -38,8 +38,8 @@ let package = Package(
 
     .binaryTarget(
       name: "SwiftFormat",
-      url: "https://github.com/calda/SwiftFormat/releases/download/0.52-beta-2/SwiftFormat.artifactbundle.zip",
-      checksum: "0cfa2c39a1d5eb7dd5d129f1eb0d525971bedac47d2864022d4f29a54e3cd0aa"),
+      url: "https://github.com/calda/SwiftFormat/releases/download/0.52-beta-3/SwiftFormat.artifactbundle.zip",
+      checksum: "ecca7f964e7dcf2d846633cf394c0cffc7628a5ff89d85d2e206f41142f0a859"),
 
     .binaryTarget(
       name: "SwiftLintBinary",

--- a/README.md
+++ b/README.md
@@ -1239,6 +1239,28 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
+* <a id='omit-internal-keyword'></a>(<a href='#omit-internal-keyword'>link</a>) Omit the `internal` keyword when defining types, properties, or functions with an internal access control level. [![SwiftFormat: redundantInternal](https://img.shields.io/badge/SwiftFormat-redundantInternal-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#redundantInternal)
+
+  <details>
+
+  ```swift
+  // WRONG
+  interal class Spaceship {
+    internal init() { … }
+
+    internal func travel(to planet: Planet) { … }
+  }
+
+  // RIGHT, because internal access control is implied if no other access control level is specified.
+  class Spaceship {
+    init() { … }
+
+    func travel(to planet: Planet) { … }
+  }
+  ```
+
+  </details>
+
 ### Functions
 
 * <a id='omit-function-void-return'></a>(<a href='#omit-function-void-return'>link</a>) **Omit `Void` return types from function definitions.** [![SwiftFormat: redundantVoidReturnType](https://img.shields.io/badge/SwiftFormat-redundantVoidReturnType-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#redundantVoidReturnType)

--- a/README.md
+++ b/README.md
@@ -1239,7 +1239,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
-* <a id='omit-internal-keyword'></a>(<a href='#omit-internal-keyword'>link</a>) Omit the `internal` keyword when defining types, properties, or functions with an internal access control level. [![SwiftFormat: redundantInternal](https://img.shields.io/badge/SwiftFormat-redundantInternal-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#redundantInternal)
+* <a id='omit-internal-keyword'></a>(<a href='#omit-internal-keyword'>link</a>) **Omit the `internal` keyword** when defining types, properties, or functions with an internal access control level. [![SwiftFormat: redundantInternal](https://img.shields.io/badge/SwiftFormat-redundantInternal-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#redundantInternal)
 
   <details>
 

--- a/README.md
+++ b/README.md
@@ -1245,7 +1245,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   ```swift
   // WRONG
-  interal class Spaceship {
+  internal class Spaceship {
     internal init() { … }
 
     internal func travel(to planet: Planet) { … }

--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -69,6 +69,7 @@
 --rules redundantInit
 --rules redundantVoidReturnType
 --rules redundantOptionalBinding
+--rules redundantInternal
 --rules unusedArguments
 --rules spaceInsideBrackets
 --rules spaceInsideBraces


### PR DESCRIPTION
#### Summary

This PR proposes a new rule to omit the `internal` keyword from declarations with internal access control.

Autocorrect is implemented in the new `redundantInternal` SwiftFormat rule, which was added in https://github.com/nicklockwood/SwiftFormat/pull/1486.

```swift
// WRONG
internal class Spaceship {
  internal init() { … }

  internal func travel(to planet: Planet) { … }
}

// RIGHT, because internal access control is implied if no other access control level is specified.
class Spaceship {
  init() { … }

  func travel(to planet: Planet) { … }
}
```

#### Reasoning

Internal access control is implied for declarations without an explicit access control level, so the `internal` keyword is redundant.

_Please react with 👍/👎 if you agree or disagree with this proposal._
