### PR TITLE
Remove Linux #error from Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -50,9 +50,3 @@ let package = Package(
       url: "https://github.com/realm/SwiftLint/releases/download/0.55.1/SwiftLintBinary-macos.artifactbundle.zip",
       checksum: "722a705de1cf4e0e07f2b7d2f9f631f3a8b2635a0c84cce99f9677b38aa4a1d6"),
   ])
-
-// Emit an error on Linux, so Swift Package Manager's platform support detection doesn't say this package supports Linux
-// https://github.com/airbnb/swift/discussions/197#discussioncomment-4055303
-#if os(Linux)
-#error("Linux is currently not supported")
-#endif


### PR DESCRIPTION
This PR removes the `#error("Linux is currently not supported")` error from our Package.swift.

This was originally so Swift Package Index wouldn't list this package as supporting Linux. This is causing issues for folks though, since it prevents the Package.manifest from being parsed on Linux: https://github.com/airbnb/swift/discussions/197#discussioncomment-9501585

Since we removed the Swift Package Index platforms badge from the README in https://github.com/airbnb/swift/pull/271, and this `#error` is causing issues for folks, it seems best to just remove it.