### PR TITLE
Add rule to prefer for loops over functional `forEach { ... }` method

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -38,8 +38,8 @@ let package = Package(
 
     .binaryTarget(
       name: "SwiftFormat",
-      url: "https://github.com/calda/SwiftFormat/releases/download/0.52-beta-2/SwiftFormat.artifactbundle.zip",
-      checksum: "0cfa2c39a1d5eb7dd5d129f1eb0d525971bedac47d2864022d4f29a54e3cd0aa"),
+      url: "https://github.com/calda/SwiftFormat/releases/download/0.52-beta-3/SwiftFormat.artifactbundle.zip",
+      checksum: "ecca7f964e7dcf2d846633cf394c0cffc7628a5ff89d85d2e206f41142f0a859"),
 
     .binaryTarget(
       name: "SwiftLintBinary",

--- a/README.md
+++ b/README.md
@@ -1239,6 +1239,41 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
+* <a id='prefer-for-loop-over-forEach'></a>(<a href='#prefer-for-loop-over-forEach'>link</a>) **Prefer using `for` loops over the functional `forEach(…)` method**, unless using `forEach(…)` as the last element in a functional chain. [![SwiftFormat: forLoop](https://img.shields.io/badge/SwiftFormat-forLoop-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#forLoop)
+
+  <details>
+
+  #### Why?
+  For loops are more idiomatic than the `forEach(…)` method, and are typically familiar to all developers who have experience with C-family languages. 
+
+  For loops are also more expressive than the `forEach(…)` method. For loops support the `return`, `continue`, and `break` control flow keywords, while `forEach(…)` only supports `return` (which has the same behavior as `continue` in a for loop).
+  
+  ```swift
+  // WRONG
+  planets.forEach { planet in
+    planet.terraform()
+  }
+
+  // WRONG
+  planets.forEach {
+    $0.terraform()
+  }
+
+  // RIGHT
+  for planet in planets {
+    planet.terraform()
+  }
+
+  // ALSO FINE, since forEach is useful when paired with other functional methods in a chain.
+  planets
+    .filter { !$0.isGasGiant }
+    .map { PlanetTerraformer(planet: $0) }
+    .forEach { $0.terraform() }
+  ```
+
+  </details>
+
+
 ### Functions
 
 * <a id='omit-function-void-return'></a>(<a href='#omit-function-void-return'>link</a>) **Omit `Void` return types from function definitions.** [![SwiftFormat: redundantVoidReturnType](https://img.shields.io/badge/SwiftFormat-redundantVoidReturnType-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#redundantVoidReturnType)
@@ -1562,40 +1597,6 @@ _You can enable the following settings in Xcode by running [this script](resourc
   // with parameter names. However, consider using non-trailing syntax
   // in cases where the parameter name is semantically meaningful.
   planets.first { $0.isGasGiant }
-  ```
-
-  </details>
-
-* <a id='prefer-for-loop-over-forEach'></a>(<a href='#prefer-for-loop-over-forEach'>link</a>) **Prefer using `for` loops over the functional `forEach { ... }` method**, unless using `forEach` as the last element in a functional chain. [![SwiftFormat: forLoop](https://img.shields.io/badge/SwiftFormat-forLoop-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#forLoop)
-
-  <details>
-
-  #### Why?
-  For loops are more idiomatic than the `forEach` method, and are typically familiar to all developers who have experience with C-family languages. 
-
-  For loops are also more expressive than the `forEach` method. For loops support the `return`, `continue`, and `break` control flow keywords, while `forEach` only supports `return` (which has the same behavior as `continue` in a for loop).
-  
-  ```swift
-  // WRONG
-  planets.forEach { planet in
-    planet.terraform()
-  }
-
-  // WRONG
-  planets.forEach {
-    $0.terraform()
-  }
-
-  // RIGHT
-  for planet in planets {
-    planet.terraform()
-  }
-
-  // ALSO FINE, since forEach is useful when paired with other functional methods in a chain.
-  planets
-    .filter { !$0.isGasGiant }
-    .map { PlanetTerraformer(planet: $0) }
-    .forEach { $0.terraform() }
   ```
 
   </details>

--- a/README.md
+++ b/README.md
@@ -1542,6 +1542,8 @@ _You can enable the following settings in Xcode by running [this script](resourc
   }
   ```
 
+  </details>
+
 * <a id='anonymous-trailing-closures'></a>(<a href='#anonymous-trailing-closures'>link</a>) **Prefer trailing closure syntax for closure arguments with no parameter name.** [![SwiftFormat: trailingClosures](https://img.shields.io/badge/SwiftFormat-trailingClosures-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#trailingClosures)
 
   <details>
@@ -1561,6 +1563,63 @@ _You can enable the following settings in Xcode by running [this script](resourc
   // in cases where the parameter name is semantically meaningful.
   planets.first { $0.isGasGiant }
   ```
+
+  </details>
+
+* <a id='prefer-for-loop-over-forEach'></a>(<a href='#prefer-for-loop-over-forEach'>link</a>) **Prefer using for loops over the functional `forEach { ... }` method**, unless using `forEach` as the last element in a functional chain. [![SwiftFormat: forLoop](https://img.shields.io/badge/SwiftFormat-forLoop-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#forLoop)
+
+  <details>
+
+  #### Why?
+  For loops are more idiomatic than the `forEach` method, and are typically familiar to all developers who have experience with C-family languages. 
+
+  For loops are also more expressive than the `forEach` method. For example, for loops support using the `break` keyword to terminate the loop. This isn't possible when just using `forEach`:
+
+  ```swift
+  let planets = [.mercury, .venus, .earth, .mars, .jupiter, .saturn, .uranus, .neptune]
+
+  for planet in planets {
+    if planet.isGasGiant { 
+      // We can only terraform the terrestrial planets, so stop once we reach a gas giant.
+      break
+    }
+    
+    planet.teraform()
+  }
+
+  planets.forEach { planet in
+    if planet.isGasGiant {
+      // We have no way to terminate the loop, since `return` just continues to the next item in the array
+    }
+
+    planet.terraform()
+  }
+  ```
+  
+  ```swift
+  // WRONG
+  planets.forEach { planet in
+    planet.terraform()
+  }
+
+  // WRONG
+  planets.forEach {
+    $0.terraform()
+  }
+
+  // RIGHT
+  for planet in planets {
+    planet.terraform()
+  }
+
+  // ALSO FINE, since forEach is useful when paired with other functional methods in a chain.
+  planets
+    .filter { !$0.isGasGiant }
+    .map { PlanetTerraformer(planet: $0) }
+    .forEach { $0.terraform() }
+  ```
+
+  </details>
 
 ### Operators
 

--- a/README.md
+++ b/README.md
@@ -1573,28 +1573,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
   #### Why?
   For loops are more idiomatic than the `forEach` method, and are typically familiar to all developers who have experience with C-family languages. 
 
-  For loops are also more expressive than the `forEach` method. For example, for loops support using the `break` keyword to terminate the loop. This isn't possible when just using `forEach`:
-
-  ```swift
-  let planets = [.mercury, .venus, .earth, .mars, .jupiter, .saturn, .uranus, .neptune]
-
-  for planet in planets {
-    if planet.isGasGiant { 
-      // We can only terraform the terrestrial planets, so stop once we reach a gas giant.
-      break
-    }
-    
-    planet.teraform()
-  }
-
-  planets.forEach { planet in
-    if planet.isGasGiant {
-      // We have no way to terminate the loop, since `return` just continues to the next item in the array
-    }
-
-    planet.terraform()
-  }
-  ```
+  For loops are also more expressive than the `forEach` method. For loops support the `return`, `continue`, and `break` control flow keywords, while `forEach` only supports `return` (which has the same behavior as `continue` in a for loop).
   
   ```swift
   // WRONG

--- a/README.md
+++ b/README.md
@@ -1566,7 +1566,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
-* <a id='prefer-for-loop-over-forEach'></a>(<a href='#prefer-for-loop-over-forEach'>link</a>) **Prefer using for loops over the functional `forEach { ... }` method**, unless using `forEach` as the last element in a functional chain. [![SwiftFormat: forLoop](https://img.shields.io/badge/SwiftFormat-forLoop-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#forLoop)
+* <a id='prefer-for-loop-over-forEach'></a>(<a href='#prefer-for-loop-over-forEach'>link</a>) **Prefer using `for` loops over the functional `forEach { ... }` method**, unless using `forEach` as the last element in a functional chain. [![SwiftFormat: forLoop](https://img.shields.io/badge/SwiftFormat-forLoop-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#forLoop)
 
   <details>
 

--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -88,3 +88,4 @@
 --rules trailingClosures
 --rules elseOnSameLine
 --rules sortTypealiases
+--rules forLoop

--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -32,6 +32,7 @@
 --someAny disabled # opaqueGenericParameters
 --elseposition same-line #elseOnSameLine
 --guardelse next-line #elseOnSameLine
+--oneLineForEach wrap #forLoop
 
 # We recommend a max width of 100 but _strictly enforce_ a max width of 130
 --maxwidth 130 # wrap


### PR DESCRIPTION
#### Summary

This PR proposes a new rule to prefer using for loops over the functional `forEach { ... }` method, unless using `forEach` as the last element in a functional chain.

Autocorrect is implemented in the new `forLoop` SwiftFormat rule, which was added in https://github.com/nicklockwood/SwiftFormat/pull/1490.

```swift
// WRONG
planets.forEach { planet in
  planet.terraform()
}

// WRONG
planets.forEach {
  $0.terraform()
}

// RIGHT
for planet in planets {
  planet.terraform()
}

// ALSO FINE, since forEach is useful when paired with other functional methods in a chain.
planets
  .filter { !$0.isGasGiant }
  .map { PlanetTerraformer(planet: $0) }
  .forEach { $0.terraform() }
```

#### Reasoning

For loops are more idiomatic than the `forEach` method, and are typically familiar to all developers who have experience with C-family languages. 

For loops are also more expressive than the `forEach` method. For loops support the `return`, `continue`, and `break` control flow keywords, while `forEach` only supports `return` (which has the same behavior as `continue` in a for loop).

_Please react with 👍/👎 if you agree or disagree with this proposal._
