### PR TITLE
Add command to update SwiftFormat reference to latest version

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -10,3 +10,6 @@ runs:
     run: sudo xcode-select --switch /Applications/Xcode_${{ inputs.xcode }}.app
     if: ${{ inputs.xcode }}
     shell: bash
+  - name: Install Ruby Gems
+    run: bundle install
+    shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,8 +17,11 @@ jobs:
         - '13.4.1' # Swift 5.6
     steps:
       - uses: actions/checkout@v2
+      - uses: ./.github/actions/setup
+        with:
+          xcode: ${{ matrix.xcode }}
       - name: Test Package Plugin
-        run: swift package --allow-writing-to-package-directory format --lint
+        run: bundle exec rake lint:swift
 
   test-package-plugin-macos-13:
     name: Test Package Plugin
@@ -32,8 +35,11 @@ jobs:
         - '15.0' # Swift 5.9
     steps:
       - uses: actions/checkout@v2
+      - uses: ./.github/actions/setup
+        with:
+          xcode: ${{ matrix.xcode }}
       - name: Test Package Plugin
-        run: swift package --allow-writing-to-package-directory format --lint
+        run: bundle exec rake lint:swift
 
   unit-tests:
     name: Unit Tests
@@ -45,5 +51,8 @@ jobs:
         - '15.0' # Swift 5.9
     steps:
       - uses: actions/checkout@v2
+      - uses: ./.github/actions/setup
+        with:
+          xcode: ${{ matrix.xcode }}
       - name: Run Unit Tests
         run: swift test

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org' do
+  gem "rake", "~> 13.0.0"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,17 @@
+GEM
+  specs:
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    rake (13.0.6)
+
+PLATFORMS
+  arm64-darwin-23
+  ruby
+
+DEPENDENCIES
+  rake (~> 13.0.0)!
+
+BUNDLED WITH
+   2.5.4

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,54 @@
+require 'json'
+require 'net/http'
+require 'json'
+require 'tempfile'
+
+namespace :lint do
+  desc 'Lints swift files'
+  task :swift do
+    sh 'swift package --allow-writing-to-package-directory format --lint'
+  end
+end
+
+namespace :format do
+  desc 'Formats swift files'
+  task :swift do
+    sh 'swift package --allow-writing-to-package-directory format'
+  end
+end
+
+namespace :update do
+  desc 'Updates SwiftFormat to the latest version'
+  task :swiftformat do
+    # Find the most recent release of SwiftFormat in the https://github.com/calda/SwiftFormat repo.
+    response = Net::HTTP.get(URI('https://api.github.com/repos/calda/SwiftFormat/releases/latest'))
+    latest_release_info = JSON.parse(response)
+
+    latest_version_number = latest_release_info['tag_name']
+
+    # Download the artifact bundle for the latest release and compute its checksum.
+    temp_dir = Dir.mktmpdir
+    artifact_bundle_url = "https://github.com/calda/SwiftFormat/releases/download/#{latest_version_number}/swiftformat.artifactbundle.zip"
+    artifact_bundle_zip_path = "#{temp_dir}/swiftformat.artifactbundle.zip"
+    
+    sh "curl #{artifact_bundle_url} -L --output #{artifact_bundle_zip_path}"
+    checksum = `swift package compute-checksum #{artifact_bundle_zip_path}`
+
+    # Update the Package.swift file to reference this version
+    package_manifest_path = 'Package.swift'
+    package_manifest_content = File.read(package_manifest_path)
+    
+    updated_swift_format_reference = <<-EOS
+    .binaryTarget(
+      name: "SwiftFormat",
+      url: "https://github.com/calda/SwiftFormat/releases/download/#{latest_version_number}/SwiftFormat.artifactbundle.zip",
+      checksum: "#{checksum.strip}"),
+    EOS
+    
+    regex = /[ ]*.binaryTarget\([\S\s]*name: "SwiftFormat"[\S\s]*?\),\s/
+    updated_package_manifest = package_manifest_content.gsub(regex, updated_swift_format_reference)
+    File.open(package_manifest_path, "w") { |file| file.puts updated_package_manifest }
+    
+    puts "Updated Package.swift to reference SwiftFormat #{latest_version_number}"
+  end
+end


### PR DESCRIPTION
This PR adds a `bundle exec rake update:swiftformat` command that updates the SwiftFormat dependency `Package.swift` to reference the most recent version published in the https://github.com/calda/SwiftFormat repo.

This combines nicely with https://github.com/nicklockwood/SwiftFormat/pull/1721, which automates the creation of the artifact bundle.

If you run this right now, the command applies this change to the `Package.swift` file:

```diff
diff --git a/Package.swift b/Package.swift
index 579c10c..7b2daee 100644
--- a/Package.swift
+++ b/Package.swift
@@ -42,8 +42,8 @@ let package = Package(
 
     .binaryTarget(
       name: "SwiftFormat",
-      url: "https://github.com/calda/SwiftFormat/releases/download/0.54-beta-7/SwiftFormat.artifactbundle.zip",
-      checksum: "0cf117050e7838f545009bfe4a75dbda98cff737cb847a7d065a89683e9e890a"),
+      url: "https://github.com/calda/SwiftFormat/releases/download/0.54-test-upload-release-artifact-3/SwiftFormat.artifactbundle.zip",
+      checksum: "45eb713635edde284f06c2aa0c556f25336cbb382ae0e2226553abf468092e63"),
 
     .binaryTarget(
       name: "SwiftLintBinary",
```