### PR TITLE
Add rule to insert a blank line following a switch case with a multi-line body

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -42,8 +42,8 @@ let package = Package(
 
     .binaryTarget(
       name: "SwiftFormat",
-      url: "https://github.com/calda/SwiftFormat/releases/download/0.54-beta-1/SwiftFormat.artifactbundle.zip",
-      checksum: "7f64c3d30179e6c51dc995ac6dd4b910def710325c62d3b4f1806c0e7f5d197b"),
+      url: "https://github.com/calda/SwiftFormat/releases/download/0.54-beta-2/SwiftFormat.artifactbundle.zip",
+      checksum: "6bb4c6c2431686579c99a1bc6a7370c6c2f9c60a13c89d4f8d82cba221147e40"),
 
     .binaryTarget(
       name: "SwiftLintBinary",

--- a/README.md
+++ b/README.md
@@ -1240,7 +1240,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
-* <a id='blank-line-after-multiline-switch-case'></a>(<a href='#blank-line-after-multiline-switch-case'>link</a>) **Insert a blank line following a switch case with a multi-line body.** For consistency within a switch statement, if any case has a multi-line body then all cases should include a trailing blank line. The last switch case doesn't need a blank line, since it is already followed by a closing brace. [![SwiftFormat: blankLineAfterMultilineSwitchCase](https://img.shields.io/badge/SwiftFormat-blankLineAfterMultilineSwitchCase-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#blankLineAfterMultilineSwitchCase) [![SwiftFormat: consistentSwitchStatementSpacing](https://img.shields.io/badge/SwiftFormat-consistentSwitchStatementSpacing-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#consistentSwitchStatementSpacing)
+* <a id='blank-line-after-multiline-switch-case'></a>(<a href='#blank-line-after-multiline-switch-case'>link</a>) **Insert a blank line following a switch case with a multi-line body.** Spacing within an individual switch statement should be consistent. If any case has a multi-line body then all cases should include a trailing blank line. The last switch case doesn't need a blank line, since it is already followed by a closing brace. [![SwiftFormat: blankLineAfterMultilineSwitchCase](https://img.shields.io/badge/SwiftFormat-blankLineAfterMultilineSwitchCase-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#blankLineAfterMultilineSwitchCase) [![SwiftFormat: consistentSwitchStatementSpacing](https://img.shields.io/badge/SwiftFormat-consistentSwitchStatementSpacing-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#consistentSwitchStatementSpacing)
 
   <details>
 
@@ -1384,6 +1384,21 @@ _You can enable the following settings in Xcode by running [this script](resourc
     case .enableArtificialGravity:
         artificialGravityEngine.enable(strength: .oneG)
 
+    case .scanPlanet(let planet):
+        scanner.scan(planet)
+
+    case .handleIncomingEnergyBlast:
+        energyShields.engage()
+    }
+  }
+
+  // WRONG. While it's fine to use blank lines to separate cases, spacing within a single switch statement should be consistent.
+  func handle(_ action: SpaceshipAction) {
+    switch action {
+    case .engageWarpDrive:
+        warpDrive.engage()
+    case .enableArtificialGravity:
+        artificialGravityEngine.enable(strength: .oneG)
     case .scanPlanet(let planet):
         scanner.scan(planet)
 

--- a/README.md
+++ b/README.md
@@ -1240,6 +1240,161 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
+* <a id='blank-line-after-multiline-switch-case'></a>(<a href='#blank-line-after-multiline-switch-case'>link</a>) **Insert a blank line following a switch case with a multi-line body.** For consistency within a switch statement, if any case has a multi-line body then all cases should include a trailing blank line. The last switch case doesn't need a blank line, since it is already followed by a closing brace. [![SwiftFormat: blankLineAfterMultilineSwitchCase](https://img.shields.io/badge/SwiftFormat-blankLineAfterMultilineSwitchCase-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#blankLineAfterMultilineSwitchCase) [![SwiftFormat: consistentSwitchStatementSpacing](https://img.shields.io/badge/SwiftFormat-consistentSwitchStatementSpacing-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#consistentSwitchStatementSpacing)
+
+  <details>
+
+  #### Why?
+
+  Like with [declarations in a file](https://github.com/airbnb/swift#newline-between-scope-siblings), inserting a blank line between scopes makes them easier to visually differentiate.
+  
+  Switch statements with multi-lines lines can become visiually busy and cramped without blank lines between the cases. In this example, all of the cases start to bleed together, making it more difficult to read the code at a glance:
+
+  ```swift
+  func handle(_ action: SpaceshipAction) {
+    switch action {
+    case .engageWarpDrive:
+      navigationComputer.destination = targetedDestination
+      warpDrive.spinUp()
+      warpDrive.activate()
+    case .enableArtificialGravity:
+      artificialGravityEngine.enable(strength: .oneG)
+    case .scanPlanet(let planet):
+      scanner.target = planet
+      scanner.scanAtmosphere()
+      scanner.scanBiosphere()
+      scanner.scanForArtificialLife()
+    case .handleIncomingEnergyBlast:
+      energyShields.engage()
+    }
+  }
+  ```
+
+  Blank lines between the individual cases make the switch statement much easier to read:
+
+  ```swift
+  func handle(_ action: SpaceshipAction) {
+    switch action {
+    case .engageWarpDrive:
+      navigationComputer.destination = targetedDestination
+      warpDrive.spinUp()
+      warpDrive.activate()
+
+    case .enableArtificialGravity:
+      artificialGravityEngine.enable(strength: .oneG)
+
+    case .scanPlanet(let planet):
+      scanner.target = planet
+      scanner.scanAtmosphere()
+      scanner.scanBiosphere()
+      scanner.scanForArtificialLife()
+
+    case .handleIncomingEnergyBlast:
+      energyShields.engage()
+    }
+  }
+  ```
+
+  #### Examples
+
+  ```swift
+  // WRONG. These switch cases should be followed by a blank line.
+  func handle(_ action: SpaceshipAction) {
+    switch action {
+    case .engageWarpDrive:
+      navigationComputer.destination = targetedDestination
+      warpDrive.spinUp()
+      warpDrive.activate()
+    case .enableArtificialGravity:
+      artificialGravityEngine.enable(strength: .oneG)
+    case .scanPlanet(let planet):
+      scanner.target = planet
+      scanner.scanAtmosphere()
+      scanner.scanBiosphere()
+      scanner.scanForArtificialLife()
+    case .handleIncomingEnergyBlast:
+      energyShields.engage()
+    }
+  }
+
+  // WRONG. While the `.enableArtificialGravity` case isn't multi-line, the other cases are.
+  // For consistency, it should also include a trailing blank line.
+  func handle(_ action: SpaceshipAction) {
+    switch action {
+    case .engageWarpDrive:
+      navigationComputer.destination = targetedDestination
+      warpDrive.spinUp()
+      warpDrive.activate()
+
+    case .enableArtificialGravity:
+      artificialGravityEngine.enable(strength: .oneG)
+    case .scanPlanet(let planet):
+      scanner.target = planet
+      scanner.scanAtmosphere()
+      scanner.scanBiosphere()
+      scanner.scanForArtificialLife()
+      
+    case .handleIncomingEnergyBlast:
+      energyShields.engage()
+    }
+  }
+
+  // RIGHT. All of the cases have a trailing blank line.
+  func handle(_ action: SpaceshipAction) {
+    switch action {
+    case .engageWarpDrive:
+      navigationComputer.destination = targetedDestination
+      warpDrive.spinUp()
+      warpDrive.activate()
+
+    case .enableArtificialGravity:
+      artificialGravityEngine.enable(strength: .oneG)
+
+    case .scanPlanet(let planet):
+      scanner.target = planet
+      scanner.scanAtmosphere()
+      scanner.scanBiosphere()
+      scanner.scanForArtificialLife()
+      
+    case .handleIncomingEnergyBlast:
+      energyShields.engage()
+    }
+  }
+
+  // RIGHT. Since none of the cases are multi-line, blank lines are not required.
+  func handle(_ action: SpaceshipAction) {
+    switch action {
+    case .engageWarpDrive:
+        warpDrive.engage()
+    case .enableArtificialGravity:
+        artificialGravityEngine.enable(strength: .oneG)
+    case .scanPlanet(let planet):
+        scanner.scan(planet)
+    case .handleIncomingEnergyBlast:
+        energyShields.engage()
+    }
+  }
+
+  // ALSO RIGHT. Blank lines are still permitted after single-line switch cases if it helps with readability.
+  func handle(_ action: SpaceshipAction) {
+    switch action {
+    case .engageWarpDrive:
+        warpDrive.engage()
+
+    case .enableArtificialGravity:
+        artificialGravityEngine.enable(strength: .oneG)
+
+    case .scanPlanet(let planet):
+        scanner.scan(planet)
+
+    case .handleIncomingEnergyBlast:
+        energyShields.engage()
+    }
+  }
+  ```
+
+  </details>
+
 * <a id='wrap-guard-else'></a>(<a href='#wrap-guard-else'>link</a>) **Add a line break before the `else` keyword in a multi-line guard statement.** For single-line guard statements, keep the `else` keyword on the same line as the `guard` keyword. The open brace should immediately follow the `else` keyword. [![SwiftFormat: elseOnSameLine](https://img.shields.io/badge/SwiftFormat-elseOnSameLine-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#elseOnSameLine)
 
   <details>

--- a/README.md
+++ b/README.md
@@ -1246,54 +1246,9 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   #### Why?
 
-  Like with [declarations in a file](https://github.com/airbnb/swift#newline-between-scope-siblings), inserting a blank line between scopes makes them easier to visually differentiate.
+  Like with [declarations in a file](#newline-between-scope-siblings), inserting a blank line between scopes makes them easier to visually differentiate.
   
-  Switch statements with multi-lines lines can become visiually busy and cramped without blank lines between the cases. In this example, all of the cases start to bleed together, making it more difficult to read the code at a glance:
-
-  ```swift
-  func handle(_ action: SpaceshipAction) {
-    switch action {
-    case .engageWarpDrive:
-      navigationComputer.destination = targetedDestination
-      warpDrive.spinUp()
-      warpDrive.activate()
-    case .enableArtificialGravity:
-      artificialGravityEngine.enable(strength: .oneG)
-    case .scanPlanet(let planet):
-      scanner.target = planet
-      scanner.scanAtmosphere()
-      scanner.scanBiosphere()
-      scanner.scanForArtificialLife()
-    case .handleIncomingEnergyBlast:
-      energyShields.engage()
-    }
-  }
-  ```
-
-  Blank lines between the individual cases make the switch statement much easier to read:
-
-  ```swift
-  func handle(_ action: SpaceshipAction) {
-    switch action {
-    case .engageWarpDrive:
-      navigationComputer.destination = targetedDestination
-      warpDrive.spinUp()
-      warpDrive.activate()
-
-    case .enableArtificialGravity:
-      artificialGravityEngine.enable(strength: .oneG)
-
-    case .scanPlanet(let planet):
-      scanner.target = planet
-      scanner.scanAtmosphere()
-      scanner.scanBiosphere()
-      scanner.scanForArtificialLife()
-
-    case .handleIncomingEnergyBlast:
-      energyShields.engage()
-    }
-  }
-  ```
+  Complex switch statements are visually busy without blank lines between the cases, making it more difficult to read the code and harder to distinguish between individual cases at a glance. Blank lines between the individual cases make complex switch statements easier to read.
 
   #### Examples
 

--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -97,3 +97,5 @@
 --rules preferForLoop
 --rules conditionalAssignment
 --rules wrapMultilineConditionalAssignment
+--rules blankLineAfterMultilineSwitchCase
+--rules consistentSwitchStatementSpacing


### PR DESCRIPTION
#### Summary

This PR proposes a new rule to insert a blank line following a switch case with a multi-line body:

> **Insert a blank line following a switch case with a multi-line body.** Spacing within an individual switch statement should be consistent. If any case has a multi-line body then all cases should include a trailing blank line. The last switch case doesn't need a blank line, since it is already followed by a closing brace.

Autocorrect is implemented in the `blankLineAfterMultilineSwitchCase` and `consistentSwitchStatementSpacing` SwiftFormat rules, which were added in https://github.com/nicklockwood/SwiftFormat/pull/1621.

#### Reasoning

Like with [declarations in a file](https://github.com/airbnb/swift#newline-between-scope-siblings), inserting a blank line between scopes makes them easier to visually differentiate.

Switch statements with multi-line cases can become visually busy and cramped without blank lines between the cases. In this example, all of the cases start to bleed together, making it more difficult to read the code at a glance:

```swift
func handle(_ action: SpaceshipAction) {
  switch action {
  case .engageWarpDrive:
    navigationComputer.destination = targetedDestination
    warpDrive.spinUp()
    warpDrive.activate()
  case .enableArtificialGravity:
    artificialGravityEngine.enable(strength: .oneG)
  case .scanPlanet(let planet):
    scanner.target = planet
    scanner.scanAtmosphere()
    scanner.scanBiosphere()
    scanner.scanForArtificialLife()
  case .handleIncomingEnergyBlast:
    energyShields.engage()
  }
}
```

Blank lines between the individual cases make the switch statement much easier to read:

```swift
func handle(_ action: SpaceshipAction) {
  switch action {
  case .engageWarpDrive:
    navigationComputer.destination = targetedDestination
    warpDrive.spinUp()
    warpDrive.activate()

  case .enableArtificialGravity:
    artificialGravityEngine.enable(strength: .oneG)

  case .scanPlanet(let planet):
    scanner.target = planet
    scanner.scanAtmosphere()
    scanner.scanBiosphere()
    scanner.scanForArtificialLife()

  case .handleIncomingEnergyBlast:
    energyShields.engage()
  }
}
```

Blank lines are not required in cases where all of the switch cases are a single line, but are still permitted if it helps with readability:

```swift
// RIGHT. Since none of the cases are multi-line, blank lines are not required.
func handle(_ action: SpaceshipAction) {
  switch action {
  case .engageWarpDrive:
      warpDrive.engage()
  case .enableArtificialGravity:
      artificialGravityEngine.enable(strength: .oneG)
  case .scanPlanet(let planet):
      scanner.scan(planet)
  case .handleIncomingEnergyBlast:
      energyShields.engage()
  }
}

// ALSO RIGHT. Blank lines are still permitted after single-line switch cases if it helps with readability. 
func handle(_ action: SpaceshipAction) {
  switch action {
  case .engageWarpDrive:
      warpDrive.engage()

  case .enableArtificialGravity:
      artificialGravityEngine.enable(strength: .oneG)

  case .scanPlanet(let planet):
      scanner.scan(planet)

  case .handleIncomingEnergyBlast:
      energyShields.engage()
  }
}
```

_Please react with 👍/👎 if you agree or disagree with this proposal._
