### PR TITLE
Use `sortImports` rule instead of deprecated `sortedImports` rule

### DIFF
--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -55,7 +55,7 @@
 --rules redundantGet
 --rules redundantFileprivate
 --rules redundantRawValues
---rules sortedImports
+--rules sortImports
 --rules sortDeclarations
 --rules strongifiedSelf
 --rules trailingCommas


### PR DESCRIPTION
When running `swift package format`, we get this deprecation warning about the `sortedImports` rule:

> warning: sortedImports rule is deprecated. Use sortImports instead.

This PR removes the deprecated `sortedImports` rule in favor of the `sortImports` rule which replaces it.