### PR TITLE
Add redundantProperty rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -3455,6 +3455,42 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
     </details>
 
+* <a id='redundant-property'></a>(<a href='#redundant-property'>link</a>) **Avoid defining properties that are then returned immediately.** Instead, return the value directly. [![SwiftFormat: redundantProperty](https://img.shields.io/badge/SwiftFormat-redundantProperty-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#redundantProperty)
+
+    <details>
+
+    ### Why?
+
+    Property declarations that are immediately returned are typically redundant and unnecessary. Sometimes these are unintentionally created as the byproduct of refactoring. Cleaning them up automatically simplifies the code. In some cases this also results in the `return` keyword itself being unnecessary, further simplifying the code.
+
+    ```swift
+    // WRONG
+    var spaceship: Spaceship {
+      let spaceship = spaceshipBuilder.build(warpDrive: warpDriveBuilder.build())
+      return spaceship
+    }
+
+    // RIGHT
+    var spaceship: Spaceship {
+      spaceshipBuilder.build(warpDrive: warpDriveBuilder.build())
+    }
+
+    // WRONG
+    var spaceship: Spaceship {
+      let warpDrive = warpDriveBuilder.build()
+      let spaceship = spaceshipBuilder.build(warpDrive: warpDrive)
+      return spaceship
+    }
+
+    // RIGHT
+    var spaceship: Spaceship {
+      let warpDrive = warpDriveBuilder.build()
+      return spaceshipBuilder.build(warpDrive: warpDrive)
+    }
+    ```
+
+    </details>
+
 **[⬆ back to top](#table-of-contents)**
 
 ## File Organization

--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -77,6 +77,7 @@
 --rules redundantVoidReturnType
 --rules redundantOptionalBinding
 --rules redundantInternal
+--rules redundantProperty
 --rules unusedArguments
 --rules spaceInsideBrackets
 --rules spaceInsideBraces


### PR DESCRIPTION
#### Summary

This PR proposes a new rule to avoid defining properties that are then returned immediately. Instead, return the value directly.

Autocorrect support is implemented in the SwiftFormat `redundantProperty` rule, which as added in https://github.com/nicklockwood/SwiftFormat/pull/1654.

```swift
// WRONG
var spaceship: Spaceship {
  let spaceship = spaceshipBuilder.build(warpDrive: warpDriveBuilder.build())
  return spaceship
}

// RIGHT
var spaceship: Spaceship {
  spaceshipBuilder.build(warpDrive: warpDriveBuilder.build())
}

// WRONG
var spaceship: Spaceship {
  let warpDrive = warpDriveBuilder.build()
  let spaceship = spaceshipBuilder.build(warpDrive: warpDrive)
  return spaceship
}

// RIGHT
var spaceship: Spaceship {
  let warpDrive = warpDriveBuilder.build()
  return spaceshipBuilder.build(warpDrive: warpDrive)
}
```

#### Reasoning

Property declarations that are immediately returned are typically redundant and unnecessary. Sometimes these are unintentionally created as the byproduct of refactoring. Cleaning them up automatically simplifies the code. In some cases this also results in the `return` keyword itself being unnecessary, further simplifying the code.