### PR TITLE
Update to SwiftLint 0.52.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -43,8 +43,8 @@ let package = Package(
 
     .binaryTarget(
       name: "SwiftLintBinary",
-      url: "https://github.com/realm/SwiftLint/releases/download/0.48.0/SwiftLintBinary-macos.artifactbundle.zip",
-      checksum: "9c255e797260054296f9e4e4cd7e1339a15093d75f7c4227b9568d63edddba50"),
+      url: "https://github.com/realm/SwiftLint/releases/download/0.52.1/SwiftLintBinary-macos.artifactbundle.zip",
+      checksum: "bb4875e7a0a80b4799211f2eb35d4a81a9d4fc9175f06be4479a680d76ddf29c"),
   ])
 
 // Emit an error on Linux, so Swift Package Manager's platform support detection doesn't say this package supports Linux

--- a/Sources/AirbnbSwiftFormatTool/AirbnbSwiftFormatTool.swift
+++ b/Sources/AirbnbSwiftFormatTool/AirbnbSwiftFormatTool.swift
@@ -101,8 +101,6 @@ struct AirbnbSwiftFormatTool: ParsableCommand {
       "--config", swiftLintConfig,
       // Required for SwiftLint to emit a non-zero exit code on lint failure
       "--strict",
-      // This flag is required when invoking SwiftLint from an SPM plugin, due to sandboxing
-      "--in-process-sourcekit",
     ]
 
     if let swiftLintCachePath = swiftLintCachePath {


### PR DESCRIPTION
I noticed we were using an outdated version of SwiftLint in this repo. We are currently using SwiftLint 0.52.1 within Airbnb.

This PR updates this repo to also use SwiftLint 0.52.1.