### PR TITLE
Fix issue where package plugin wouldn't run SwiftLint lint-only rules unless passing in `--lint` flag

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,5 +45,5 @@ jobs:
         - '15.0' # Swift 5.9
     steps:
       - uses: actions/checkout@v2
-      - name: Test Package Plugin
+      - name: Run Unit Tests
         run: swift test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,21 @@ jobs:
         xcode:
         - '14.2' # Swift 5.7
         - '14.3' # Swift 5.8
+        - '15.0' # Swift 5.9
     steps:
       - uses: actions/checkout@v2
       - name: Test Package Plugin
         run: swift package --allow-writing-to-package-directory format --lint
+
+  unit-tests:
+    name: Unit Tests
+    runs-on: macos-13
+    strategy:
+      fail-fast: false
+      matrix:
+        xcode:
+        - '15.0' # Swift 5.9
+    steps:
+      - uses: actions/checkout@v2
+      - name: Test Package Plugin
+        run: swift test

--- a/Package.swift
+++ b/Package.swift
@@ -36,6 +36,10 @@ let package = Package(
         .process("swiftlint.yml"),
       ]),
 
+    .testTarget(
+      name: "AirbnbSwiftFormatToolTests",
+      dependencies: ["AirbnbSwiftFormatTool"]),
+
     .binaryTarget(
       name: "SwiftFormat",
       url: "https://github.com/calda/SwiftFormat/releases/download/0.52-beta-3/SwiftFormat.artifactbundle.zip",

--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ $ swift package format --targets AirbnbSwiftFormatTool
 $ swift package format --swift-version 5.3
 ```
 
+The package plugin returns a non-zero exit code if there is a lint failure that requires attention.
+ - In `--lint` mode, any lint failure from any tool will result in a non-zero exit code.
+ - In standard autocorrect mode without `--lint`, only failures from SwiftLint lint-only rules will result in a non-zero exit code.
+
 </details>
 
 ## Table of Contents

--- a/Sources/AirbnbSwiftFormatTool/AirbnbSwiftFormatTool.swift
+++ b/Sources/AirbnbSwiftFormatTool/AirbnbSwiftFormatTool.swift
@@ -40,40 +40,64 @@ struct AirbnbSwiftFormatTool: ParsableCommand {
   @Option(help: "The project's minimum Swift version")
   var swiftVersion: String?
 
-  mutating func run() throws {
-    try swiftFormat.run()
-    swiftFormat.waitUntilExit()
+  func run() throws {
+    let swiftFormat = makeSwiftFormatCommand()
+    let swiftLint = makeSwiftLintCommand(autocorrect: false)
+    let swiftLintAutocorrect = makeSwiftLintCommand(autocorrect: true)
 
-    try swiftLint.run()
-    swiftLint.waitUntilExit()
+    let swiftFormatExitCode = try swiftFormat.run()
 
-    if log {
-      log(swiftFormat.shellCommand)
-      log(swiftLint.shellCommand)
-      log("SwiftFormat ended with exit code \(swiftFormat.terminationStatus)")
-      log("SwiftLint ended with exit code \(swiftLint.terminationStatus)")
+    // We always have to run SwiftLint in lint-only mode at least once,
+    // because when in autocorrect mode SwiftLint won't emit any lint warnings.
+    let swiftLintExitCode = try swiftLint.run()
+
+    let swiftLintAutocorrectExitCode: Int32?
+    if
+      // When only linting, we shouldn't run SwiftLint with autocorrect enabled
+      !lintOnly,
+      // When formatting, only re-run SwiftLint a second time if the first
+      // invocation reported a lint failure that needs to be corrected
+      swiftLintExitCode == SwiftLintExitCode.lintFailure
+    {
+      swiftLintAutocorrectExitCode = try swiftLintAutocorrect.run()
+    } else {
+      swiftLintAutocorrectExitCode = nil
     }
 
     if
-      swiftFormat.terminationStatus == SwiftFormatExitCode.lintFailure ||
-      swiftLint.terminationStatus == SwiftLintExitCode.lintFailure
+      swiftFormatExitCode == SwiftFormatExitCode.lintFailure ||
+      swiftLintExitCode == SwiftLintExitCode.lintFailure ||
+      swiftLintAutocorrectExitCode == SwiftLintExitCode.lintFailure
     {
       throw ExitCode.failure
     }
 
     // Any other non-success exit code is an unknown failure
-    if swiftFormat.terminationStatus != EXIT_SUCCESS {
-      throw ExitCode(swiftFormat.terminationStatus)
+    if swiftFormatExitCode != EXIT_SUCCESS {
+      throw ExitCode(swiftFormatExitCode)
     }
 
-    if swiftLint.terminationStatus != EXIT_SUCCESS {
-      throw ExitCode(swiftLint.terminationStatus)
+    if swiftLintExitCode != EXIT_SUCCESS {
+      throw ExitCode(swiftLintExitCode)
+    }
+
+    if
+      let swiftLintAutocorrectExitCode = swiftLintAutocorrectExitCode,
+      swiftLintAutocorrectExitCode != EXIT_SUCCESS
+    {
+      throw ExitCode(swiftLintAutocorrectExitCode)
     }
   }
 
   // MARK: Private
 
-  private lazy var swiftFormat: Process = {
+  /// Whether the command should autocorrect invalid code, or only emit lint errors
+  private var lintOnly: Bool {
+    lint
+  }
+
+  /// Builds a command that runs the SwiftFormat tool
+  private func makeSwiftFormatCommand() -> Command {
     var arguments = directories + [
       "--config", swiftFormatConfig,
     ]
@@ -90,13 +114,16 @@ struct AirbnbSwiftFormatTool: ParsableCommand {
       arguments += ["--swiftversion", swiftVersion]
     }
 
-    let swiftFormat = Process()
-    swiftFormat.launchPath = swiftFormatPath
-    swiftFormat.arguments = arguments
-    return swiftFormat
-  }()
+    return Command(
+      log: log,
+      launchPath: swiftFormatPath,
+      arguments: arguments)
+  }
 
-  private lazy var swiftLint: Process = {
+  /// Builds a command that runs the SwiftLint tool
+  ///  - If `autocorrect` is true, passes the `--fix` flag to SwiftLint.
+  ///    When autocorrecting, SwiftLint doesn't emit any lint warnings.
+  private func makeSwiftLintCommand(autocorrect: Bool) -> Command {
     var arguments = directories + [
       "--config", swiftLintConfig,
       // Required for SwiftLint to emit a non-zero exit code on lint failure
@@ -107,15 +134,15 @@ struct AirbnbSwiftFormatTool: ParsableCommand {
       arguments += ["--cache-path", swiftLintCachePath]
     }
 
-    if !lint {
+    if autocorrect {
       arguments += ["--fix"]
     }
 
-    let swiftLint = Process()
-    swiftLint.launchPath = swiftLintPath
-    swiftLint.arguments = arguments
-    return swiftLint
-  }()
+    return Command(
+      log: log,
+      launchPath: swiftLintPath,
+      arguments: arguments)
+  }
 
   private func log(_ string: String) {
     // swiftlint:disable:next no_direct_standard_out_logs

--- a/Sources/AirbnbSwiftFormatTool/AirbnbSwiftFormatTool.swift
+++ b/Sources/AirbnbSwiftFormatTool/AirbnbSwiftFormatTool.swift
@@ -47,22 +47,21 @@ struct AirbnbSwiftFormatTool: ParsableCommand {
 
     let swiftFormatExitCode = try swiftFormat.run()
 
-    // We always have to run SwiftLint in lint-only mode at least once,
-    // because when in autocorrect mode SwiftLint won't emit any lint warnings.
-    let swiftLintExitCode = try swiftLint.run()
-
+    // Run SwiftLint in autocorrect mode first, so that if autocorrect fixes all of the SwiftLint violations
+    // then the following lint-only invocation will not report any violations.
     let swiftLintAutocorrectExitCode: Int32?
     if
       // When only linting, we shouldn't run SwiftLint with autocorrect enabled
-      !lintOnly,
-      // When formatting, only re-run SwiftLint a second time if the first
-      // invocation reported a lint failure that needs to be corrected
-      swiftLintExitCode == SwiftLintExitCode.lintFailure
+      !lintOnly
     {
       swiftLintAutocorrectExitCode = try swiftLintAutocorrect.run()
     } else {
       swiftLintAutocorrectExitCode = nil
     }
+
+    // We always have to run SwiftLint in lint-only mode at least once,
+    // because when in autocorrect mode SwiftLint won't emit any lint warnings.
+    let swiftLintExitCode = try swiftLint.run()
 
     if
       swiftFormatExitCode == SwiftFormatExitCode.lintFailure ||

--- a/Sources/AirbnbSwiftFormatTool/AirbnbSwiftFormatTool.swift
+++ b/Sources/AirbnbSwiftFormatTool/AirbnbSwiftFormatTool.swift
@@ -89,6 +89,16 @@ struct AirbnbSwiftFormatTool: ParsableCommand {
     }
   }
 
+  /// Runs the `AirbnbSwiftFormatTool` command with the given closure that executes each individual command.
+  func run(executeCommand: @escaping (Command) -> Int32) throws {
+    let existingImplementation = Command.runCommand
+
+    Command.runCommand = executeCommand
+    defer { Command.runCommand = existingImplementation }
+
+    try run()
+  }
+
   // MARK: Private
 
   /// Whether the command should autocorrect invalid code, or only emit lint errors

--- a/Sources/AirbnbSwiftFormatTool/Command.swift
+++ b/Sources/AirbnbSwiftFormatTool/Command.swift
@@ -9,18 +9,22 @@ struct Command {
   // MARK: Internal
 
   /// Mock implementation of `Command.run` which can be provided during unit test
-  static var _mockRunCommand: ((Command) -> Int32)?
+  static var runCommand: (Command) throws -> Int32 = { try $0.executeShellCommand() }
 
   let log: Bool
   let launchPath: String
   let arguments: [String]
 
-  /// Synchronously runs this command and returns its exit code
+  /// Runs this command using the implementation of `Command.runCommand`
+  ///  - By default, synchronously runs this command and returns its exit code
   func run() throws -> Int32 {
-    if let _mockRunCommand = Command._mockRunCommand {
-      return _mockRunCommand(self)
-    }
+    try Command.runCommand(self)
+  }
 
+  // MARK: Private
+
+  /// Synchronously runs this command and returns its exit code
+  private func executeShellCommand() throws -> Int32 {
     let process = Process()
     process.launchPath = launchPath
     process.arguments = arguments
@@ -39,8 +43,6 @@ struct Command {
 
     return process.terminationStatus
   }
-
-  // MARK: Private
 
   private func log(_ string: String) {
     // swiftlint:disable:next no_direct_standard_out_logs

--- a/Sources/AirbnbSwiftFormatTool/Command.swift
+++ b/Sources/AirbnbSwiftFormatTool/Command.swift
@@ -8,7 +8,7 @@ struct Command {
 
   // MARK: Internal
 
-  /// Mock implementation of `Command.run` which can be provided during unit test
+  /// This property can be overridden to provide a mock implementation in unit tests.
   static var runCommand: (Command) throws -> Int32 = { try $0.executeShellCommand() }
 
   let log: Bool

--- a/Sources/AirbnbSwiftFormatTool/Command.swift
+++ b/Sources/AirbnbSwiftFormatTool/Command.swift
@@ -1,0 +1,50 @@
+// Created by Cal Stephens on 9/25/23.
+// Copyright © 2023 Airbnb Inc. All rights reserved.
+
+import Foundation
+
+/// A single command line invocation
+struct Command {
+
+  // MARK: Internal
+
+  /// Mock implementation of `Command.run` which can be provided during unit test
+  static var _mockRunCommand: ((Command) -> Int32)?
+
+  let log: Bool
+  let launchPath: String
+  let arguments: [String]
+
+  /// Synchronously runs this command and returns its exit code
+  func run() throws -> Int32 {
+    if let _mockRunCommand = Command._mockRunCommand {
+      return _mockRunCommand(self)
+    }
+
+    let process = Process()
+    process.launchPath = launchPath
+    process.arguments = arguments
+
+    if log {
+      log(process.shellCommand)
+    }
+
+    try process.run()
+    process.waitUntilExit()
+
+    if log {
+      let commandName = process.launchPath?.components(separatedBy: "/").last ?? "unknown"
+      log("\(commandName) command completed with exit code \(process.terminationStatus)")
+    }
+
+    return process.terminationStatus
+  }
+
+  // MARK: Private
+
+  private func log(_ string: String) {
+    // swiftlint:disable:next no_direct_standard_out_logs
+    print("[AibnbSwiftFormatTool]", string)
+  }
+
+}

--- a/Tests/AirbnbSwiftFormatToolTests/AirbnbSwiftFormatToolTests.swift
+++ b/Tests/AirbnbSwiftFormatToolTests/AirbnbSwiftFormatToolTests.swift
@@ -170,9 +170,6 @@ final class AirbnbSwiftFormatToolTest: XCTestCase {
 
   /// Runs `AirbnbSwiftFormatTool` with the `Command` calls mocked using the given mocks
   private func runFormatTool(arguments: [String]? = nil, with mocks: MockCommands) -> Error? {
-    Command._mockRunCommand = mocks.mockRunCommand(_:)
-    defer { Command._mockRunCommand = nil }
-
     let formatTool = try! AirbnbSwiftFormatTool.parse([
       "Sources",
       "--swift-format-path",
@@ -182,7 +179,7 @@ final class AirbnbSwiftFormatToolTest: XCTestCase {
     ] + (arguments ?? []))
 
     do {
-      try formatTool.run()
+      try formatTool.run(executeCommand: mocks.mockRunCommand(_:))
       return nil
     } catch {
       return error

--- a/Tests/AirbnbSwiftFormatToolTests/AirbnbSwiftFormatToolTests.swift
+++ b/Tests/AirbnbSwiftFormatToolTests/AirbnbSwiftFormatToolTests.swift
@@ -1,0 +1,219 @@
+// Created by Cal Stephens on 9/25/23.
+// Copyright © 2023 Airbnb Inc. All rights reserved.
+
+import ArgumentParser
+import XCTest
+
+@testable import AirbnbSwiftFormatTool
+
+// MARK: - AirbnbSwiftFormatToolTest
+
+final class AirbnbSwiftFormatToolTest: XCTestCase {
+
+  // MARK: Internal
+
+  func testFormatWithNoViolations() {
+    var ranSwiftFormat = false
+    var ranSwiftLint = false
+    var ranSwiftLintAutocorrect = false
+
+    let error = runFormatTool(
+      with: MockCommands(
+        swiftFormat: {
+          ranSwiftFormat = true
+          return EXIT_SUCCESS
+        },
+        swiftLint: {
+          ranSwiftLint = true
+          return EXIT_SUCCESS
+        },
+        swiftLintAutocorrect: {
+          ranSwiftLintAutocorrect = true
+          return EXIT_SUCCESS
+        }))
+
+    XCTAssertNil(error)
+    XCTAssertTrue(ranSwiftFormat)
+    XCTAssertTrue(ranSwiftLint)
+
+    // No need to run SwiftLint autocorrect if there were no violations
+    XCTAssertFalse(ranSwiftLintAutocorrect)
+  }
+
+  func testLintWithNoViolations() {
+    var ranSwiftFormat = false
+    var ranSwiftLint = false
+    var ranSwiftLintAutocorrect = false
+
+    let error = runFormatTool(
+      arguments: ["--lint"],
+      with: MockCommands(
+        swiftFormat: {
+          ranSwiftFormat = true
+          return EXIT_SUCCESS
+        },
+        swiftLint: {
+          ranSwiftLint = true
+          return EXIT_SUCCESS
+        },
+        swiftLintAutocorrect: {
+          ranSwiftLintAutocorrect = true
+          return EXIT_SUCCESS
+        }))
+
+    XCTAssertNil(error)
+    XCTAssertTrue(ranSwiftFormat)
+    XCTAssertTrue(ranSwiftLint)
+
+    // Should't run SwiftLint autocorrect in lint-only mode
+    XCTAssertFalse(ranSwiftLintAutocorrect)
+  }
+
+  func testFormatWithViolations() {
+    var ranSwiftFormat = false
+    var ranSwiftLint = false
+    var ranSwiftLintAutocorrect = false
+
+    let error = runFormatTool(
+      with: MockCommands(
+        swiftFormat: {
+          ranSwiftFormat = true
+
+          // When autocorrecting SwiftFormat returns EXIT_SUCCESS
+          // even if there were violations that were fixed
+          return EXIT_SUCCESS
+        },
+        swiftLint: {
+          ranSwiftLint = true
+          return SwiftLintExitCode.lintFailure
+        },
+        swiftLintAutocorrect: {
+          ranSwiftLintAutocorrect = true
+
+          // When autocorrecting SwiftLint returns EXIT_SUCCESS
+          // even if there were violations that were fixed
+          return EXIT_SUCCESS
+        }))
+
+    XCTAssertEqual(error as? ExitCode, ExitCode(SwiftFormatExitCode.lintFailure))
+    XCTAssertTrue(ranSwiftFormat)
+    XCTAssertTrue(ranSwiftLint)
+    XCTAssertTrue(ranSwiftLintAutocorrect)
+  }
+
+  func testLintWithViolations() {
+    var ranSwiftFormat = false
+    var ranSwiftLint = false
+    var ranSwiftLintAutocorrect = false
+
+    let error = runFormatTool(
+      arguments: ["--lint"],
+      with: MockCommands(
+        swiftFormat: {
+          ranSwiftFormat = true
+          return SwiftFormatExitCode.lintFailure
+        },
+        swiftLint: {
+          ranSwiftLint = true
+          return SwiftLintExitCode.lintFailure
+        },
+        swiftLintAutocorrect: {
+          ranSwiftLintAutocorrect = true
+          return EXIT_SUCCESS
+        }))
+
+    XCTAssertEqual(error as? ExitCode, ExitCode.failure)
+    XCTAssertTrue(ranSwiftFormat)
+    XCTAssertTrue(ranSwiftLint)
+    XCTAssertFalse(ranSwiftLintAutocorrect)
+  }
+
+  func testLintWithOnlySwiftLintViolation() {
+    var ranSwiftFormat = false
+    var ranSwiftLint = false
+    var ranSwiftLintAutocorrect = false
+
+    let error = runFormatTool(
+      arguments: ["--lint"],
+      with: MockCommands(
+        swiftFormat: {
+          ranSwiftFormat = true
+          return EXIT_SUCCESS
+        },
+        swiftLint: {
+          ranSwiftLint = true
+          return SwiftLintExitCode.lintFailure
+        },
+        swiftLintAutocorrect: {
+          ranSwiftLintAutocorrect = true
+          return EXIT_SUCCESS
+        }))
+
+    XCTAssertEqual(error as? ExitCode, ExitCode.failure)
+    XCTAssertTrue(ranSwiftFormat)
+    XCTAssertTrue(ranSwiftLint)
+    XCTAssertFalse(ranSwiftLintAutocorrect)
+  }
+
+  func testHandlesUnexpectedErrorCode() {
+    let unexpectedSwiftFormatExitCode = runFormatTool(
+      with: MockCommands(swiftFormat: { 1234 }))
+
+    let unexpectedSwiftLintExitCode = runFormatTool(
+      with: MockCommands(swiftLint: { 42 }))
+
+    XCTAssertEqual(unexpectedSwiftFormatExitCode as? ExitCode, ExitCode(1234))
+    XCTAssertEqual(unexpectedSwiftLintExitCode as? ExitCode, ExitCode(42))
+  }
+
+  // MARK: Private
+
+  /// Runs `AirbnbSwiftFormatTool` with the `Command` calls mocked using the given mocks
+  private func runFormatTool(arguments: [String]? = nil, with mocks: MockCommands) -> Error? {
+    Command._mockRunCommand = mocks.mockRunCommand(_:)
+    defer { Command._mockRunCommand = nil }
+
+    let formatTool = try! AirbnbSwiftFormatTool.parse([
+      "Sources",
+      "--swift-format-path",
+      "airbnb.swiftformat",
+      "--swift-lint-path",
+      "swiftlint.yml",
+    ] + (arguments ?? []))
+
+    do {
+      try formatTool.run()
+      return nil
+    } catch {
+      return error
+    }
+  }
+
+}
+
+// MARK: - MockCommands
+
+/// Mock implementations of the commands ran by `AirbnbSwiftFormatTool`
+struct MockCommands {
+  var swiftFormat: (() -> Int32)?
+  var swiftLint: (() -> Int32)?
+  var swiftLintAutocorrect: (() -> Int32)?
+
+  func mockRunCommand(_ command: Command) -> Int32 {
+    if command.launchPath.lowercased().contains("swiftformat") {
+      return swiftFormat?() ?? EXIT_SUCCESS
+    }
+
+    else if command.launchPath.lowercased().contains("swiftlint") {
+      if command.arguments.contains("--fix") {
+        return swiftLintAutocorrect?() ?? EXIT_SUCCESS
+      } else {
+        return swiftLint?() ?? EXIT_SUCCESS
+      }
+    }
+
+    else {
+      fatalError("Unexpected command: \(command)")
+    }
+  }
+}

--- a/Tests/AirbnbSwiftFormatToolTests/AirbnbSwiftFormatToolTests.swift
+++ b/Tests/AirbnbSwiftFormatToolTests/AirbnbSwiftFormatToolTests.swift
@@ -38,47 +38,6 @@ final class AirbnbSwiftFormatToolTest: XCTestCase {
     XCTAssertTrue(ranSwiftLintAutocorrect)
   }
 
-  func testFormatWithOnlySwiftLintAutocorrectedViolation() {
-    var ranSwiftFormat = false
-    var ranSwiftLint = false
-    var ranSwiftLintAutocorrect = false
-
-    let error = runFormatTool(
-      with: MockCommands(
-        swiftFormat: {
-          ranSwiftFormat = true
-          return EXIT_SUCCESS
-        },
-        swiftLint: {
-          ranSwiftLint = true
-
-          // Assume that the codebase has violations that would be corrected by SwiftLint autocorrect.
-          if ranSwiftLintAutocorrect {
-            // If SwiftLint autocorrect has already run, then there are no more violations.
-            // This is the expected behavior.
-            return EXIT_SUCCESS
-          } else {
-            // If SwiftLint autocorrect hasn't run yet, then there are still violations.
-            // This should not happen, because we run autocorrect first.
-            return SwiftLintExitCode.lintFailure
-          }
-        },
-        swiftLintAutocorrect: {
-          // Assume that this SwiftLint autocorrect invocation applied a code change.
-          // In this case, SwiftLint still returns a zero exit code.
-          ranSwiftLintAutocorrect = true
-          return EXIT_SUCCESS
-        }))
-
-    // Even though there was a SwiftLint failure, it was autocorrected so doesn't require attention.
-    // The tool should not return an error (e.g. it should return a zero exit code).
-    XCTAssertNil(error)
-
-    XCTAssertTrue(ranSwiftFormat)
-    XCTAssertTrue(ranSwiftLint)
-    XCTAssertTrue(ranSwiftLintAutocorrect)
-  }
-
   func testLintWithNoViolations() {
     var ranSwiftFormat = false
     var ranSwiftLint = false
@@ -135,6 +94,47 @@ final class AirbnbSwiftFormatToolTest: XCTestCase {
         }))
 
     XCTAssertEqual(error as? ExitCode, ExitCode(SwiftFormatExitCode.lintFailure))
+    XCTAssertTrue(ranSwiftFormat)
+    XCTAssertTrue(ranSwiftLint)
+    XCTAssertTrue(ranSwiftLintAutocorrect)
+  }
+
+  func testFormatWithOnlySwiftLintAutocorrectedViolation() {
+    var ranSwiftFormat = false
+    var ranSwiftLint = false
+    var ranSwiftLintAutocorrect = false
+
+    let error = runFormatTool(
+      with: MockCommands(
+        swiftFormat: {
+          ranSwiftFormat = true
+          return EXIT_SUCCESS
+        },
+        swiftLint: {
+          ranSwiftLint = true
+
+          // Assume that the codebase has violations that would be corrected by SwiftLint autocorrect.
+          if ranSwiftLintAutocorrect {
+            // If SwiftLint autocorrect has already run, then there are no more violations.
+            // This is the expected behavior.
+            return EXIT_SUCCESS
+          } else {
+            // If SwiftLint autocorrect hasn't run yet, then there are still violations.
+            // This should not happen, because we run autocorrect first.
+            return SwiftLintExitCode.lintFailure
+          }
+        },
+        swiftLintAutocorrect: {
+          // Assume that this SwiftLint autocorrect invocation applied a code change.
+          // In this case, SwiftLint still returns a zero exit code.
+          ranSwiftLintAutocorrect = true
+          return EXIT_SUCCESS
+        }))
+
+    // Even though there was a SwiftLint failure, it was autocorrected so doesn't require attention.
+    // The tool should not return an error (e.g. it should return a zero exit code).
+    XCTAssertNil(error)
+
     XCTAssertTrue(ranSwiftFormat)
     XCTAssertTrue(ranSwiftLint)
     XCTAssertTrue(ranSwiftLintAutocorrect)

--- a/Tests/AirbnbSwiftFormatToolTests/AirbnbSwiftFormatToolTests.swift
+++ b/Tests/AirbnbSwiftFormatToolTests/AirbnbSwiftFormatToolTests.swift
@@ -50,15 +50,18 @@ final class AirbnbSwiftFormatToolTest: XCTestCase {
           return EXIT_SUCCESS
         },
         swiftLint: {
-          // If we run autocorrect on a codebase and SwiftLint autocorrect
-          // applies a fix, the SwiftLint lint-only invocation can only
-          // return EXIT_SUCCESS if ran after the autocorrect rule.
-          // (Because if it ran before the autocorrect rule, it would have
-          // seen the failure that was autocorrected before it was fixed).
-          XCTAssert(ranSwiftLintAutocorrect)
           ranSwiftLint = true
 
-          return EXIT_SUCCESS
+          // Assume that the codebase has violations that would be corrected by SwiftLint autocorrect.
+          if ranSwiftLintAutocorrect {
+            // If SwiftLint autocorrect has already run, then there are no more violations.
+            // This is the expected behavior.
+            return EXIT_SUCCESS
+          } else {
+            // If SwiftLint autocorrect hasn't run yet, then there are still violations.
+            // This should not happen, because we run autocorrect first.
+            return SwiftLintExitCode.lintFailure
+          }
         },
         swiftLintAutocorrect: {
           // Assume that this SwiftLint autocorrect invocation applied a code change.
@@ -67,7 +70,10 @@ final class AirbnbSwiftFormatToolTest: XCTestCase {
           return EXIT_SUCCESS
         }))
 
+    // Even though there was a SwiftLint failure, it was autocorrected so doesn't require attention.
+    // The tool should not return an error (e.g. it should return a zero exit code).
     XCTAssertNil(error)
+
     XCTAssertTrue(ranSwiftFormat)
     XCTAssertTrue(ranSwiftLint)
     XCTAssertTrue(ranSwiftLintAutocorrect)


### PR DESCRIPTION
#### Summary

This PR fixes an issue where the package plugin wouldn't run any of the SwiftLint lint-only rules unless we passed in the `--lint` flag (e.g. `swift format format --lint`).

That is, running `swift package format` would only run the SwiftLint rules that included autocorrect, but wouldn't run any of the SwiftLint rules lacking autocorrect.

For SwiftLint to apply autocorrection, you have to pass in the `--fix` flag, but that causes SwiftFormat to not run any of the lint-only rules. As a fix we _always_ run SwiftLint in lint-only mode (without `--fix`) and then additionally run it in autocorrect mode (with `--fix`) if there were lint errors that need to be corrected.

This PR also adds unit tests for the `AirbnbSwiftFormatTool` type, testing its behavior in response to receiving various exit codes from the underlying commands.