### PR TITLE
Add unusedPrivateDeclaration rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -4002,35 +4002,6 @@ _You can enable the following settings in Xcode by running [this script](resourc
   ```
 
   </details>
-
-**[⬆ back to top](#table-of-contents)**
-
-## Objective-C Interoperability
-
-* <a id='prefer-pure-swift-classes'></a>(<a href='#prefer-pure-swift-classes'>link</a>) **Prefer pure Swift classes over subclasses of NSObject.** If your code needs to be used by some Objective-C code, wrap it to expose the desired functionality. Use `@objc` on individual methods and variables as necessary rather than exposing all API on a class to Objective-C via `@objcMembers`.
-
-  <details>
-
-  ```swift
-  class PriceBreakdownViewController {
-
-    private let acceptButton = UIButton()
-
-    private func setUpAcceptButton() {
-      acceptButton.addTarget(
-        self,
-        action: #selector(didTapAcceptButton),
-        forControlEvents: .touchUpInside)
-    }
-
-    @objc
-    private func didTapAcceptButton() {
-      // ...
-    }
-  }
-  ```
-
-  </details>
   
 * <a id='unused-private-declaration'></a>(<a href='#unused-private-declaration'>link</a>) **Remove unused private and fileprivate properties, functions, and typealiases** [![SwiftFormat: unusedPrivateDeclaration](https://img.shields.io/badge/SwiftFormat-unusedPrivateDeclaration-008489.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#unusedPrivateDeclaration)
 
@@ -4068,6 +4039,35 @@ _You can enable the following settings in Xcode by running [this script](resourc
   }
   ```
   
+  </details>
+
+**[⬆ back to top](#table-of-contents)**
+
+## Objective-C Interoperability
+
+* <a id='prefer-pure-swift-classes'></a>(<a href='#prefer-pure-swift-classes'>link</a>) **Prefer pure Swift classes over subclasses of NSObject.** If your code needs to be used by some Objective-C code, wrap it to expose the desired functionality. Use `@objc` on individual methods and variables as necessary rather than exposing all API on a class to Objective-C via `@objcMembers`.
+
+  <details>
+
+  ```swift
+  class PriceBreakdownViewController {
+
+    private let acceptButton = UIButton()
+
+    private func setUpAcceptButton() {
+      acceptButton.addTarget(
+        self,
+        action: #selector(didTapAcceptButton),
+        forControlEvents: .touchUpInside)
+    }
+
+    @objc
+    private func didTapAcceptButton() {
+      // ...
+    }
+  }
+  ```
+
   </details>
 
 **[⬆ back to top](#table-of-contents)**

--- a/README.md
+++ b/README.md
@@ -4031,6 +4031,44 @@ _You can enable the following settings in Xcode by running [this script](resourc
   ```
 
   </details>
+  
+* <a id='unused-private-declaration'></a>(<a href='#unused-private-declaration'>link</a>) **Remove unused private and fileprivate properties, functions, and typealiases** [![SwiftFormat: unusedPrivateDeclaration](https://img.shields.io/badge/SwiftFormat-unusedPrivateDeclaration-008489.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#unusedPrivateDeclaration)
+
+  <details>
+
+  #### Why?
+  
+  Improves readability since the code has no effect and should be removed for clarity.
+  
+  ```swift
+  // WRONG: Unused private property is unused and redundant
+  struct Planet {
+    private var mass: Double
+    
+    var age: Double
+  }
+
+  // WRONG: Unused private function is unused and redundant
+  struct Planet {
+    private func distance(to: Planet) { }
+    
+    var age: Double
+  }
+
+  // WRONG. Unused private typealias is unused and redundant
+  struct Planet {
+    private typealias Dependencies = UniverseBuilderProviding
+    
+    var age: Double
+  }
+    
+  // RIGHT
+  struct Planet {
+    var age: Double
+  }
+  ```
+  
+  </details>
 
 **[⬆ back to top](#table-of-contents)**
 

--- a/README.md
+++ b/README.md
@@ -4012,30 +4012,25 @@ _You can enable the following settings in Xcode by running [this script](resourc
   Improves readability since the code has no effect and should be removed for clarity.
   
   ```swift
-  // WRONG: Unused private property is unused and redundant
+  // WRONG: Includes private declarations that are unused
   struct Planet {
-    private var mass: Double
+    var ageInBillionYears: Double {
+      ageInMillionYears / 1000
+    }
     
-    var age: Double
-  }
-
-  // WRONG: Unused private function is unused and redundant
-  struct Planet {
-    private func distance(to: Planet) { }
-    
-    var age: Double
-  }
-
-  // WRONG. Unused private typealias is unused and redundant
-  struct Planet {
-    private typealias Dependencies = UniverseBuilderProviding
-    
-    var age: Double
+    private var ageInMillionsOfYears: Double
+    private typealias Dependencies = UniverseBuilderProviding // unused
+    private var mass: Double // unused
+    private func distance(to: Planet) { } // unused
   }
     
   // RIGHT
   struct Planet {
-    var age: Double
+    var ageInBillionsOfYears: Double {
+      ageInMillionYears / 1000
+    }
+
+    private var ageInMillionYears: Double
   }
   ```
   

--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -109,3 +109,4 @@
 --rules semicolons
 --rules propertyType
 --rules blankLinesBetweenChainedFunctions
+--rules unusedPrivateDeclaration


### PR DESCRIPTION
#### Summary

This PR adds rule `unusedPrivateDeclaration` to remove unused private and fileprivate properties, functions, and typealiases.

```swift
// WRONG: Includes private declarations that are unused
struct Planet {
  var ageInBillionYears: Double {
    ageInMillionYears / 1000
  }

  private var ageInMillionsOfYears: Double
  private typealias Dependencies = UniverseBuilderProviding // unused
  private var mass: Double // unused
  private func distance(to: Planet) { } // unused
}

// RIGHT
struct Planet {
  var ageInBillionsOfYears: Double {
    ageInMillionYears / 1000
  }

  private var ageInMillionYears: Double
}
```

#### Reasoning

Improves readability since the code has no effect and should be removed for clarity.
