### PR TITLE
Fix typographical error

### DIFF
--- a/Plugins/FormatSwift/Plugin.swift
+++ b/Plugins/FormatSwift/Plugin.swift
@@ -67,7 +67,7 @@ struct AirbnbSwiftFormatPlugin {
 
 }
 
-// MARK: CommandPlugin
+// MARK: - CommandPlugin
 
 extension AirbnbSwiftFormatPlugin: CommandPlugin {
 

--- a/Sources/AirbnbSwiftFormatTool/AirbnbSwiftFormatTool.swift
+++ b/Sources/AirbnbSwiftFormatTool/AirbnbSwiftFormatTool.swift
@@ -110,7 +110,7 @@ struct AirbnbSwiftFormatTool: ParsableCommand {
     }
 
     if let swiftVersion = swiftVersion {
-      arguments += ["--swiftversion", swiftVersion]
+      arguments += ["--swiftVersion", swiftVersion]
     }
 
     return Command(
@@ -145,7 +145,7 @@ struct AirbnbSwiftFormatTool: ParsableCommand {
 
   private func log(_ string: String) {
     // swiftlint:disable:next no_direct_standard_out_logs
-    print("[AibnbSwiftFormatTool]", string)
+    print("[AirbnbSwiftFormatTool]", string)
   }
 
 }


### PR DESCRIPTION
#### Summary

They were not critical errors, but I corrected a few typos.

#### Reasoning

1. `CommandPlugin` is major category but `-` was missing in the annotation.
2. `swiftversion` was not written in lowerCamelCase.
3. Letter `r` was missing in `AibnbSwiftFormatTool`


