### PR TITLE
Update infix operator spacing rule to clarify rule for operator definitions like `static func ==(lhs: T, rhs: T) -> Bool`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2450,24 +2450,34 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
 ### Operators
 
-* <a id='infix-operator-spacing'></a>(<a href='#infix-operator-spacing'>link</a>) **Infix operators should have a single space on either side.** Prefer parenthesis to visually group statements with many operators rather than varying widths of whitespace. This rule does not apply to range operators (e.g. `1...3`) and postfix or prefix operators (e.g. `guest?` or `-1`). [![SwiftLint: operator_usage_whitespace](https://img.shields.io/badge/SwiftLint-operator__usage__whitespace-007A87.svg)](https://realm.github.io/SwiftLint/operator_usage_whitespace)
+* <a id='infix-operator-spacing'></a>(<a href='#infix-operator-spacing'>link</a>) **Infix operators should have a single space on either side.** However, in operator definitions, omit the trailing space between the operator and the open parenthesis. This rule does not apply to range operators (e.g. `1...3`). [![SwiftLint: operator_usage_whitespace](https://img.shields.io/badge/SwiftLint-operator__usage__whitespace-007A87.svg)](https://realm.github.io/SwiftLint/operator_usage_whitespace)
 
   <details>
 
   ```swift
   // WRONG
   let capacity = 1+2
-  let capacity = currentCapacity   ?? 0
-  let mask = (UIAccessibilityTraitButton|UIAccessibilityTraitSelected)
+  let capacity = currentCapacity??0
   let capacity=newCapacity
-  let latitude = region.center.latitude - region.span.latitudeDelta/2.0
+  let latitude = region.center.latitude-region.span.latitudeDelta/2.0
 
   // RIGHT
   let capacity = 1 + 2
   let capacity = currentCapacity ?? 0
-  let mask = (UIAccessibilityTraitButton | UIAccessibilityTraitSelected)
   let capacity = newCapacity
-  let latitude = region.center.latitude - (region.span.latitudeDelta / 2.0)
+  let latitude = region.center.latitude - region.span.latitudeDelta / 2.0
+  ```
+
+  ```swift
+  // WRONG
+  static func == (_ lhs: MyView, _ rhs: MyView) -> Bool {
+    lhs.id == rhs.id
+  }
+
+  // RIGHT
+  static func ==(_ lhs: MyView, _ rhs: MyView) -> Bool {
+    lhs.id == rhs.id
+  }
   ```
 
   </details>

--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -34,6 +34,7 @@
 --redundanttype inferred # redundantType, propertyType
 --typeblanklines preserve # blankLinesAtStartOfScope, blankLinesAtEndOfScope
 --emptybraces spaced # emptyBraces
+--operatorfunc no-space # spaceAroundOperators
 --someAny disabled # opaqueGenericParameters
 --elseposition same-line # elseOnSameLine
 --guardelse next-line # elseOnSameLine


### PR DESCRIPTION
#### Summary

This PR proposals an update to the infix operator spacing rule, clarifying that we should omit the trailing space after operators in operator `func` implementations like `static func ==(lhs: T, rhs: T) -> Bool`

```swift
// WRONG
static func == (_ lhs: MyView, _ rhs: MyView) -> Bool {
  lhs.id == rhs.id
}

// RIGHT
static func ==(_ lhs: MyView, _ rhs: MyView) -> Bool {
  lhs.id == rhs.id
}
```

#### Reasoning

The existing wording of the rule implies that it applies in all cases. However, for operator definitions like this, omitting the space is more common.

In our codebase we have 540 examples of `func == (` and 709 examples of `func ==(`. All of the other custom operator definitions I found for other operators (`+`, `-`, `+=`, `!=`, `<`, `>`)  also omitted the trailing space.

This is also more consistent with other function definitions. For example, adding a space here looks weird and is disallowed in all other function definitions:

```swift
// Looks strange, not allowed
static func isEqual (_ lhs: MyView, _ rhs: MyView) -> Bool {
  lhs.id == rhs.id
}

// Right
static func isEqual(_ lhs: MyView, _ rhs: MyView) -> Bool {
  lhs.id == rhs.id
}
```