### PR TITLE
Fix issue where linter would disallow "@unchecked Sendable" string in comments

### DIFF
--- a/Sources/AirbnbSwiftFormatTool/swiftlint.yml
+++ b/Sources/AirbnbSwiftFormatTool/swiftlint.yml
@@ -55,5 +55,8 @@ custom_rules:
   no_unchecked_sendable:
     name: "`@unchecked Sendable` is discouraged."
     regex: "@unchecked Sendable"
+    match_kinds:
+    - attribute.builtin
+    - typeidentifier
     message: "Instead of using `@unchecked Sendable`, consider a safe alternative like a standard `Sendable` conformance or using `@preconcurrency import`. If you really must use `@unchecked Sendable`, you can add a `// swiftlint:disable:next no_unchecked_sendable` annotation with an explanation for how we know the type is thread-safe, and why we have to use @unchecked Sendable instead of Sendable. More explanation and suggested safe alternatives are available at https://github.com/airbnb/swift#unchecked-sendable."
     severity: error


### PR DESCRIPTION
This PR fixes an issue where the linter would now allow you to use the string `@unchecked Sendable` in a comment.

This was previously disallowed by the linter, because the regex matched the `"@unchecked Sendable"` text in the comment:

```swift
// Conform to @unchecked Sendable since the type is internally thread-safe
// swiftlint:disable:next no_unchecked_sendable
extension MyType: @unchecked Sendable
```

but is now allowed as expected