### PR TITLE
Add rule to infer property types from the right-hand-side value rather than writing the type explicitly on the left-hand side

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -42,8 +42,8 @@ let package = Package(
 
     .binaryTarget(
       name: "SwiftFormat",
-      url: "https://github.com/calda/SwiftFormat/releases/download/0.54-beta-4/SwiftFormat.artifactbundle.zip",
-      checksum: "65335d1e059714d570ee6dbe76d3738fbae3a404dafb109371a6a55670b5bcd7"),
+      url: "https://github.com/calda/SwiftFormat/releases/download/0.54-beta-5/SwiftFormat.artifactbundle.zip",
+      checksum: "7447986db45a51164d23672c07f971406a4c0589b0c423fcb85e95ed8f8e7e48"),
 
     .binaryTarget(
       name: "SwiftLintBinary",

--- a/Package.swift
+++ b/Package.swift
@@ -42,8 +42,8 @@ let package = Package(
 
     .binaryTarget(
       name: "SwiftFormat",
-      url: "https://github.com/calda/SwiftFormat/releases/download/0.54-beta-5/SwiftFormat.artifactbundle.zip",
-      checksum: "7447986db45a51164d23672c07f971406a4c0589b0c423fcb85e95ed8f8e7e48"),
+      url: "https://github.com/calda/SwiftFormat/releases/download/0.54-beta-7/SwiftFormat.artifactbundle.zip",
+      checksum: "0cf117050e7838f545009bfe4a75dbda98cff737cb847a7d065a89683e9e890a"),
 
     .binaryTarget(
       name: "SwiftLintBinary",

--- a/README.md
+++ b/README.md
@@ -388,7 +388,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   // ALSO RIGHT: Explicit types can be necessary when the right-hand side has
   // a different type from the one written explicitly on the left-hand side.
-  let nautralSatellite: PlanetaryBody? = Moon(mass: 7.347e22)
+  let naturalSatellite: PlanetaryBody? = Moon(mass: 7.347e22)
   let moon: PlanetaryBody? = nil // nil literals are typeless
   let numberOfPlanets: UInt = 8 // integer literals default to `Int`
   let sunMass: CGFloat = 1.989e30 // floating-point literals default to `Double`
@@ -399,6 +399,40 @@ _You can enable the following settings in Xcode by running [this script](resourc
   let numberOfPlanets = UInt(8)
   let sunMass = CGFloat(1.989e30)
   let planets = [Planet]()
+  ```
+  
+  There are some rarer cases where the inferred type syntax has a different meaning than the explicit type syntax. In these cases, the explicit type syntax is still permitted:
+  
+  ```swift
+  extension String {
+    static let earth = "Earth"
+  }
+
+  // RIGHT: If the property's type is optional, moving the optional type 
+  // to the right-hand side may result in invalid code.  
+  let planetName: String? = .earth
+  
+  // WRONG: fails with "error: type 'String?' has no member 'foo'"
+  let planetName = String?.earth
+  ```
+  
+  ```swift
+  struct SaturnOutline: ShapeStyle { ... }
+  
+  extension ShapeStyle where Self == SaturnOutline {
+    static var saturnOutline: SaturnOutline { 
+      SaturnOutline() 
+    }
+  }
+  
+  // RIGHT: If the property's type is an existential / protocol type, moving the type
+  // to the right-hand side will result in invalid code if the value is defined in an
+  // extension like `extension ShapeStyle where Self == SaturnOutline`.
+  // SwiftFormat autocorrect detects this case by checking for the existential `any` keyword.
+  let myShape1: any ShapeStyle = .saturnOutline
+  
+  // WRONG: fails with "error: static member 'saturnOutline' cannot be used on protocol metatype '(any ShapeStyle).Type'"
+  let myShape2 = (any ShapeStyle).myShape
   ```
 
   </details>

--- a/README.md
+++ b/README.md
@@ -333,25 +333,72 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   ```swift
   // WRONG
-  let host: Host = Host()
+  let sun: Star = Star(mass: 1.989e30)
+  let earth: Planet = Planet.earth
 
   // RIGHT
-  let host = Host()
+  let sun = Star(mass: 1.989e30)
+  let earth = Planet.earth
+
+  // WRONG: Most literals provide a default type that can be inferred.
+  let enableGravity: Bool = true
+  let numberOfPlanets: Int = 8
+  let sunMass: Double = 1.989e30
+
+  // RIGHT
+  let enableGravity = true
+  let numberOfPlanets = 8
+  let sunMass = 1.989e30
+  
+  // WRONG: Types can be inferred from if/switch expressions as well if each branch has the same explicit type.
+  let smallestPlanet: Planet =
+    if treatPlutoAsPlanet {
+      Planet.pluto
+    } else {
+      Planet.mercury
+    }
+
+  // RIGHT
+  let smallestPlanet =
+    if treatPlutoAsPlanet {
+      Planet.pluto
+    } else {
+      Planet.mercury
+    }
   ```
 
+  </details>
+
+* <a id='infer-property-types'></a>(<a href='#infer-property-types'>link</a>) **Prefer letting the type of a property be inferred from the right-hand-side value rather than writing the type explicitly on the left-hand side.** [![SwiftFormat: preferInferredTypes](https://img.shields.io/badge/SwiftFormat-preferInferredTypes-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#preferInferredTypes)
+
+  <details>
+
   ```swift
-  enum Direction {
-    case left
-    case right
-  }
+  // WRONG
+  let sun: Star = .init(mass: 1.989e30)
+  let earth: Planet = .earth
 
-  func someDirection() -> Direction {
-    // WRONG
-    return Direction.left
+  // RIGHT
+  let sun = Star(mass: 1.989e30)
+  let earth = Planet.earth
 
-    // RIGHT
-    return .left
-  }
+  // ALSO RIGHT: Explicit types are required when there is no right-hand-side value.
+  let sun: Star
+  let earth: Planet
+
+  // ALSO RIGHT: Explicit types can be necessary when the right-hand side has
+  // a different type from the one written explicitly on the left-hand side.
+  let nautralSatellite: PlanetaryBody? = Moon(mass: 7.347e22)
+  let moon: PlanetaryBody? = nil // nil literals are typeless
+  let numberOfPlanets: UInt = 8 // integer literals default to `Int`
+  let sunMass: CGFloat = 1.989e30 // floating-point literals default to `Double`
+  let planets: [Planet] = [] // empty collection literals are typeless
+
+  // ALSO RIGHT: Some of the examples above can also be written idiomatically without an explicit type on
+  // the left-hand-side, by instead giving the right-hand side value an explicit type. Either style is fine.
+  let numberOfPlanets = UInt(8)
+  let sunMass = CGFloat(1.989e30)
+  let planets = [Planet]()
   ```
 
   </details>

--- a/README.md
+++ b/README.md
@@ -340,6 +340,13 @@ _You can enable the following settings in Xcode by running [this script](resourc
   let sun = Star(mass: 1.989e30)
   let earth = Planet.earth
 
+  // NOT RECOMMENDED. However, since the linter doesn't have full type information, this is not enforced automatically.
+  let moon: Moon = earth.moon // returns `Moon`
+
+  // RIGHT
+  let moon = earth.moon
+  let moon: PlanetaryBody? = earth.moon
+
   // WRONG: Most literals provide a default type that can be inferred.
   let enableGravity: Bool = true
   let numberOfPlanets: Int = 8
@@ -369,70 +376,82 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
-* <a id='infer-property-types'></a>(<a href='#infer-property-types'>link</a>) **Prefer letting the type of a property be inferred from the right-hand-side value rather than writing the type explicitly on the left-hand side.** [![SwiftFormat: preferInferredTypes](https://img.shields.io/badge/SwiftFormat-preferInferredTypes-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#preferInferredTypes)
+* <a id='infer-property-types'></a>(<a href='#infer-property-types'>link</a>) **Prefer letting the type of a variable or property be inferred from the right-hand-side value rather than writing the type explicitly on the left-hand side.** [![SwiftFormat: preferInferredTypes](https://img.shields.io/badge/SwiftFormat-preferInferredTypes-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#preferInferredTypes)
 
   <details>
 
+  Prefer using inferred types when the right-hand-side value is a static member with a leading dot (e.g. an `init`, a `static` property / function, or an enum case). This applies to both local variables and property declarations:
+
   ```swift
   // WRONG
-  let sun: Star = .init(mass: 1.989e30)
-  let earth: Planet = .earth
+  struct SolarSystemBuilder {
+    let sun: Star = .init(mass: 1.989e30)
+    let earth: Planet = .earth
 
+    func setUp() {
+      let galaxy: Galaxy = .andromeda
+      let system: SolarSystem = .init(sun, earth)
+      galaxy.add(system)
+    }
+  }
+  
   // RIGHT
-  let sun = Star(mass: 1.989e30)
-  let earth = Planet.earth
+  struct SolarSystemBuilder {
+    let sun = Star(mass: 1.989e30)
+    let earth = Planet.earth
 
-  // ALSO RIGHT: Explicit types are required when there is no right-hand-side value.
-  let sun: Star
-  let earth: Planet
-
-  // ALSO RIGHT: Explicit types can be necessary when the right-hand side has
-  // a different type from the one written explicitly on the left-hand side.
-  let naturalSatellite: PlanetaryBody? = Moon(mass: 7.347e22)
-  let moon: PlanetaryBody? = nil // nil literals are typeless
-  let numberOfPlanets: UInt = 8 // integer literals default to `Int`
-  let sunMass: CGFloat = 1.989e30 // floating-point literals default to `Double`
-  let planets: [Planet] = [] // empty collection literals are typeless
-
-  // ALSO RIGHT: Some of the examples above can also be written idiomatically without an explicit type on
-  // the left-hand-side, by instead giving the right-hand side value an explicit type. Either style is fine.
-  let numberOfPlanets = UInt(8)
-  let sunMass = CGFloat(1.989e30)
-  let planets = [Planet]()
+    func setUp() {
+      let galaxy = Galaxy.andromeda
+      let system = SolarSystem(sun, earth)
+      galaxy.add(system)
+    }
+  }
   ```
-  
-  There are some rarer cases where the inferred type syntax has a different meaning than the explicit type syntax. In these cases, the explicit type syntax is still permitted:
-  
+
+  Explicit types are still permitted in other cases:
+
+  ```swift
+  // RIGHT: There is no right-hand-side value, so an explicit type is required.
+  let sun: Star
+
+  // RIGHT: The right-hand-side is not a static member of the left-hand type.
+  let moon: PlantaryBody = earth.moon
+  let sunMass: Float = 1.989e30
+  let planets: [Planet] = []
+  let venusMoon: Moon? = nil
+  ```
+
+  There are some rare cases where the inferred type syntax has a different meaning than the explicit type syntax. In these cases, the explicit type syntax is still permitted:
+
   ```swift
   extension String {
     static let earth = "Earth"
   }
 
-  // RIGHT: If the property's type is optional, moving the optional type 
-  // to the right-hand side may result in invalid code.  
-  let planetName: String? = .earth
-  
-  // WRONG: fails with "error: type 'String?' has no member 'foo'"
+  // WRONG: fails with "error: type 'String?' has no member 'earth'"
   let planetName = String?.earth
+
+  // RIGHT
+  let planetName: String? = .earth
   ```
-  
+
   ```swift
   struct SaturnOutline: ShapeStyle { ... }
-  
+
   extension ShapeStyle where Self == SaturnOutline {
     static var saturnOutline: SaturnOutline { 
       SaturnOutline() 
     }
   }
-  
+
+  // WRONG: fails with "error: static member 'saturnOutline' cannot be used on protocol metatype '(any ShapeStyle).Type'"
+  let myShape2 = (any ShapeStyle).myShape
+
   // RIGHT: If the property's type is an existential / protocol type, moving the type
   // to the right-hand side will result in invalid code if the value is defined in an
   // extension like `extension ShapeStyle where Self == SaturnOutline`.
   // SwiftFormat autocorrect detects this case by checking for the existential `any` keyword.
   let myShape1: any ShapeStyle = .saturnOutline
-  
-  // WRONG: fails with "error: static member 'saturnOutline' cannot be used on protocol metatype '(any ShapeStyle).Type'"
-  let myShape2 = (any ShapeStyle).myShape
   ```
 
   </details>

--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -101,3 +101,4 @@
 --rules blankLineAfterMultilineSwitchCase
 --rules consistentSwitchStatementSpacing
 --rules semicolons
+--rules preferInferredTypes

--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -29,15 +29,15 @@
 --organizetypes class,struct,enum,extension,actor # organizeDeclarations
 --extensionacl on-declarations # extensionAccessControl
 --patternlet inline # hoistPatternLet
---redundanttype inferred # redundantType
+--redundanttype inferred # redundantType, propertyType
 --typeblanklines preserve # blankLinesAtStartOfScope, blankLinesAtEndOfScope
 --emptybraces spaced # emptyBraces
 --someAny disabled # opaqueGenericParameters
---elseposition same-line #elseOnSameLine
---guardelse next-line #elseOnSameLine
---onelineforeach convert #preferForLoop
---shortoptionals always #typeSugar
---semicolons never #semicolons
+--elseposition same-line # elseOnSameLine
+--guardelse next-line # elseOnSameLine
+--onelineforeach convert # preferForLoop
+--shortoptionals always # typeSugar
+--semicolons never # semicolons
 
 # We recommend a max width of 100 but _strictly enforce_ a max width of 130
 --maxwidth 130 # wrap
@@ -101,4 +101,4 @@
 --rules blankLineAfterMultilineSwitchCase
 --rules consistentSwitchStatementSpacing
 --rules semicolons
---rules preferInferredTypes
+--rules propertyType


### PR DESCRIPTION
_Please react with 👍/👎 below if you agree or disagree with this proposal._

#### Summary

This PR proposes a new rule to prefer letting the type of a property be inferred from the right-hand-side value rather than writing the type explicitly on the left-hand side:

```swift
// WRONG
let sun: Star = .init(mass: 1.989e30)
let earth: Planet = .earth

// RIGHT
let sun = Star(mass: 1.989e30)
let earth = Planet.earth
```

Autocorrect support for this rule is implemented in https://github.com/nicklockwood/SwiftFormat/pull/1640.

#### Reasoning

We already have a rule to omit redundant types. It converts `let sun: Star = Star()` to `let sun = Star()`, rather than to `let sun: Star = .init()`.

The syntax with inferred types is more idiomatic, and is much more common, than the syntax with explicit types.

I briefly checked the frequency of these two styles in our codebase with a regex search:
 - Syntax with implicit types (`let sun = Star()` or `let earth = Planet.earth`, etc):
   - ~20,000 matches using the regex `((let)|(var)) \w+ = [A-Z]+\w+(\.|\()`
 - Syntax with explicit types (`let sun: Star = .init()`, etc)
   - ~5,000 matches using the regex `((let)|(var)) \w+: \w+ = \.`.

This rule only applies to simple cases where the right-hand side starts with a leading dot (meaning we know that the RHS value refers to a static member of the type written on the LHS). For other cases, we don't state a preference.