### PR TITLE
Add explicit category ordering configuration for organizeDeclarations rule

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -42,8 +42,8 @@ let package = Package(
 
     .binaryTarget(
       name: "swiftformat",
-      url: "https://github.com/calda/SwiftFormat/releases/download/0.55-beta-2/SwiftFormat.artifactbundle.zip",
-      checksum: "f7ba281b879af7920e368144117269ba00abcc589b6d36f47ea0c21e62410a7c"),
+      url: "https://github.com/calda/SwiftFormat/releases/download/0.55-beta-4/SwiftFormat.artifactbundle.zip",
+      checksum: "ebdb5cefe050099d2cbc0e00a0d45abc3f45e763c7cd6b849a1113026b2b2a3b"),
 
     .binaryTarget(
       name: "SwiftLintBinary",

--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -27,6 +27,7 @@
 --structthreshold 20 # organizeDeclarations
 --enumthreshold 20 # organizeDeclarations
 --organizetypes class,struct,enum,extension,actor # organizeDeclarations
+--typeorder nestedType,staticProperty,staticPropertyWithBody,classPropertyWithBody,instanceProperty,instancePropertyWithBody,staticMethod,classMethod,instanceMethod # organizeDeclarations
 --extensionacl on-declarations # extensionAccessControl
 --patternlet inline # hoistPatternLet
 --redundanttype inferred # redundantType, propertyType

--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -27,6 +27,7 @@
 --structthreshold 20 # organizeDeclarations
 --enumthreshold 20 # organizeDeclarations
 --organizetypes class,struct,enum,extension,actor # organizeDeclarations
+--visibilityorder beforeMarks,instanceLifecycle,open,public,package,internal,fileprivate,private # organizeDeclarations
 --typeorder nestedType,staticProperty,staticPropertyWithBody,classPropertyWithBody,instanceProperty,instancePropertyWithBody,staticMethod,classMethod,instanceMethod # organizeDeclarations
 --extensionacl on-declarations # extensionAccessControl
 --patternlet inline # hoistPatternLet


### PR DESCRIPTION
As of https://github.com/nicklockwood/SwiftFormat/pull/1736, the `organizeDeclarations` rule is now fully configurable, and lets you specify the sort order of declarations. The default behavior of the `organizeDeclarations` is now different from the behavior defined in our style guide. To keep the behavior we want, we can provide our own configuration explicitly.

The corresponding configuration that matches our style guide is:

```
--visibilityorder beforeMarks,instanceLifecycle,open,public,package,internal,fileprivate,private # organizeDeclarations
--typeorder nestedType,staticProperty,staticPropertyWithBody,classPropertyWithBody,instanceProperty,instancePropertyWithBody,staticMethod,classMethod,instanceMethod # organizeDeclarations
```