### PR TITLE
Add rule to add a line break after the assignment operator before a multi-line `if` or `switch` expressions

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -42,8 +42,8 @@ let package = Package(
 
     .binaryTarget(
       name: "SwiftFormat",
-      url: "https://github.com/calda/SwiftFormat/releases/download/0.53-beta-3/SwiftFormat.artifactbundle.zip",
-      checksum: "ef7283d3dab42809d3faa812dbad71d4f35cd2863db60bc920128fcc12a36a1e"),
+      url: "https://github.com/calda/SwiftFormat/releases/download/0.53-beta-4/SwiftFormat.artifactbundle.zip",
+      checksum: "8506e9f6a434127f9eabe62c0a0349ccfd1e12e7cd7a96ba6a0c8f9d4a596099"),
 
     .binaryTarget(
       name: "SwiftLintBinary",

--- a/README.md
+++ b/README.md
@@ -900,6 +900,79 @@ _You can enable the following settings in Xcode by running [this script](resourc
     …
   }
   ```
+  
+  </details>
+
+* <a id='wrap-multiline-conditional-assignment'></a>(<a href='#wrap-multiline-conditional-assignment'>link</a>) **Add a line break after the assignment operator (`=`) before a multi-line `if` or `switch` expression**, and indent the following `if` / `switch` expression. If the declaration fits on a single line, a line break not required. [![SwiftFormat: wrapMultilineConditionalAssignment](https://img.shields.io/badge/SwiftFormat-wrapMultilineConditionalAssignment-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapMultilineConditionalAssignment)
+
+  <details>
+
+  #### Why?
+  
+  This makes it so that `if` and `switch` expressions always have the same "shape" as standard `if` and `switch` statements, where:
+  1. The `if` / `switch` keyword is always the left-most token on a dedicated line of code
+  2. The conditional branches are always to the right of and below the `if` / `switch` keyword
+
+  This is most consistent with the formatting of `if` / `switch` statements in other contexts, and thus makes it easier to recognize that the code is using an `if` or `switch` expression at a glance. 
+  
+  ```swift
+  // WRONG. Should have a line break after the `=`. 
+  let planetLocation = if let star = planet.star {
+    "The \(star.name) system"
+   } else {
+    "Rogue planet"
+  }
+
+  // WRONG. The `=` should be on the line before the `if` / `switch` expression. 
+  let planetLocation 
+    = if let star = planet.star {
+      "The \(star.name) system"
+    } else {
+      "Rogue planet"
+    }
+
+  // WRONG. `if` expression should be indented.
+  let planetLocation =
+  if let star = planet.star {
+    "The \(star.name) system"
+  } else {
+    "Rogue planet"
+  }
+    
+  // RIGHT 
+  let planetLocation = 
+    if let star = planet.star {
+      "The \(star.name) system"
+    } else {
+      "Rogue planet"
+    }
+    
+  // RIGHT 
+  let planetLocation = 
+    if let star = planet.star {
+      "The \(star.name) system"
+    } else {
+      "Rogue planet"
+    }
+    
+  // RIGHT
+  let planetType: PlanetType =
+    switch planet {
+    case .mercury, .venus, .earth, .mars:
+      .terrestrial
+    case .jupiter, .saturn, .uranus, .neptune:
+      .gasGiant
+    }
+    
+  // ALSO RIGHT. A line break is not required because the declaration fits on a single line. 
+  let planet = if useFirst { mercury } else { neptune }
+
+  // ALSO RIGHT. A line break is permitted if it helps with readability.
+  let planet =
+    if useFirst { mercury } else { neptune }
+  ```
+  
+  </details>
 
 * <a id='wrap-guard-else'></a>(<a href='#wrap-guard-else'>link</a>) **Add a line break before the `else` keyword in a multi-line guard statement.** For single-line guard statements, keep the `else` keyword on the same line as the `guard` keyword. The open brace should immediately follow the `else` keyword. [![SwiftFormat: elseOnSameLine](https://img.shields.io/badge/SwiftFormat-elseOnSameLine-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#elseOnSameLine)
 

--- a/README.md
+++ b/README.md
@@ -903,7 +903,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
   
   </details>
 
-* <a id='wrap-multiline-conditional-assignment'></a>(<a href='#wrap-multiline-conditional-assignment'>link</a>) **Add a line break after the assignment operator (`=`) before a multi-line `if` or `switch` expression**, and indent the following `if` / `switch` expression. If the declaration fits on a single line, a line break not required. [![SwiftFormat: wrapMultilineConditionalAssignment](https://img.shields.io/badge/SwiftFormat-wrapMultilineConditionalAssignment-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapMultilineConditionalAssignment)
+* <a id='wrap-multiline-conditional-assignment'></a>(<a href='#wrap-multiline-conditional-assignment'>link</a>) **Add a line break after the assignment operator (`=`) before a multi-line `if` or `switch` expression**, and indent the following `if` / `switch` expression. If the declaration fits on a single line, a line break is not required. [![SwiftFormat: wrapMultilineConditionalAssignment](https://img.shields.io/badge/SwiftFormat-wrapMultilineConditionalAssignment-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapMultilineConditionalAssignment)
 
   <details>
 
@@ -913,17 +913,17 @@ _You can enable the following settings in Xcode by running [this script](resourc
   1. The `if` / `switch` keyword is always the left-most token on a dedicated line of code
   2. The conditional branches are always to the right of and below the `if` / `switch` keyword
 
-  This is most consistent with the formatting of `if` / `switch` statements in other contexts, and thus makes it easier to recognize that the code is using an `if` or `switch` expression at a glance. 
+  This is most consistent with how the `if` / `switch` keywords are used for control flow, and thus makes it easier to recognize that the code is using an `if` or `switch` expression at a glance. 
   
   ```swift
-  // WRONG. Should have a line break after the `=`. 
+  // WRONG. Should have a line break after the first `=`. 
   let planetLocation = if let star = planet.star {
     "The \(star.name) system"
    } else {
     "Rogue planet"
   }
 
-  // WRONG. The `=` should be on the line before the `if` / `switch` expression. 
+  // WRONG. The first `=` should be on the line of the variable being assigned.
   let planetLocation 
     = if let star = planet.star {
       "The \(star.name) system"
@@ -938,14 +938,6 @@ _You can enable the following settings in Xcode by running [this script](resourc
   } else {
     "Rogue planet"
   }
-    
-  // RIGHT 
-  let planetLocation = 
-    if let star = planet.star {
-      "The \(star.name) system"
-    } else {
-      "Rogue planet"
-    }
     
   // RIGHT 
   let planetLocation = 

--- a/README.md
+++ b/README.md
@@ -931,12 +931,13 @@ _You can enable the following settings in Xcode by running [this script](resourc
       "Rogue planet"
     }
 
-  // WRONG. `if` expression should be indented.
+  // WRONG. `switch` expression should be indented.
   let planetLocation =
-  if let star = planet.star {
-    "The \(star.name) system"
-  } else {
-    "Rogue planet"
+  switch planet {
+  case .mercury, .venus, .earth, .mars:
+    .terrestrial
+  case .jupiter, .saturn, .uranus, .neptune:
+    .gasGiant
   }
     
   // RIGHT 
@@ -957,11 +958,11 @@ _You can enable the following settings in Xcode by running [this script](resourc
     }
     
   // ALSO RIGHT. A line break is not required because the declaration fits on a single line. 
-  let planet = if useFirst { mercury } else { neptune }
+  let moonName = if let moon = planet.moon { moon.name } else { "none" }
 
   // ALSO RIGHT. A line break is permitted if it helps with readability.
-  let planet =
-    if useFirst { mercury } else { neptune }
+  let moonName =
+    if let moon = planet.moon { moon.name } else { "none" }
   ```
   
   </details>

--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -91,3 +91,4 @@
 --rules elseOnSameLine
 --rules sortTypealiases
 --rules preferForLoop
+--rules wrapMultilineConditionalAssignment


### PR DESCRIPTION
#### Summary

This PR proposes a new rule to add a line break after the assignment operator before a multi-line `if` or `switch` expression.

Autocorrection for this rule is implemented in the `wrapMultilineConditionalAssignment` SwiftFormat rule, added in https://github.com/nicklockwood/SwiftFormat/pull/1574.

#### Reasoning

This makes it so that `if` and `switch` expressions always have the same "shape" as standard `if` and `switch` statements, where:
1. The `if` / `switch` keyword is always the left-most token on a dedicated line of code
2. The conditional branches are always to the right of and below the `if` / `switch` keyword.

This is most consistent with the formatting of `if` / `switch` statements in other contexts, and thus makes it easier to recognize that the code is using an `if` or `switch` expression at a glance.

This is independent of #250 and could be accepted even if we reject #250, but #250 depends on these changes given the discussion [here](https://github.com/airbnb/swift/pull/250#issuecomment-1797079165).

#### Examples

```swift
// WRONG. Should have a line break after the `=`. 
let planetLocation = if let star = planet.star {
  "The \(star.name) system"
 } else {
  "Rogue planet"
}

// WRONG. The `=` should be on the line before the `if` / `switch` expression. 
let planetLocation 
  = if let star = planet.star {
    "The \(star.name) system"
  } else {
    "Rogue planet"
  }
  
// RIGHT 
let planetLocation = 
  if let star = planet.star {
    "The \(star.name) system"
  } else {
    "Rogue planet"
  }
  
// RIGHT 
let planetLocation = 
  if let star = planet.star {
    "The \(star.name) system"
  } else {
    "Rogue planet"
  }
  
// RIGHT
let planetType: PlanetType =
  switch planet {
  case .mercury, .venus, .earth, .mars:
    .terrestrial
  case .jupiter, .saturn, .uranus, .neptune:
    .gasGiant
  }
  
// ALSO RIGHT. A line break is not required because the declaration fits on a single line. 
let planet = if useFirst { mercury } else { neptune }

// ALSO RIGHT. A line break is always permitted if it helps with readability.
let planet =
  if useFirst { mercury } else { neptune }
```

_Please react with 👍/👎 if you agree or disagree with this proposal._
