### PR TITLE
Add rule to prefer `count(where: { ... })` over `filter { ... }.count`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -42,8 +42,8 @@ let package = Package(
 
     .binaryTarget(
       name: "swiftformat",
-      url: "https://github.com/calda/SwiftFormat/releases/download/0.56-beta-1-build-2/SwiftFormat.artifactbundle.zip",
-      checksum: "52555bc9fa90a31e68f77917eac2307c2ebbad023d83b3e728e0deb2c7ec98a2"),
+      url: "https://github.com/calda/SwiftFormat/releases/download/0.56-beta-3/SwiftFormat.artifactbundle.zip",
+      checksum: "4fef0f8d76ed185c1fe2026cfd6252504b1adb37fdda4ffff379fa2820d282cd"),
 
     .binaryTarget(
       name: "SwiftLintBinary",

--- a/README.md
+++ b/README.md
@@ -3809,6 +3809,21 @@ _You can enable the following settings in Xcode by running [this script](resourc
   ```
   </details>
 
+* <a id='count-where'></a>(<a href='#count-where'>link</a>) **Prefer using `count(where: { … })` over `filter { … }.count`**.
+
+  <details>
+
+  Swift 6.0 ([finally!](https://forums.swift.org/t/accepted-again-se-0220-count-where/66659)) added a `count(where:)` method to the standard library. Prefer using the `count(where:)` method over using the `filter(_:)` method followed by a `count` call.
+
+  ```swift
+  // WRONG
+  let planetsWithMoons = planets.filter { !$0.moons.isEmpty }.count
+
+  // RIGHT
+  let planetsWithMoons = planets.count(where: { !$0.moons.isEmpty })
+  ```
+  </details>
+
 **[⬆ back to top](#table-of-contents)**
 
 ## File Organization

--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -121,3 +121,4 @@
 --rules blankLinesBetweenChainedFunctions
 --rules unusedPrivateDeclarations
 --rules emptyExtensions
+--rules preferCountWhere


### PR DESCRIPTION
#### Summary

This PR proposes a new rule to prefer using `count(where: { ... })` over `filter { ... }.count`.

```swift
// WRONG
let planetsWithMoons = planets.filter { !$0.moons.isEmpty }.count

// RIGHT
let planetsWithMoons = planets.count(where: { !$0.moons.isEmpty })
```

Autocorrect is implemented in https://github.com/nicklockwood/SwiftFormat/pull/1939.

#### Reasoning

 Swift 6.0 ([finally!](https://forums.swift.org/t/accepted-again-se-0220-count-where/66659)) added a `count(where:)` method to the standard library.
