### PR TITLE
Remove "Please react with 👍/👎 if you agree or disagree with this proposal" text from PR template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -5,5 +5,3 @@
 #### Reasoning
 
 <!--- required --->
-
-_Please react with 👍/👎 if you agree or disagree with this proposal._


### PR DESCRIPTION
#### Summary

This PR removes the `Please react with 👍/👎 if you agree or disagree with this proposal.` text from this repo's PR template.

#### Reasoning

We have moved proposal reviews from github.com to our internal Slack. While feedback is still welcome on the github.com pull request, we no longer need to specifically ask readers to react to the PR.

This should make it more clear that the internal poll is the source of truth for proposal reviews.