### PR TITLE
Update to SwiftFormat 0.56-beta-1 based on 0.55 release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,23 +7,7 @@ on:
     branches: [ master ]
 
 jobs:
-  test-package-plugin-macos-12:
-    name: Test Package Plugin
-    runs-on: macos-12
-    strategy:
-      fail-fast: false
-      matrix:
-        xcode:
-        - '13.4.1' # Swift 5.6
-    steps:
-      - uses: actions/checkout@v2
-      - uses: ./.github/actions/setup
-        with:
-          xcode: ${{ matrix.xcode }}
-      - name: Test Package Plugin
-        run: bundle exec rake lint:swift
-
-  test-package-plugin-macos-13:
+  test-package-plugin:
     name: Test Package Plugin
     runs-on: macos-13
     strategy:

--- a/Package.swift
+++ b/Package.swift
@@ -42,8 +42,8 @@ let package = Package(
 
     .binaryTarget(
       name: "swiftformat",
-      url: "https://github.com/calda/SwiftFormat/releases/download/0.55-beta-17/SwiftFormat.artifactbundle.zip",
-      checksum: "659bdcccc69a6e5ccbd273f0fb7b7af9655d5fa7acc17c4fb3deba6a7b1e9a5b"),
+      url: "https://github.com/calda/SwiftFormat/releases/download/0.56-beta-1-build-2/SwiftFormat.artifactbundle.zip",
+      checksum: "52555bc9fa90a31e68f77917eac2307c2ebbad023d83b3e728e0deb2c7ec98a2"),
 
     .binaryTarget(
       name: "SwiftLintBinary",

--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
-* <a id='infer-property-types'></a>(<a href='#infer-property-types'>link</a>) **Prefer letting the type of a variable or property be inferred from the right-hand-side value rather than writing the type explicitly on the left-hand side.** [![SwiftFormat: propertyType](https://img.shields.io/badge/SwiftFormat-propertyType-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#propertyType)
+* <a id='infer-property-types'></a>(<a href='#infer-property-types'>link</a>) **Prefer letting the type of a variable or property be inferred from the right-hand-side value rather than writing the type explicitly on the left-hand side.** [![SwiftFormat: propertyTypes](https://img.shields.io/badge/SwiftFormat-propertyTypes-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#propertyTypes)
 
   <details>
 
@@ -1880,7 +1880,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
-* <a id='doc-comments-before-attributes'></a>(<a href='#doc-comments-before-attributes'>link</a>) **Place doc comments for a declaration before any attributes.** [![SwiftFormat: docCommentsBeforeAttributes](https://img.shields.io/badge/SwiftFormat-docCommentsBeforeAttributes-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#docCommentsBeforeAttributes)
+* <a id='doc-comments-before-attributes'></a>(<a href='#doc-comments-before-attributes'>link</a>) **Place doc comments for a declaration before any attributes or modifiers.** [![SwiftFormat: docCommentsBeforeModifiers](https://img.shields.io/badge/SwiftFormat-docCommentsBeforeModifiers-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#docCommentsBeforeModifiers)
 
   <details>
 
@@ -1891,11 +1891,18 @@ _You can enable the following settings in Xcode by running [this script](resourc
   /// A spacecraft with everything you need to explore the universe.
   struct Spaceship { … }
 
+  public
+  /// A spacecraft with everything you need to explore the universe.
+  struct Spaceship { … }
+
   // RIGHT
 
   /// A spacecraft with everything you need to explore the universe.
   @MainActor
   struct Spaceship { … }
+
+  /// A spacecraft with everything you need to explore the universe.
+  public struct Spaceship { … }
   ```
 
   </details>
@@ -3758,7 +3765,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
     struct IsSelectedEnvironmentKey: EnvironmentKey {
       static var defaultValue: Bool { false }
     }
-    
+
     extension EnvironmentValues {
       var isSelected: Bool {
        get { self[IsSelectedEnvironmentKey.self] }
@@ -4179,7 +4186,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
       
-* <a id='unused-private-declaration'></a>(<a href='#unused-private-declaration'>link</a>) **Remove unused private and fileprivate properties, functions, and typealiases** [![SwiftFormat: unusedPrivateDeclaration](https://img.shields.io/badge/SwiftFormat-unusedPrivateDeclaration-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#unusedPrivateDeclaration)
+* <a id='unused-private-declaration'></a>(<a href='#unused-private-declaration'>link</a>) **Remove unused private and fileprivate properties, functions, and typealiases** [![SwiftFormat: unusedPrivateDeclarations](https://img.shields.io/badge/SwiftFormat-unusedPrivateDeclarations-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#unusedPrivateDeclarations)
 
   <details>
 
@@ -4212,7 +4219,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
   
   </details>
   
-* <a id='remove-empty-extensions'></a>(<a href='#remove-empty-extensions'>link</a>) **Remove empty extensions that define no properties, functions, or conformances.** [![SwiftFormat: emptyExtension](https://img.shields.io/badge/SwiftFormat-emptyExtension-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#emptyExtension)
+* <a id='remove-empty-extensions'></a>(<a href='#remove-empty-extensions'>link</a>) **Remove empty extensions that define no properties, functions, or conformances.** [![SwiftFormat: emptyExtensions](https://img.shields.io/badge/SwiftFormat-emptyExtensions-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#emptyExtensions)
 
   <details>
 

--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -33,7 +33,7 @@
 --sortswiftuiprops first-appearance-sort #organizeDeclarations
 --extensionacl on-declarations # extensionAccessControl
 --patternlet inline # hoistPatternLet
---redundanttype inferred # redundantType, propertyType
+--propertytypes inferred # redundantType, propertyTypes
 --typeblanklines preserve # blankLinesAtStartOfScope, blankLinesAtEndOfScope
 --emptybraces spaced # emptyBraces
 --ranges preserve # spaceAroundOperators
@@ -98,7 +98,7 @@
 --rules enumNamespaces
 --rules blockComments
 --rules docComments
---rules docCommentsBeforeAttributes
+--rules docCommentsBeforeModifiers
 --rules spaceAroundComments
 --rules spaceInsideComments
 --rules blankLinesAtStartOfScope
@@ -117,7 +117,7 @@
 --rules blankLineAfterSwitchCase
 --rules consistentSwitchCaseSpacing
 --rules semicolons
---rules propertyType
+--rules propertyTypes
 --rules blankLinesBetweenChainedFunctions
---rules unusedPrivateDeclaration
---rules emptyExtension
+--rules unusedPrivateDeclarations
+--rules emptyExtensions


### PR DESCRIPTION
SwiftFormat 0.55 was recently released. This PR updates our build to 0.56-beta-1, which is based off of 0.55.3.

Several rules that were previously only available on `develop` were released officially in 0.55.0. As a part of this some of the rule and option names were updated.