### PR TITLE
Add rule to prefer a generated EnvironmentValue property implementation when possible

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -42,8 +42,8 @@ let package = Package(
 
     .binaryTarget(
       name: "swiftformat",
-      url: "https://github.com/calda/SwiftFormat/releases/download/0.55-beta-16/SwiftFormat.artifactbundle.zip",
-      checksum: "3db287e8fec8dea6eb73e646c0e69285d0140e409e78644b22286d92e4ae573c"),
+      url: "https://github.com/calda/SwiftFormat/releases/download/0.55-beta-17/SwiftFormat.artifactbundle.zip",
+      checksum: "659bdcccc69a6e5ccbd273f0fb7b7af9655d5fa7acc17c4fb3deba6a7b1e9a5b"),
 
     .binaryTarget(
       name: "SwiftLintBinary",

--- a/Package.swift
+++ b/Package.swift
@@ -42,8 +42,8 @@ let package = Package(
 
     .binaryTarget(
       name: "swiftformat",
-      url: "https://github.com/calda/SwiftFormat/releases/download/0.55-beta-15/SwiftFormat.artifactbundle.zip",
-      checksum: "5da82a61d4a29e77acc5a2e8668c40168970e1d6b2078bdfcb377b6f6ef35039"),
+      url: "https://github.com/calda/SwiftFormat/releases/download/0.55-beta-16/SwiftFormat.artifactbundle.zip",
+      checksum: "3db287e8fec8dea6eb73e646c0e69285d0140e409e78644b22286d92e4ae573c"),
 
     .binaryTarget(
       name: "SwiftLintBinary",

--- a/README.md
+++ b/README.md
@@ -3745,6 +3745,35 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
     </details>
 
+* <a id='redundant-environment-key-implementation'></a>(<a href='#redundant-environment-key-implementation'>link</a>) **Prefer using the `@Entry` macro to define properties inside `EnvironmentValues`**. When adding properties to SwiftUI `EnvironemtnValues`, prefer using the compiler-synthesized property implementation when possible. [![SwiftFormat: environmentEntry](https://img.shields.io/badge/SwiftFormat-environmentEntry-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/develop/Rules.md#environmentEntry)
+
+    <details>
+
+    ### Why?
+
+    Manually-implemented environment keys are verbose, and keeping them up-to-date is error-prone.
+
+    ```swift
+    /// WRONG: The `EnvironmentValues` property depends on `IsSelectedEnvironmentKey`
+    struct IsSelectedEnvironmentKey: EnvironmentKey {
+      static var defaultValue: Bool { false }
+    }
+    
+    extension EnvironmentValues {
+      var isSelected: Bool {
+       get { self[IsSelectedEnvironmentKey.self] }
+       set { self[IsSelectedEnvironmentKey.self] = newValue }
+      }
+    }
+
+    /// RIGHT: The `EnvironmentValues` property uses the @Entry macro 
+    extension EnvironmentValues {
+      @Entry var isSelected: Bool = false
+    }
+    ```
+    
+    </details>
+
 * <a id='void-type'></a>(<a href='#void-type'>link</a>) **Avoid using `()` as a type**. Prefer `Void`.
 
   <details>

--- a/README.md
+++ b/README.md
@@ -3751,7 +3751,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
     ### Why?
 
-    Manually-implemented environment keys are verbose, and keeping them up-to-date is error-prone.
+    Manually-implemented environment keys are verbose and it is considered a legacy pattern. `@Entry` was specifically intended to be a replacement considering it was backported to iOS 13.
 
     ```swift
     /// WRONG: The `EnvironmentValues` property depends on `IsSelectedEnvironmentKey`
@@ -3771,7 +3771,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
       @Entry var isSelected: Bool = false
     }
     ```
-    
+
     </details>
 
 * <a id='void-type'></a>(<a href='#void-type'>link</a>) **Avoid using `()` as a type**. Prefer `Void`.

--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -56,6 +56,7 @@
 --rules consecutiveBlankLines
 --rules duplicateImports
 --rules extensionAccessControl
+--rules environmentEntry
 --rules hoistPatternLet
 --rules indent
 --rules markTypes


### PR DESCRIPTION
#### Summary

<!--- required --->

This PR adds a new rule to prefer using a generated EnvironmentValues property implementation.

This rule is implemented by the new `environmentEntry` SwiftFormat rule added in https://github.com/nicklockwood/SwiftFormat/pull/1908.

 ```swift
 /// WRONG: The `EnvironmentValues` property depends on `IsSelectedEnvironmentKey`
 struct IsSelectedEnvironmentKey: EnvironmentKey {
   static var defaultValue: Bool { false }
 }
 
 extension EnvironmentValues {
   var isSelected: Bool {
    get { self[IsSelectedEnvironmentKey.self] }
    set { self[IsSelectedEnvironmentKey.self] = newValue }
   }
 }

/// RIGHT: The `EnvironmentValues` property uses the @Entry macro 
extension EnvironmentValues {
  @Entry var isSelected: Bool = false
}
```

#### Reasoning

<!--- required --->

 Manually-implemented environment keys are verbose and it is considered a legacy pattern. `@Entry` was specifically intended to be a replacement considering it was back ported to iOS 13.
