### PR TITLE
Correct indentation in multi-line switch case

### DIFF
--- a/README.md
+++ b/README.md
@@ -1320,13 +1320,13 @@ _You can enable the following settings in Xcode by running [this script](resourc
   func handle(_ action: SpaceshipAction) {
     switch action {
     case .engageWarpDrive:
-        warpDrive.engage()
+      warpDrive.engage()
     case .enableArtificialGravity:
-        artificialGravityEngine.enable(strength: .oneG)
+      artificialGravityEngine.enable(strength: .oneG)
     case .scanPlanet(let planet):
-        scanner.scan(planet)
+      scanner.scan(planet)
     case .handleIncomingEnergyBlast:
-        energyShields.engage()
+      energyShields.engage()
     }
   }
 
@@ -1334,16 +1334,16 @@ _You can enable the following settings in Xcode by running [this script](resourc
   func handle(_ action: SpaceshipAction) {
     switch action {
     case .engageWarpDrive:
-        warpDrive.engage()
+      warpDrive.engage()
 
     case .enableArtificialGravity:
-        artificialGravityEngine.enable(strength: .oneG)
+      artificialGravityEngine.enable(strength: .oneG)
 
     case .scanPlanet(let planet):
-        scanner.scan(planet)
+      scanner.scan(planet)
 
     case .handleIncomingEnergyBlast:
-        energyShields.engage()
+      energyShields.engage()
     }
   }
 
@@ -1351,14 +1351,14 @@ _You can enable the following settings in Xcode by running [this script](resourc
   func handle(_ action: SpaceshipAction) {
     switch action {
     case .engageWarpDrive:
-        warpDrive.engage()
+      warpDrive.engage()
     case .enableArtificialGravity:
-        artificialGravityEngine.enable(strength: .oneG)
+      artificialGravityEngine.enable(strength: .oneG)
     case .scanPlanet(let planet):
-        scanner.scan(planet)
+      scanner.scan(planet)
 
     case .handleIncomingEnergyBlast:
-        energyShields.engage()
+      energyShields.engage()
     }
   }
   ```


### PR DESCRIPTION
#### Summary

- This PR corrects indentation inconsistencies in `switch case with a multi-line body`.

#### Reasoning

- By the basic rule itself. :) "Use 2 spaces to indent lines."

_Please react with 👍/👎 if you agree or disagree with this proposal._