### PR TITLE
Update colon spacing rule to apply to dictionary literals

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,37 +593,47 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
-* <a id='colon-spacing'></a>(<a href='#colon-spacing'>link</a>) **Place the colon immediately after an identifier, followed by a space.** [![SwiftLint: colon](https://img.shields.io/badge/SwiftLint-colon-007A87.svg)](https://realm.github.io/SwiftLint/colon)
+* <a id='colon-spacing'></a>(<a href='#colon-spacing'>link</a>) **Colons should always be followed by a space, but not preceded by a space**. [![SwiftLint: colon](https://img.shields.io/badge/SwiftLint-colon-007A87.svg)](https://realm.github.io/SwiftLint/colon)
 
   <details>
 
   ```swift
   // WRONG
-  var something : Double = 0
+  let planet:CelestialObject = sun.planets[0]
+  let planet : CelestialObject = sun.planets[0]
 
   // RIGHT
-  var something: Double = 0
+  let planet: CelestialObject = sun.planets[0]
   ```
 
   ```swift
   // WRONG
-  class MyClass : SuperClass {
+  class Planet : CelestialObject {
     // ...
   }
 
   // RIGHT
-  class MyClass: SuperClass {
+  class Planet: CelestialObject {
     // ...
   }
   ```
 
   ```swift
   // WRONG
-  var dict = [KeyType:ValueType]()
-  var dict = [KeyType : ValueType]()
+  let moons: [Planet : Moon] = [
+    mercury : [], 
+    venus : [], 
+    earth : [theMoon], 
+    mars : [phobos,deimos],
+  ]
 
   // RIGHT
-  var dict = [KeyType: ValueType]()
+  let moons: [Planet: Moon] = [
+    mercury: [], 
+    venus: [], 
+    earth: [theMoon], 
+    mars: [phobos,deimos],
+  ]
   ```
 
   </details>

--- a/Sources/AirbnbSwiftFormatTool/swiftlint.yml
+++ b/Sources/AirbnbSwiftFormatTool/swiftlint.yml
@@ -20,9 +20,6 @@ excluded:
   - Pods
   - .build
 
-colon:
-  apply_to_dictionaries: false
-
 indentation: 2
 
 custom_rules:


### PR DESCRIPTION
#### Summary

This PR proposes updating the existing colon-spacing rule to also apply to dictionary literals. Previously, it applied to all usage of commas _except_ dictionary literals.

```swift
// WRONG
let moons: [Planet : Moon] = [
  mercury : [], 
  venus : [], 
  earth : [theMoon], 
  mars : [phobos,deimos],
]

// RIGHT
let moons: [Planet: Moon] = [
  mercury: [], 
  venus: [], 
  earth: [theMoon], 
  mars: [phobos,deimos],
]
```

#### Reasoning

It is much more common to omit the space before colon in dictionary literals. This also makes the rule more consistent and general.

This will also let us replace the SwiftLint `colon` rule with the SwiftFormat `spaceAroundOperators` rule. The SwiftLint rule has a `apply_to_dictionaries: false` option to exclude dictionary literals, but the SwiftFormat rule currently does not.