### PR TITLE
Add emptyExtension rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -4003,7 +4003,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
   
-* <a id='remove-empty-extensions'></a>(<a href='#remove-empty-extensions'>link</a>) **Remove empty, non-conforming, extensions.** Does not affect empty extensions that are appended by a macro. [![SwiftFormat: emptyExtension](https://img.shields.io/badge/SwiftFormat-emptyExtension-008489.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#emptyExtension)
+* <a id='remove-empty-extensions'></a>(<a href='#remove-empty-extensions'>link</a>) **Remove empty extensions that define no properties, functions, or conformances.** [![SwiftFormat: emptyExtension](https://img.shields.io/badge/SwiftFormat-emptyExtension-008489.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#emptyExtension)
 
   <details>
 

--- a/README.md
+++ b/README.md
@@ -4002,6 +4002,35 @@ _You can enable the following settings in Xcode by running [this script](resourc
   ```
 
   </details>
+  
+* <a id='remove-empty-extensions'></a>(<a href='#remove-empty-extensions'>link</a>) **Remove empty, non-conforming, extensions.** [![SwiftFormat: emptyExtension](https://img.shields.io/badge/SwiftFormat-emptyExtension-008489.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#emptyExtension)
+
+  <details>
+
+  #### Why?
+  Improves readability since the code has no effect and should be removed for clarity.
+  
+  ```swift
+  // WRONG
+  extension String {}
+  
+  extension [Foo: Bar] {}
+  
+  extension Array where Element: Foo {}
+  
+  extension String: Equatable {}
+  
+  @GenerateBoilerPlate
+  extension Foo {}
+
+  // RIGHT
+  extension String: Equatable {}
+  
+  @GenerateBoilerPlate
+  extension Foo {}
+  ```
+
+  </details>
 
 **[⬆ back to top](#table-of-contents)**
 

--- a/README.md
+++ b/README.md
@@ -4011,23 +4011,13 @@ _You can enable the following settings in Xcode by running [this script](resourc
   Improves readability since the code has no effect and should be removed for clarity.
   
   ```swift
-  // WRONG
-  extension String {}
+  // WRONG: The first extension is empty and redundant.
+  extension Planet {}
   
-  extension [Foo: Bar] {}
-  
-  extension Array where Element: Foo {}
-  
-  extension String: Equatable {}
-  
-  @GenerateBoilerPlate
-  extension Foo {}
+  extension Planet: Equatable {}
 
-  // RIGHT
-  extension String: Equatable {}
-  
-  @GenerateBoilerPlate
-  extension Foo {}
+  // RIGHT: Empty extensions that add a protocol conformance aren't redundant.
+  extension Planet: Equatable {}
   ```
 
   </details>

--- a/README.md
+++ b/README.md
@@ -4003,7 +4003,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
   
-* <a id='remove-empty-extensions'></a>(<a href='#remove-empty-extensions'>link</a>) **Remove empty, non-conforming, extensions.** [![SwiftFormat: emptyExtension](https://img.shields.io/badge/SwiftFormat-emptyExtension-008489.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#emptyExtension)
+* <a id='remove-empty-extensions'></a>(<a href='#remove-empty-extensions'>link</a>) **Remove empty, non-conforming, extensions.** Does not affect empty extensions that are appended by a macro. [![SwiftFormat: emptyExtension](https://img.shields.io/badge/SwiftFormat-emptyExtension-008489.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#emptyExtension)
 
   <details>
 

--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -109,3 +109,4 @@
 --rules semicolons
 --rules propertyType
 --rules blankLinesBetweenChainedFunctions
+--rules emptyExtension


### PR DESCRIPTION
#### Summary

This PR adds rule `emptyExtension` to remove empty extensions that define no properties, functions, or conformances.

 ```swift
// WRONG: The first extension is empty and redundant.
extension Planet {}

extension Planet: Equatable {}

// RIGHT: Empty extensions that add a protocol conformance aren't redundant.
extension Planet: Equatable {}
  ```

#### Reasoning

Improves readability since the code has no effect and should be removed for clarity.
