### PR TITLE
Include version-specific package manifests when determining default minimum Swift version

### DIFF
--- a/Plugins/FormatSwift/Plugin.swift
+++ b/Plugins/FormatSwift/Plugin.swift
@@ -95,8 +95,9 @@ extension AirbnbSwiftFormatPlugin: CommandPlugin {
     // When running on a SPM package we infer the minimum Swift version from the
     // `swift-tools-version` in `Package.swift` by default if the user doesn't
     // specify one manually
+    lazy var minimumSwiftVersion = context.package.minimumSwiftVersion
     let swiftVersion = argumentExtractor.extractOption(named: "swift-version").last
-      ?? "\(context.package.toolsVersion.major).\(context.package.toolsVersion.minor)"
+      ?? "\(minimumSwiftVersion.major).\(minimumSwiftVersion.minor)"
 
     let arguments = [
       "--swift-version",
@@ -165,4 +166,93 @@ extension AirbnbSwiftFormatPlugin: XcodeCommandPlugin {
 enum CommandError: Error {
   case lintFailure
   case unknownError(exitCode: Int32)
+}
+
+// MARK: - SwiftVersion
+
+struct SwiftVersion: Comparable {
+  var major: Int
+  var minor: Int
+
+  static func ==(_ lhs: SwiftVersion, _ rhs: SwiftVersion) -> Bool {
+    lhs.major == rhs.major
+      && lhs.minor == rhs.minor
+  }
+
+  static func <(_ lhs: SwiftVersion, _ rhs: SwiftVersion) -> Bool {
+    if lhs.major == rhs.major {
+      return lhs.minor < rhs.minor
+    } else {
+      return lhs.major < rhs.major
+    }
+  }
+}
+
+extension Package {
+
+  // MARK: Internal
+
+  /// The minimum Swift version supported by this package
+  var minimumSwiftVersion: SwiftVersion {
+    supportedSwiftVersions.sorted().first!
+  }
+
+  // MARK: Private
+
+  /// Swift versions supported by this package. Guaranteed to be non-empty.
+  ///  - This includes the `swift-tools-version` from the `Package.swift`,
+  ///    plus the Swift version of any additional version-specific Package manifest
+  ///    (e.g. `Package@swift-5.6.swift`).
+  private var supportedSwiftVersions: [SwiftVersion] {
+    guard let projectDirectory = URL(string: directory.string) else { return [] }
+
+    var supportedSwiftVersions = [
+      SwiftVersion(major: toolsVersion.major, minor: toolsVersion.minor),
+    ]
+
+    // Look for all of the package manifest files in the directory root
+    let enumerator = FileManager.default.enumerator(
+      at: projectDirectory,
+      includingPropertiesForKeys: nil,
+      options: [.skipsSubdirectoryDescendants, .skipsHiddenFiles])
+
+    while let fileURL = enumerator?.nextObject() as? URL {
+      let fileName = fileURL.lastPathComponent
+
+      guard fileName.hasPrefix("Package"), fileName.hasSuffix(".swift") else { continue }
+
+      // Parse the Swift version from the file name if it has a format like `Package@swift-5.8.swift`
+      if
+        fileName.hasPrefix("Package@swift-"),
+        let swiftVersion = parseSwiftVersion(from: fileName.dropFirst("Package@swift-".count))
+      {
+        supportedSwiftVersions.append(swiftVersion)
+      }
+
+      // Parse the Swift tools version from the file body if it starts with a comment like `// swift-tools-version: 5.8`
+      if
+        let fileContents = try? String(contentsOf: fileURL),
+        fileContents.hasPrefix("// swift-tools-version: "),
+        let swiftVersion = parseSwiftVersion(from: fileContents.dropFirst("// swift-tools-version: ".count))
+      {
+        supportedSwiftVersions.append(swiftVersion)
+      }
+    }
+
+    return supportedSwiftVersions
+  }
+
+  /// Parses a Swift version from a string like "5.8"
+  private func parseSwiftVersion(from string: Substring) -> SwiftVersion? {
+    var string = string
+
+    guard
+      string.count >= 3,
+      let major = string.popFirst().flatMap({ Int("\($0)") }),
+      string.popFirst() == ".",
+      let minor = string.popFirst().flatMap({ Int("\($0)") })
+    else { return nil }
+
+    return SwiftVersion(major: major, minor: minor)
+  }
 }


### PR DESCRIPTION
The Airbnb Swift Format Tool currently infers a package's minimum Swift supported version by taking the `// swift-tools-version` from the `Package.swift` (e.g. `// swift-tools-version:5.6`).

A project can also have multiple `Package.swift`s with different tools versions. This is required if a package wants to make use of functionality that is only available in later tools versions, without dropping support for earlier tool versions. For example, you can use `// swift-tools-version:5.8` in your `Package.swift` and have an additional `Package@swift-5.7.swift` with `// swift-tools-version:5.7`.

This PR updates the AirbnbSwift Format Tool to take into account all of these versions, and use the lowest value as the minimum Swift version when running the code formatter.