### PR TITLE
Soften wording for rule to avoid using default in switch statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -2289,7 +2289,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
-* <a id='switch-never-default'></a>(<a href='#switch-never-default'>link</a>) When switching over an enum, generally prefer enumerating all cases rather than using the `default` case.
+* <a id='switch-avoid-default'></a>(<a href='#switch-avoid-default'>link</a>) When switching over an enum, generally prefer enumerating all cases rather than using the `default` case.
 
   <details>
 
@@ -2322,7 +2322,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
     case success(Success)
     case failure(Error)
 
-    // We don't expect additional cases that may be added to the enumeration affecting this method.
+    // We expect that this property will remain valid if additional cases are added to the enumeration.
     public var isRunning: Bool {
       switch self {
       case .running:
@@ -2334,7 +2334,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
   }
 
   extension TaskState: Equatable {
-    // Explicitly listing each state would be too burdensome. Ideally this function could be implemented with a custom macro.
+    // Explicitly listing each state would be too burdensome. Ideally this function could be implemented with a well-tested macro.
     public static func == (lhs: TaskState, rhs: TaskState) -> Bool {
       switch (lhs, rhs) {
       case (.pending, .pending):

--- a/README.md
+++ b/README.md
@@ -2313,9 +2313,45 @@ _You can enable the following settings in Xcode by running [this script](resourc
     // Stop your vehicle
   }
   
-  This is not always necessary, though:
-   - If the enum is very large, it may be unwieldy or unreasonable to enumerate each case in every switch statement.
-   - If you don't expect to need to exhaustively handle all enum cases added in the future at every call site, using `default` can reduce the overhead of introducing new enum cases.
+  // COUNTEREXAMPLES
+
+  enum TaskState {
+    case pending
+    case running
+    case canceling
+    case success(Success)
+    case failure(Error)
+
+    // We don't expect additional cases that may be added to the enumeration affecting this method.
+    public var isRunning: Bool {
+      switch self {
+      case .running:
+        true
+      default:
+        false
+      }
+    }  
+  }
+
+  extension TaskState: Equatable {
+    // Explicitly listing each state would be too burdensome. Ideally this function could be implemented with a custom macro.
+    public static func == (lhs: TaskState, rhs: TaskState) -> Bool {
+      switch (lhs, rhs) {
+      case (.pending, .pending):
+        true
+      case (.running, .running):
+        true
+      case (.canceling, .canceling):
+        true
+      case (.success, .success):
+        true
+      case (.failure, .failure):
+        true
+      default:
+        false
+      }
+    }
+  }
   ```
 
   </details>

--- a/README.md
+++ b/README.md
@@ -2343,10 +2343,10 @@ _You can enable the following settings in Xcode by running [this script](resourc
         true
       case (.canceling, .canceling):
         true
-      case (.success, .success):
-        true
-      case (.failure, .failure):
-        true
+      case (.success(let lhs), .success(let rhs)):
+        lhs == rhs
+      case (.failure(let lhs), .failure(let rhs)):
+        lhs == rhs
       default:
         false
       }

--- a/README.md
+++ b/README.md
@@ -2289,15 +2289,15 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
-* <a id='switch-never-default'></a>(<a href='#switch-never-default'>link</a>) **Never use the `default` case when `switch`ing over an enum.**
+* <a id='switch-never-default'></a>(<a href='#switch-never-default'>link</a>) When switching over an enum, generally prefer enumerating all cases rather than using the `default` case.
 
   <details>
 
   #### Why?
-  Enumerating every case requires developers and reviewers have to consider the correctness of every switch statement when new cases are added.
+  Enumerating every case requires developers and reviewers have to consider the correctness of every switch statement when new cases are added in the future.
 
   ```swift
-  // WRONG
+  // NOT PREFERRED
   switch trafficLight {
   case .greenLight:
     // Move your vehicle
@@ -2305,13 +2305,17 @@ _You can enable the following settings in Xcode by running [this script](resourc
     // Stop your vehicle
   }
 
-  // RIGHT
+  // PREFERRED
   switch trafficLight {
   case .greenLight:
     // Move your vehicle
   case .yellowLight, .redLight:
     // Stop your vehicle
   }
+  
+  This is not always necessary, though:
+   - If the enum is very large, it may be unwieldy or unreasonable to enumerate each case in every switch statement.
+   - If you don't expect to need to exhaustively handle all enum cases added in the future at every call site, using `default` can reduce the overhead of introducing new enum cases.
   ```
 
   </details>


### PR DESCRIPTION
#### Summary

We have a rule that suggests to avoid using the `default` case when switching over an enum.

This rule is worded pretty strongly ("never use the `default` case"), but lacks autocorrect or linting, so has no enforcement. I also think there are valid reasons to use the default case.

I think we should just soften the wording of this rule (not use strict wording like "never"), since it is still good advice overall.

Some alternatives we could consider:
  1. Add a lint rule to enforce this rule
     - This is too heavy-handed, because there are valid use cases for using `default`. The prose rule includes a set of exceptions where it can make sense to use `default`.
     - This is infeasible, because a linter wouldn't know if we are switching over an enum or not. We may be switching over something that can't be switched over exhaustively, which would require a `default` case. (edit: Michael has suggested some heuristics we could use to reduce the number of false positives here without needing full type information).
  3. Remove this rule completely
     - We don't have many rules that are mere suggestions, without any linter enforcement or autocorrection. We haven't added any _new_ rules like this in many years.
     - I think we should continue to permit this sorts of rule, which makes recommendations that can result in higher-quality code but aren't strictly enforced. This is probably the biggest "expansion opportunity" for the content in our style guide.

#### Reasoning

<!--- required --->

_Please react with 👍/👎 if you agree or disagree with this proposal._
