### PR TITLE
Add SwiftUI properties sort

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -42,8 +42,8 @@ let package = Package(
 
     .binaryTarget(
       name: "swiftformat",
-      url: "https://github.com/calda/SwiftFormat/releases/download/0.55-beta-11/SwiftFormat.artifactbundle.zip",
-      checksum: "421884ecccc34b75135e9aa4b80e21ee6d9985084896fe8d58e07b28d9a2e0f6"),
+      url: "https://github.com/calda/SwiftFormat/releases/download/0.55-beta-12/SwiftFormat.artifactbundle.zip",
+      checksum: "8783cefc0837416759f81064df7907cc60ddca6d3f8c3b301b123a2193a8585b"),
 
     .binaryTarget(
       name: "SwiftLintBinary",

--- a/README.md
+++ b/README.md
@@ -4002,7 +4002,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
     }
     ```
 
-    Additioanlly, after grouping SwiftUI properties, its prefered that propeties are sorted by their dynamic property type. The order is determined by the first time a type appears:
+    Additioanlly, after grouping SwiftUI properties, its preferred that properties are sorted by their dynamic property type. The order is determined by the first time a type appears:
 
     ```swift
     // WRONG

--- a/README.md
+++ b/README.md
@@ -3908,7 +3908,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
   * Static properties
   * Static property with body
   * Class properties with body
-  * SwiftUI dynamic properties (@State, @Environment, @Binding, etc)
+  * SwiftUI dynamic properties (@State, @Environment, @Binding, etc), grouped by type
   * Instance properties
   * Instance properties with body
   * Static methods
@@ -4002,7 +4002,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
     }
     ```
 
-    Additioanlly, after grouping SwiftUI properties, its preferred that properties are sorted by their dynamic property type. The order is determined by the first time a type appears:
+    Additionally, within the grouping of SwiftUI properties, it is preferred that the properties are also grouped by their dynamic property type. The group order applied by the formatter is determined by the first time a type appears:
 
     ```swift
     // WRONG

--- a/README.md
+++ b/README.md
@@ -4001,6 +4001,37 @@ _You can enable the following settings in Xcode by running [this script](resourc
       private let step: Double.Stride
     }
     ```
+
+    Additioanlly, after grouping SwiftUI properties, its prefered that propeties are sorted by their dynamic property type. The order is determined by the first time a type appears:
+
+    ```swift
+    // WRONG
+    struct CustomSlider: View {
+
+      @Binding private var value: Value
+      @State private var foo = Foo()
+      @Environment(\.sliderStyle) private var style
+      @State private var bar = Bar()
+      @Environment(\.layoutDirection) private var layoutDirection
+
+      private let range: ClosedRange<Double>
+      private let step: Double.Stride
+    }
+
+    // RIGHT
+    struct CustomSlider: View {
+
+      @Binding private var value: Value
+      @State private var foo = Foo()
+      @State private var bar = Bar()
+      @Environment(\.sliderStyle) private var style
+      @Environment(\.layoutDirection) private var layoutDirection
+
+      private let range: ClosedRange<Double>
+      private let step: Double.Stride
+    }
+    ```
+
   </details>
 
 

--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -25,6 +25,7 @@
 --typeattributes prev-line # wrapAttributes
 --wrapternary before-operators # wrap
 --structthreshold 20 # organizeDeclarations
+--sortswiftuiprops first-appearance-sort
 --enumthreshold 20 # organizeDeclarations
 --organizetypes class,struct,enum,extension,actor # organizeDeclarations
 --visibilityorder beforeMarks,instanceLifecycle,open,public,package,internal,fileprivate,private # organizeDeclarations

--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -25,11 +25,11 @@
 --typeattributes prev-line # wrapAttributes
 --wrapternary before-operators # wrap
 --structthreshold 20 # organizeDeclarations
---sortswiftuiprops first-appearance-sort
 --enumthreshold 20 # organizeDeclarations
 --organizetypes class,struct,enum,extension,actor # organizeDeclarations
 --visibilityorder beforeMarks,instanceLifecycle,open,public,package,internal,fileprivate,private # organizeDeclarations
 --typeorder nestedType,staticProperty,staticPropertyWithBody,classPropertyWithBody,swiftUIPropertyWrapper,instanceProperty,instancePropertyWithBody,staticMethod,classMethod,instanceMethod # organizeDeclarations
+--sortswiftuiprops first-appearance-sort #organizeDeclarations
 --extensionacl on-declarations # extensionAccessControl
 --patternlet inline # hoistPatternLet
 --redundanttype inferred # redundantType, propertyType


### PR DESCRIPTION
#### Summary

<!--- required --->

This PR adds the SwiftUI property declaration sort rule to the style guide.

#### Reasoning

its preferred that SwiftUI properties are sorted by their dynamic property type. The order is determined by the first time a type appears:

```swift
    // WRONG
    struct CustomSlider: View {

      @Binding private var value: Value
      @State private var foo = Foo()
      @Environment(\.sliderStyle) private var style
      @State private var bar = Bar()
      @Environment(\.layoutDirection) private var layoutDirection

      private let range: ClosedRange<Double>
      private let step: Double.Stride
    }

    // RIGHT
    struct CustomSlider: View {

      @Binding private var value: Value
      @State private var foo = Foo()
      @State private var bar = Bar()
      @Environment(\.sliderStyle) private var style
      @Environment(\.layoutDirection) private var layoutDirection

      private let range: ClosedRange<Double>
      private let step: Double.Stride
    }
```
