### PR TITLE
Add rule to avoid using semicolons

### DIFF
--- a/README.md
+++ b/README.md
@@ -2148,6 +2148,44 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
+* <a id='no-semicolons'></a>(<a href='#no-semicolons'>link</a>) **Avoid using semicolons.** Semicolons are not required at the end of a line, so should be omitted. While you can use semicolons to place two statements on the same line, it is more common and preferred to separate them using a newline instead. [![SwiftFormat: semicolons](https://img.shields.io/badge/SwiftFormat-semicolons-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#semicolons)
+
+  <details>
+
+  ### Examples
+
+  ```swift
+  /// WRONG. Semicolons are not required and can be omitted.
+  let mercury = planets[0];
+  let venus = planets[1];
+  let earth = planets[2];
+
+  /// WRONG. While you can use semicolons to place multiple statements on a single line,
+  // it is more common and preferred to separate them using newlines instead.
+  let mercury = planets[0]; let venus = planets[1]; let earth = planets[2];
+
+  /// RIGHT
+  let mercury = planets[0]
+  let venus = planets[1]
+  let earth = planets[2]
+
+  // WRONG
+  guard let moon = planet.moon else { completion(nil); return }
+
+  // WRONG
+  guard let moon = planet.moon else { 
+    completion(nil); return
+  }
+
+  // RIGHT
+  guard let moon = planet.moon else { 
+    completion(nil)
+    return
+  }
+  ```
+
+  </details>
+
 **[⬆ back to top](#table-of-contents)**
 
 ## Patterns

--- a/README.md
+++ b/README.md
@@ -2155,16 +2155,16 @@ _You can enable the following settings in Xcode by running [this script](resourc
   ### Examples
 
   ```swift
-  /// WRONG. Semicolons are not required and can be omitted.
+  // WRONG. Semicolons are not required and can be omitted.
   let mercury = planets[0];
   let venus = planets[1];
   let earth = planets[2];
 
-  /// WRONG. While you can use semicolons to place multiple statements on a single line,
+  // WRONG. While you can use semicolons to place multiple statements on a single line,
   // it is more common and preferred to separate them using newlines instead.
   let mercury = planets[0]; let venus = planets[1]; let earth = planets[2];
 
-  /// RIGHT
+  // RIGHT
   let mercury = planets[0]
   let venus = planets[1]
   let earth = planets[2]

--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -37,6 +37,7 @@
 --guardelse next-line #elseOnSameLine
 --onelineforeach convert #preferForLoop
 --shortoptionals always #typeSugar
+--semicolons never #semicolons
 
 # We recommend a max width of 100 but _strictly enforce_ a max width of 130
 --maxwidth 130 # wrap
@@ -97,3 +98,4 @@
 --rules preferForLoop
 --rules conditionalAssignment
 --rules wrapMultilineConditionalAssignment
+--rules semicolons


### PR DESCRIPTION
#### Summary

This PR proposes a new rule to avoid using semicolons.

#### Reasoning

Semicolons are not required at the end of a line, so should be omitted. While you can use semicolons to place two statements on the same line, it is more common and preferred to separate them using a newline instead.

#### Examples

```swift
/// WRONG. Semicolons are not required and can be omitted.
let mercury = planets[0];
let venus = planets[1];
let earth = planets[2];

// WRONG. While you can use semicolons to place multiple statements on a single line,
// it is more common and preferred to separate them using newlines instead.
let mercury = planets[0]; let venus = planets[1]; let earth = planets[2];

// RIGHT
let mercury = planets[0]
let venus = planets[1]
let earth = planets[2]

// WRONG
guard let moon = planet.moon else { completion(nil); return }

// WRONG
guard let moon = planet.moon else { 
  completion(nil); return
}

// RIGHT
guard let moon = planet.moon else { 
  completion(nil)
  return
}
```

_Please react with 👍/👎 if you agree or disagree with this proposal._
