### PR TITLE
Specify `--shortoptionals always` option explicitly since default was updated to `except-properties`

### DIFF
--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -33,6 +33,7 @@
 --elseposition same-line #elseOnSameLine
 --guardelse next-line #elseOnSameLine
 --oneLineForEach wrap #preferForLoop
+--shortoptionals always #typeSugar
 
 # We recommend a max width of 100 but _strictly enforce_ a max width of 130
 --maxwidth 130 # wrap


### PR DESCRIPTION
#### Summary

The default value of the `--shortoptionals` rule was changed from `always` to `except-properties` in https://github.com/nicklockwood/SwiftFormat/commit/5ec0a9413c7a2f22901ab9008fec7620cc75d14f. 

In anticipation of this change, let's explicitly list the `--shortoptionals always` option. This preserves the existing behavior of the `typeSugar` rule.
