### PR TITLE
Update to Swift 5.9

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -42,8 +42,8 @@ let package = Package(
 
     .binaryTarget(
       name: "SwiftFormat",
-      url: "https://github.com/calda/SwiftFormat/releases/download/0.53-beta-1/SwiftFormat.artifactbundle.zip",
-      checksum: "a97a1231fd279d826c03611ec89772ee1131805f17f32bb16575bcd373d398a6"),
+      url: "https://github.com/calda/SwiftFormat/releases/download/0.53-beta-3/SwiftFormat.artifactbundle.zip",
+      checksum: "ef7283d3dab42809d3faa812dbad71d4f35cd2863db60bc920128fcc12a36a1e"),
 
     .binaryTarget(
       name: "SwiftLintBinary",

--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -2,7 +2,7 @@
 --exclude Carthage,Pods,.build
 
 # options
---swiftversion 5.8
+--swiftversion 5.9
 --self remove # redundantSelf
 --importgrouping testable-bottom # sortedImports
 --commas always # trailingCommas


### PR DESCRIPTION
This PR updates the default SwiftFormat `--swiftversion` to Swift 5.9, which is the Swift version we now use internally at Airbnb.