### PR TITLE
Update SwiftFormat to v. 0.55-beta-2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -42,8 +42,8 @@ let package = Package(
 
     .binaryTarget(
       name: "SwiftFormat",
-      url: "https://github.com/calda/SwiftFormat/releases/download/0.55-beta-1/SwiftFormat.artifactbundle.zip",
-      checksum: "ec2a022fc3a010750190c1933bb9cfd10e69c294acacac584680e208d1df73c6"),
+      url: "https://github.com/calda/SwiftFormat/releases/download/0.55-beta-2/SwiftFormat.artifactbundle.zip",
+      checksum: "f7ba281b879af7920e368144117269ba00abcc589b6d36f47ea0c21e62410a7c"),
 
     .binaryTarget(
       name: "SwiftLintBinary",

--- a/Package.swift
+++ b/Package.swift
@@ -42,8 +42,8 @@ let package = Package(
 
     .binaryTarget(
       name: "SwiftFormat",
-      url: "https://github.com/calda/SwiftFormat/releases/download/0.54-beta-7/SwiftFormat.artifactbundle.zip",
-      checksum: "0cf117050e7838f545009bfe4a75dbda98cff737cb847a7d065a89683e9e890a"),
+      url: "https://github.com/calda/SwiftFormat/releases/download/0.55-beta-1/SwiftFormat.artifactbundle.zip",
+      checksum: "ec2a022fc3a010750190c1933bb9cfd10e69c294acacac584680e208d1df73c6"),
 
     .binaryTarget(
       name: "SwiftLintBinary",

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         ]),
       dependencies: [
         "AirbnbSwiftFormatTool",
-        "SwiftFormat",
+        "swiftformat",
         "SwiftLintBinary",
       ]),
 
@@ -41,7 +41,7 @@ let package = Package(
       dependencies: ["AirbnbSwiftFormatTool"]),
 
     .binaryTarget(
-      name: "SwiftFormat",
+      name: "swiftformat",
       url: "https://github.com/calda/SwiftFormat/releases/download/0.55-beta-2/SwiftFormat.artifactbundle.zip",
       checksum: "f7ba281b879af7920e368144117269ba00abcc589b6d36f47ea0c21e62410a7c"),
 

--- a/Rakefile
+++ b/Rakefile
@@ -40,12 +40,12 @@ namespace :update do
     
     updated_swift_format_reference = <<-EOS
     .binaryTarget(
-      name: "SwiftFormat",
+      name: "swiftformat",
       url: "https://github.com/calda/SwiftFormat/releases/download/#{latest_version_number}/SwiftFormat.artifactbundle.zip",
       checksum: "#{checksum.strip}"),
     EOS
     
-    regex = /[ ]*.binaryTarget\([\S\s]*name: "SwiftFormat"[\S\s]*?\),\s/
+    regex = /[ ]*.binaryTarget\([\S\s]*name: "swiftformat"[\S\s]*?\),\s/
     updated_package_manifest = package_manifest_content.gsub(regex, updated_swift_format_reference)
     File.open(package_manifest_path, "w") { |file| file.puts updated_package_manifest }
     

--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -100,7 +100,7 @@
 --rules preferForLoop
 --rules conditionalAssignment
 --rules wrapMultilineConditionalAssignment
---rules blankLineAfterMultilineSwitchCase
---rules consistentSwitchStatementSpacing
+--rules blankLineAfterSwitchCase
+--rules consistentSwitchCaseSpacing
 --rules semicolons
 --rules propertyType


### PR DESCRIPTION
#### Summary

Updating to [0.55-beta-2](https://github.com/calda/SwiftFormat/releases/tag/0.55-beta-2). 

Also updated two breaking rule name changes in [airbnb.swiftformat](https://github.com/airbnb/swift/compare/manny-lopez--update-swiftformat-version?expand=1#diff-18c32716db8d9f80bf3ceeeba1eb9c57a8557a085a1e632d06e0738710b81af1) 
```diff
- --rules blankLineAfterMultilineSwitchCase
- --rules consistentSwitchStatementSpacing
+ --rules blankLineAfterSwitchCase
+ --rules consistentSwitchCaseSpacing
```
