### PR TITLE
Remove "Platforms: macOS" supported platforms banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Airbnb Swift Style Guide
 
-[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fairbnb%2Fswift%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/airbnb/swift)
-
 ## Goals
 
 Following this style guide should:
@@ -24,6 +22,8 @@ Note that brevity is not a primary goal. Code should be made more concise only i
   * Exceptions to these rules should be rare and heavily justified.
 
 ## Swift Package Manager command plugin
+
+[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fairbnb%2Fswift%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/airbnb/swift) [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fairbnb%2Fswift%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/airbnb/swift)
 
 This repo includes a Swift Package Manager command plugin that you can use to automatically reformat or lint your package according to the style guide. To use this command plugin with your package, all you need to do is add this repo as a dependency:
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Airbnb Swift Style Guide
 
+[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fairbnb%2Fswift%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/airbnb/swift)
+
 ## Goals
 
 Following this style guide should:
@@ -22,8 +24,6 @@ Note that brevity is not a primary goal. Code should be made more concise only i
   * Exceptions to these rules should be rare and heavily justified.
 
 ## Swift Package Manager command plugin
-
-[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fairbnb%2Fswift%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/airbnb/swift) [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fairbnb%2Fswift%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/airbnb/swift)
 
 This repo includes a Swift Package Manager command plugin that you can use to automatically reformat or lint your package according to the style guide. To use this command plugin with your package, all you need to do is add this repo as a dependency:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Airbnb Swift Style Guide
 
-[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fairbnb%2Fswift%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/airbnb/swift) [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fairbnb%2Fswift%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/airbnb/swift)
+[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fairbnb%2Fswift%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/airbnb/swift)
 
 ## Goals
 


### PR DESCRIPTION
We realized that the "Platforms: macOS" banner at the top of the README is potentially confusing.

These Swift Package Index banners refer to the Swift versions and platforms supported by our Swift package plugin. However, without this context it may look like this is saying that the Style Guide primarily supports macOS.

I still like the Swift versions banner, so think that's worth keeping. This has the side effect of suggesting that the style guide itself "supports" the given range of Swift versions, which is true.

### Before

<img width="524" alt="image" src="https://github.com/airbnb/swift/assets/1811727/818f519f-8473-4e06-aa95-942818a7a33d">

### After

<img width="501" alt="image" src="https://github.com/airbnb/swift/assets/1811727/0ba6fff3-b85c-4d07-be0c-7092d1d8790e">

@airbnb/swift-styleguide-maintainers 