### PR TITLE
Add rule to place doc comments before any attributes

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -42,8 +42,8 @@ let package = Package(
 
     .binaryTarget(
       name: "swiftformat",
-      url: "https://github.com/calda/SwiftFormat/releases/download/0.55-beta-4/SwiftFormat.artifactbundle.zip",
-      checksum: "ebdb5cefe050099d2cbc0e00a0d45abc3f45e763c7cd6b849a1113026b2b2a3b"),
+      url: "https://github.com/calda/SwiftFormat/releases/download/0.55-beta-6/SwiftFormat.artifactbundle.zip",
+      checksum: "c4faeb1068eece2b644192afc1a35a82a81935794034d2efaa3f44ddd8a4b8d4"),
 
     .binaryTarget(
       name: "SwiftLintBinary",

--- a/README.md
+++ b/README.md
@@ -843,9 +843,9 @@ _You can enable the following settings in Xcode by running [this script](resourc
     var oldestMoons: [Moon]
 
   }
-  ```swift
-
   ```
+
+  ```swift
   // WRONG. These long, complex attributes should be written on the previous line.
   struct RocketFactory {
 

--- a/README.md
+++ b/README.md
@@ -1870,7 +1870,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
-* <a id='doc-comments-before-attributes'></a>(<a href='#doc-comments-before-declarations'>link</a>) **Place doc comments for a declaration before any attributes.** [![SwiftFormat: docCommentsBeforeAttributes](https://img.shields.io/badge/SwiftFormat-docCommentsBeforeAttributes-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#docCommentsBeforeAttributes)
+* <a id='doc-comments-before-attributes'></a>(<a href='#doc-comments-before-attributes'>link</a>) **Place doc comments for a declaration before any attributes.** [![SwiftFormat: docCommentsBeforeAttributes](https://img.shields.io/badge/SwiftFormat-docCommentsBeforeAttributes-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#docCommentsBeforeAttributes)
 
   <details>
 

--- a/README.md
+++ b/README.md
@@ -1870,6 +1870,26 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
+* <a id='doc-comments-before-attributes'></a>(<a href='#doc-comments-before-declarations'>link</a>) **Place doc comments for a declaration before any attributes.** [![SwiftFormat: docCommentsBeforeAttributes](https://img.shields.io/badge/SwiftFormat-docCommentsBeforeAttributes-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#docCommentsBeforeAttributes)
+
+  <details>
+
+  ```swift
+  // WRONG
+
+  @MainActor
+  /// A spacecraft with everything you need to explore the universe.
+  struct Spaceship { … }
+
+  // RIGHT
+
+  /// A spacecraft with everything you need to explore the universe.
+  @MainActor
+  struct Spaceship { … }
+  ```
+
+  </details>
+
 * <a id='whitespace-around-comment-delimiters'></a>(<a href='#whitespace-around-comment-delimiters'>link</a>) Include spaces or newlines before and after comment delimiters (`//`, `///`, `/*`, and `*/`) [![SwiftFormat: spaceAroundComments](https://img.shields.io/badge/SwiftFormat-spaceAroundComments-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#spaceAroundComments) [![SwiftFormat: spaceInsideComments](https://img.shields.io/badge/SwiftFormat-spaceInsideComments-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#spaceInsideComments)
 
   <details>

--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -89,6 +89,7 @@
 --rules enumNamespaces
 --rules blockComments
 --rules docComments
+--rules docCommentsBeforeAttributes
 --rules spaceAroundComments
 --rules spaceInsideComments
 --rules blankLinesAtStartOfScope


### PR DESCRIPTION
#### Summary

This PR adds a new rule to place doc comments for a declaration before any attributes on the declaration.

```swift
// WRONG

@MainActor
/// A spacecraft with everything you need to explore the universe.
struct Spaceship { … }

// RIGHT

/// A spacecraft with everything you need to explore the universe.
@MainActor
struct Spaceship { … }
```

Autocorrect support is implemented in the SwiftFormat `docCommentsBeforeAttributes` rule, which was added in https://github.com/nicklockwood/SwiftFormat/pull/1766.

#### Reasoning

Placing the doc comment before any attributes is the most common practice, but I noticed some examples in our codebase where the doc comment is between the attributes and the rest of the declaration.

On the tooling side, Xcode correctly handles doc comments placed above attributes (see how the doc comment shows up in the inspector on the right):

<img width="1087" alt="Screenshot 2024-07-22 at 4 03 49 PM" src="https://github.com/user-attachments/assets/4c4374d2-36a0-4336-903d-a0af6634c64b">

But doesn't correctly handle doc comments placed after the attributes (see how the doc comment doesn't show up in the inspector on the right):

<img width="1107" alt="Screenshot 2024-07-22 at 4 04 07 PM" src="https://github.com/user-attachments/assets/fc51fb67-1662-4559-b594-3939e71a3776">