### PR TITLE
Add SwiftFormat void rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -3677,6 +3677,39 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
     </details>
 
+* <a id='generic-void'></a>(<a href='#generic-void'>link</a>) **Avoid using `()` as a generic type**. Prefer `Void`.
+
+  <details>
+
+  ```swift
+  struct Wrapper<T> { ... }
+  // WRONG
+  let wrapper = Wrapper<()>()
+
+  // RIGHT
+  let wrapper = Wrapper<Void>()
+  ```
+  </details>
+
+* <a id='void-instance'></a>(<a href='#void-instance'>link</a>) **Avoid using `Void()` as an instance of `Void`**. Prefer `()`.
+
+  <details>
+
+  ```swift
+  struct Resolver<T> { 
+    func resolve(T) { ... }
+  }
+
+  let resolver = Resolver()
+
+  // WRONG
+  resolver.resolve(Void())
+
+  // RIGHT
+  resolver.resolve(())
+  ```
+  </details>
+
 **[⬆ back to top](#table-of-contents)**
 
 ## File Organization

--- a/README.md
+++ b/README.md
@@ -3677,17 +3677,16 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
     </details>
 
-* <a id='generic-void'></a>(<a href='#generic-void'>link</a>) **Avoid using `()` as a generic type**. Prefer `Void`.
+* <a id='void-type'></a>(<a href='#void-type'>link</a>) **Avoid using `()` as a type**. Prefer `Void`.
 
   <details>
 
   ```swift
-  struct Wrapper<T> { ... }
   // WRONG
-  let wrapper = Wrapper<()>()
+  let result: Result<(), Error>
 
   // RIGHT
-  let wrapper = Wrapper<Void>()
+  let result: Result<Void, Error>
   ```
   </details>
 
@@ -3696,17 +3695,13 @@ _You can enable the following settings in Xcode by running [this script](resourc
   <details>
 
   ```swift
-  struct Resolver<T> { 
-    func resolve(T) { ... }
-  }
-
-  let resolver = Resolver()
+  let completion: (Result<Void, Error>) -> Void 
 
   // WRONG
-  resolver.resolve(Void())
-
+  completion(.success(Void()))
+  
   // RIGHT
-  resolver.resolve(())
+  completion(.success(()))
   ```
   </details>
 

--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -109,6 +109,7 @@
 --rules preferForLoop
 --rules conditionalAssignment
 --rules wrapMultilineConditionalAssignment
+--rules void
 --rules blankLineAfterSwitchCase
 --rules consistentSwitchCaseSpacing
 --rules semicolons

--- a/Sources/AirbnbSwiftFormatTool/swiftlint.yml
+++ b/Sources/AirbnbSwiftFormatTool/swiftlint.yml
@@ -6,7 +6,6 @@ only_rules:
   - legacy_constructor
   - legacy_nsgeometry_functions
   - unused_optional_binding
-  - void_return # TODO: Replace with SwiftFormat void rule
   - unowned_variable_capture
   - custom_rules
 


### PR DESCRIPTION
#### Summary

<!--- required --->

This PR replaces the SwiftLint `void_return` in favor to the SwiftFormat `void` rule in conjunction with the existing `redundantVoidReturnType` which cover the same functionality and additional rules described in the PR.

#### Reasoning

<!--- required --->

This is an effort to migrate all autocorrect rules to SwiftFormat
