### PR TITLE
Add SwiftUI Property declaration to sub section ordering list

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -42,8 +42,8 @@ let package = Package(
 
     .binaryTarget(
       name: "swiftformat",
-      url: "https://github.com/calda/SwiftFormat/releases/download/0.55-beta-4/SwiftFormat.artifactbundle.zip",
-      checksum: "ebdb5cefe050099d2cbc0e00a0d45abc3f45e763c7cd6b849a1113026b2b2a3b"),
+      url: "https://github.com/calda/SwiftFormat/releases/download/0.55-beta-9/SwiftFormat.artifactbundle.zip",
+      checksum: "95bdb70c7f236c1208a96595193cda17ec188630efd7cee35e3d210160a01e5f"),
 
     .binaryTarget(
       name: "SwiftLintBinary",

--- a/README.md
+++ b/README.md
@@ -3877,26 +3877,51 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   <details>
   
-    Computed properties and properties with property observers should appear at the end of the set of declarations of the same kind. (e.g. instance properties.) [![SwiftFormat: organizeDeclarations](https://img.shields.io/badge/SwiftFormat-organizeDeclarations-008489.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#organizeDeclarations)
+    Computed properties and properties with property observers should appear at the end of the set of declarations of the same kind. (e.g. instance properties.)
 
     ```swift
     // WRONG
-    var atmosphere: Atmosphere {
-      didSet {
-        print("oh my god, the atmosphere changed")
+    class PlanetView: UIView {
+    
+      static var startOfTime { -CGFloat.greatestFiniteMagnitude / 0 }
+    
+      var atmosphere: Atmosphere {
+         didSet {
+           print("oh my god, the atmosphere changed")
+         }
+       }
+    
+      override class var layerClass: AnyClass {
+        PlanetLayer.self
       }
+    
+      var gravity: CGFloat
+    
+      static var speedOfLight: CGFloat = 300_000
     }
-    var gravity: CGFloat
+    
     // RIGHT
-    var gravity: CGFloat
-    var atmosphere: Atmosphere {
-      didSet {
-        print("oh my god, the atmosphere changed")
+    class PlanetView: UIView {
+    
+      static var speedOfLight: CGFloat = 300_000
+      
+      static var startOfTime { -CGFloat.greatestFiniteMagnitude / 0 }
+      
+      override class var layerClass: AnyClass {
+        PlanetLayer.self
       }
+      
+      var gravity: CGFloat
+      
+      var atmosphere: Atmosphere {
+         didSet {
+           print("oh my god, the atmosphere changed")
+         }
+       }
     }
     ```
 
-    SwiftUI Properties are a special type of property that lives inside SwiftUI views. These views conform to the DynamicProperty protocol and cause the view's body to re-compute. Given this common functionality and also a similar syntax, it is preferred to group them.
+    SwiftUI Properties are a special type of property that lives inside SwiftUI views. These views conform to the [`DynamicProperty`](https://developer.apple.com/documentation/swiftui/dynamicproperty) protocol and cause the view's body to re-compute. Given this common functionality and also a similar syntax, it is preferred to group them.
 
     ```swift
     // WRONG

--- a/README.md
+++ b/README.md
@@ -3864,13 +3864,86 @@ _You can enable the following settings in Xcode by running [this script](resourc
   * If the type in question is a simple value type (e.g. fewer than 20 lines), it is OK to omit the `// MARK:`s, as it would hurt legibility.
 
 * <a id='subsection-organization'></a>(<a href='#subsection-organization'>link</a>) **Within each top-level section, place content in the following order.** This allows a new reader of your code to more easily find what they are looking for. [![SwiftFormat: organizeDeclarations](https://img.shields.io/badge/SwiftFormat-organizeDeclarations-008489.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#organizeDeclarations)
-  * Nested types and type aliases
-  * Static properties
-  * Class properties
-  * Instance properties
-  * Static methods
-  * Class methods
-  * Instance methods
+  - **Nested types and type aliases**: 
+  - **Static properties**: 
+  - **static property with body**: 
+  - **Class properties with body**: 
+  - **SwiftUI dynamic properties (@State, @Environment, @Binding, etc)**: SwiftUI Dynamic properties should appear grouped since they share a common semantic meaning and cause a SwiftUI view to re-render its body.
+      
+      <details>
+      
+      ```swift
+      // WRONG
+    
+      struct CustomSlider: View {
+      
+        // Internal
+    
+        var body: some View {
+          ...
+        }
+    
+        // Private
+    
+        @Binding private var value: Value
+        private let range: ClosedRange<Double>
+        @Environment(\.DLSSliderStyle) private var style
+        private let step: Double.Stride
+        @Environment(\.layoutDirection) private var layoutDirection
+      }
+    
+      // RIGHT
+      
+        struct CustomSlider: View {
+        
+        // Internal
+    
+        var body: some View {
+          ...
+        }
+    
+        // Private
+    
+        @Environment(\.DLSSliderStyle) private var style
+        @Environment(\.layoutDirection) private var layoutDirection
+        @Binding private var value: Value
+        
+        private let range: ClosedRange<Double>
+        private let step: Double.Stride
+      }
+      ```
+    
+      </details>
+
+  - **Instance properties**: 
+  - **Instance properties with body**: Computed properties and properties with property observers should appear at the end of the set of declarations of the same kind. (e.g. instance properties.) [![SwiftFormat: organizeDeclarations](https://img.shields.io/badge/SwiftFormat-organizeDeclarations-008489.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#organizeDeclarations)
+
+      <details>
+
+       ```swift
+       // WRONG
+       var atmosphere: Atmosphere {
+         didSet {
+           print("oh my god, the atmosphere changed")
+         }
+       }
+       var gravity: CGFloat
+
+       // RIGHT
+       var gravity: CGFloat
+       var atmosphere: Atmosphere {
+         didSet {
+           print("oh my god, the atmosphere changed")
+         }
+       }
+       ```
+
+      </details>
+
+  - **Static methods**: 
+  - **Class methods**: 
+  - **Instance methods**: 
+
 
 * <a id='newline-between-subsections'></a>(<a href='#newline-between-subsections'>link</a>) **Add empty lines between property declarations of different kinds.** (e.g. between static properties and instance properties.) [![SwiftFormat: organizeDeclarations](https://img.shields.io/badge/SwiftFormat-organizeDeclarations-008489.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#organizeDeclarations)
 
@@ -3891,7 +3964,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
-* <a id='computed-properties-at-end'></a>(<a href='#computed-properties-at-end'>link</a>) **Computed properties and properties with property observers should appear at the end of the set of declarations of the same kind.** (e.g. instance properties.) [![SwiftFormat: organizeDeclarations](https://img.shields.io/badge/SwiftFormat-organizeDeclarations-008489.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#organizeDeclarations)
+**Computed properties and properties with property observers should appear at the end of the set of declarations of the same kind.** (e.g. instance properties.) [![SwiftFormat: organizeDeclarations](https://img.shields.io/badge/SwiftFormat-organizeDeclarations-008489.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#organizeDeclarations)
 
   <details>
 

--- a/README.md
+++ b/README.md
@@ -3884,35 +3884,33 @@ _You can enable the following settings in Xcode by running [this script](resourc
     class PlanetView: UIView {
     
       static var startOfTime { -CGFloat.greatestFiniteMagnitude / 0 }
-    
+
       var atmosphere: Atmosphere {
          didSet {
            print("oh my god, the atmosphere changed")
          }
        }
-    
+
       override class var layerClass: AnyClass {
         PlanetLayer.self
       }
-    
+
       var gravity: CGFloat
-    
-      static var speedOfLight: CGFloat = 300_000
+
+      static let speedOfLight: CGFloat = 300_000
     }
-    
+
     // RIGHT
     class PlanetView: UIView {
     
-      static var speedOfLight: CGFloat = 300_000
-      
+      static let speedOfLight: CGFloat = 300_000
       static var startOfTime { -CGFloat.greatestFiniteMagnitude / 0 }
-      
+
       override class var layerClass: AnyClass {
         PlanetLayer.self
       }
-      
+
       var gravity: CGFloat
-      
       var atmosphere: Atmosphere {
          didSet {
            print("oh my god, the atmosphere changed")

--- a/README.md
+++ b/README.md
@@ -3866,7 +3866,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 * <a id='subsection-organization'></a>(<a href='#subsection-organization'>link</a>) **Within each top-level section, place content in the following order.** This allows a new reader of your code to more easily find what they are looking for. [![SwiftFormat: organizeDeclarations](https://img.shields.io/badge/SwiftFormat-organizeDeclarations-008489.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#organizeDeclarations)
   - **Nested types and type aliases**: 
   - **Static properties**: 
-  - **static property with body**: 
+  - **Static property with body**: 
   - **Class properties with body**: 
   - **SwiftUI dynamic properties (@State, @Environment, @Binding, etc)**: SwiftUI Dynamic properties should appear grouped since they share a common semantic meaning and cause a SwiftUI view to re-render its body.
       

--- a/README.md
+++ b/README.md
@@ -3864,85 +3864,81 @@ _You can enable the following settings in Xcode by running [this script](resourc
   * If the type in question is a simple value type (e.g. fewer than 20 lines), it is OK to omit the `// MARK:`s, as it would hurt legibility.
 
 * <a id='subsection-organization'></a>(<a href='#subsection-organization'>link</a>) **Within each top-level section, place content in the following order.** This allows a new reader of your code to more easily find what they are looking for. [![SwiftFormat: organizeDeclarations](https://img.shields.io/badge/SwiftFormat-organizeDeclarations-008489.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#organizeDeclarations)
-  - **Nested types and type aliases**: 
-  - **Static properties**: 
-  - **Static property with body**: 
-  - **Class properties with body**: 
-  - **SwiftUI dynamic properties (@State, @Environment, @Binding, etc)**: SwiftUI Dynamic properties should appear grouped since they share a common semantic meaning and cause a SwiftUI view to re-render its body.
-      
-      <details>
-      
-      ```swift
-      // WRONG
-    
-      struct CustomSlider: View {
-      
-        // Internal
-    
-        var body: some View {
-          ...
-        }
-    
-        // Private
-    
-        @Binding private var value: Value
-        private let range: ClosedRange<Double>
-        @Environment(\.DLSSliderStyle) private var style
-        private let step: Double.Stride
-        @Environment(\.layoutDirection) private var layoutDirection
+  * Nested types and type aliases
+  * Static properties
+  * Static property with body
+  * Class properties with body
+  * SwiftUI dynamic properties (@State, @Environment, @Binding, etc)
+  * Instance properties
+  * Instance properties with body
+  * Static methods
+  * Class methods
+  * Instance methods
+
+  <details>
+  
+    Computed properties and properties with property observers should appear at the end of the set of declarations of the same kind. (e.g. instance properties.) [![SwiftFormat: organizeDeclarations](https://img.shields.io/badge/SwiftFormat-organizeDeclarations-008489.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#organizeDeclarations)
+
+    ```swift
+    // WRONG
+    var atmosphere: Atmosphere {
+      didSet {
+        print("oh my god, the atmosphere changed")
       }
-    
-      // RIGHT
-      
-        struct CustomSlider: View {
-        
-        // Internal
-    
-        var body: some View {
-          ...
-        }
-    
-        // Private
-    
-        @Environment(\.DLSSliderStyle) private var style
-        @Environment(\.layoutDirection) private var layoutDirection
-        @Binding private var value: Value
-        
-        private let range: ClosedRange<Double>
-        private let step: Double.Stride
+    }
+    var gravity: CGFloat
+    // RIGHT
+    var gravity: CGFloat
+    var atmosphere: Atmosphere {
+      didSet {
+        print("oh my god, the atmosphere changed")
       }
-      ```
+    }
+    ```
+
+    SwiftUI Properties are a special type of property that lives inside SwiftUI views. These views conform to the DynamicProperty protocol and cause the view's body to re-compute. Given this common functionality and also a similar syntax, it is preferred to group them.
+
+    ```swift
+    // WRONG
+
+    struct CustomSlider: View {
     
-      </details>
+      // MARK: Internal
 
-  - **Instance properties**: 
-  - **Instance properties with body**: Computed properties and properties with property observers should appear at the end of the set of declarations of the same kind. (e.g. instance properties.) [![SwiftFormat: organizeDeclarations](https://img.shields.io/badge/SwiftFormat-organizeDeclarations-008489.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#organizeDeclarations)
+      var body: some View {
+        ...
+      }
 
-      <details>
+      // MARK: Private
 
-       ```swift
-       // WRONG
-       var atmosphere: Atmosphere {
-         didSet {
-           print("oh my god, the atmosphere changed")
-         }
-       }
-       var gravity: CGFloat
+      @Binding private var value: Value
+      private let range: ClosedRange<Double>
+      @Environment(\.sliderStyle) private var style
+      private let step: Double.Stride
+      @Environment(\.layoutDirection) private var layoutDirection
+    }
 
-       // RIGHT
-       var gravity: CGFloat
-       var atmosphere: Atmosphere {
-         didSet {
-           print("oh my god, the atmosphere changed")
-         }
-       }
-       ```
+    // RIGHT
 
-      </details>
+    struct CustomSlider: View {
+      
+      // MARK: Internal
 
-  - **Static methods**: 
-  - **Class methods**: 
-  - **Instance methods**: 
+      var body: some View {
+        ...
+      }
+
+      // MARK: Private
+
+      @Environment(\.sliderStyle) private var style
+      @Environment(\.layoutDirection) private var layoutDirection
+      @Binding private var value: Value
+
+      private let range: ClosedRange<Double>
+      private let step: Double.Stride
+    }
+    ```
+  </details>
 
 
 * <a id='newline-between-subsections'></a>(<a href='#newline-between-subsections'>link</a>) **Add empty lines between property declarations of different kinds.** (e.g. between static properties and instance properties.) [![SwiftFormat: organizeDeclarations](https://img.shields.io/badge/SwiftFormat-organizeDeclarations-008489.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#organizeDeclarations)
@@ -3960,30 +3956,6 @@ _You can enable the following settings in Xcode by running [this script](resourc
   static let gravityMoon: CGFloat = 1.6
 
   var gravity: CGFloat
-  ```
-
-  </details>
-
-**Computed properties and properties with property observers should appear at the end of the set of declarations of the same kind.** (e.g. instance properties.) [![SwiftFormat: organizeDeclarations](https://img.shields.io/badge/SwiftFormat-organizeDeclarations-008489.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#organizeDeclarations)
-
-  <details>
-
-  ```swift
-  // WRONG
-  var atmosphere: Atmosphere {
-    didSet {
-      print("oh my god, the atmosphere changed")
-    }
-  }
-  var gravity: CGFloat
-
-  // RIGHT
-  var gravity: CGFloat
-  var atmosphere: Atmosphere {
-    didSet {
-      print("oh my god, the atmosphere changed")
-    }
-  }
   ```
 
   </details>

--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -28,7 +28,7 @@
 --enumthreshold 20 # organizeDeclarations
 --organizetypes class,struct,enum,extension,actor # organizeDeclarations
 --visibilityorder beforeMarks,instanceLifecycle,open,public,package,internal,fileprivate,private # organizeDeclarations
---typeorder nestedType,staticProperty,staticPropertyWithBody,classPropertyWithBody,instanceProperty,instancePropertyWithBody,staticMethod,classMethod,instanceMethod # organizeDeclarations
+--typeorder nestedType,staticProperty,staticPropertyWithBody,classPropertyWithBody,swiftUIPropertyWrapper,instanceProperty,instancePropertyWithBody,staticMethod,classMethod,instanceMethod # organizeDeclarations
 --extensionacl on-declarations # extensionAccessControl
 --patternlet inline # hoistPatternLet
 --redundanttype inferred # redundantType, propertyType


### PR DESCRIPTION
#### Summary

<!--- required --->

After merging https://github.com/nicklockwood/SwiftFormat/pull/1747 and https://github.com/airbnb/swift/pull/280, this PR adds the SwiftUI property declaration ordering rule to the style guide.

#### Reasoning

SwiftUI Properties are a special type of property that lives inside SwiftUI views. These views conform to the `DynamicProperty` protocol and cause the a view's body to re-compute. Given this common functionality and also a similar syntax, it is preferred to group them together. 

  ```swift
  // WRONG

  struct CustomSlider: View {
  
    // MARK: Internal

    var body: some View {
      ...
    }

    // MARK: Private

    @Binding private var value: Value
    private let range: ClosedRange<Double>
    @Environment(\.sliderStyle) private var style
    private let step: Double.Stride
    @Environment(\.layoutDirection) private var layoutDirection
  }

  // RIGHT
  
    struct CustomSlider: View {
    
    // MARK: Internal

    var body: some View {
      ...
    }

    // MARK: Private

    @Environment(\.sliderStyle) private var style
    @Environment(\.layoutDirection) private var layoutDirection
    @Binding private var value: Value
    
    private let range: ClosedRange<Double>
    private let step: Double.Stride
  }
  ```
