### PR TITLE
Update omit-return rule discussion to include examples using if/swift expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2360,6 +2360,22 @@ _You can enable the following settings in Xcode by running [this script](resourc
       preferredStyle: .alert)
   }
 
+  var alertTitle: String {
+    if issue.severity == .critical {
+      return "💥 Critical Error"
+    } else {
+      return "ℹ️ Info"
+  }
+
+  func type(of planet: Planet) -> PlanetType {
+    switch planet {
+    case .mercury, .venus, .earth, .mars:
+      return .terrestrial
+    case .jupiter, .saturn, .uranus, .neptune:
+      return .gasGiant
+    }
+  }
+
   // RIGHT
   ["1", "2", "3"].compactMap { Int($0) }
 
@@ -2374,6 +2390,22 @@ _You can enable the following settings in Xcode by running [this script](resourc
       title: "ℹ️ Info",
       message: message,
       preferredStyle: .alert)
+  }
+
+  var alertTitle: String {
+    if issue.severity == .critical {
+      "💥 Critical Error"
+    } else {
+      "ℹ️ Info"
+  }
+
+  func type(of planet: Planet) -> PlanetType {
+    switch planet {
+    case .mercury, .venus, .earth, .mars:
+      .terrestrial
+    case .jupiter, .saturn, .uranus, .neptune:
+      .gasGiant
+    }
   }
   ```
 


### PR DESCRIPTION
Now that we use [Swift 5.9](https://github.com/airbnb/swift/pull/248), the existing omit-return rule now also applies to functions / properties that have single-expression if/switch statements. Let's add some examples using this syntax to make it explicit that this existing rule applies to those cases. This is also potentially good educational content for anyone who doesn't know that this is permitted now.