### PR TITLE
Add rule to avoid prefixing Swift Testing test case methods with "test"

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -42,8 +42,8 @@ let package = Package(
 
     .binaryTarget(
       name: "swiftformat",
-      url: "https://github.com/calda/SwiftFormat/releases/download/0.56-beta-6/SwiftFormat.artifactbundle.zip",
-      checksum: "5248a8e1d3ff8165ed1f4bbfbc9b763a77f22e656f067d8e01b61b3b8d6ca5ec"),
+      url: "https://github.com/calda/SwiftFormat/releases/download/0.56-beta-8/SwiftFormat.artifactbundle.zip",
+      checksum: "32e21fd84bffcc9154c7d80ff2173fb1d6a3dbd740e4bf6a151b6e33e0cced3d"),
 
     .binaryTarget(
       name: "SwiftLintBinary",

--- a/README.md
+++ b/README.md
@@ -3781,7 +3781,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
     </details>
 
-* <a id='void-type'></a>(<a href='#void-type'>link</a>) **Avoid using `()` as a type**. Prefer `Void`.
+* <a id='void-type'></a>(<a href='#void-type'>link</a>) **Avoid using `()` as a type**. Prefer `Void`. [![SwiftFormat: void](https://img.shields.io/badge/SwiftFormat-void-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#void)
 
   <details>
 
@@ -3794,7 +3794,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
   ```
   </details>
 
-* <a id='void-instance'></a>(<a href='#void-instance'>link</a>) **Avoid using `Void()` as an instance of `Void`**. Prefer `()`.
+* <a id='void-instance'></a>(<a href='#void-instance'>link</a>) **Avoid using `Void()` as an instance of `Void`**. Prefer `()`. [![SwiftFormat: void](https://img.shields.io/badge/SwiftFormat-void-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#void)
 
   <details>
 
@@ -3809,7 +3809,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
   ```
   </details>
 
-* <a id='count-where'></a>(<a href='#count-where'>link</a>) **Prefer using `count(where: { … })` over `filter { … }.count`**.
+* <a id='count-where'></a>(<a href='#count-where'>link</a>) **Prefer using `count(where: { … })` over `filter { … }.count`**. [![SwiftFormat: preferCountWhere](https://img.shields.io/badge/SwiftFormat-preferCountWhere-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#preferCountWhere)
 
   <details>
 
@@ -3821,6 +3821,37 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   // RIGHT
   let planetsWithMoons = planets.count(where: { !$0.moons.isEmpty })
+  ```
+  </details>
+
+* <a id='swift-testing-test-case-names'></a>(<a href='#swift-testing-test-case-names'>link</a>) **In Swift Testing, don't prefix test case methods with "`test`".** [![SwiftFormat: swiftTestingTestCaseNames](https://img.shields.io/badge/SwiftFormat-swiftTestingTestCaseNames-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#swiftTestingTestCaseNames)
+
+  <details>
+
+  ### Why?
+
+  Prefixing test case methods with "`test`" was necessary with XCTest, but is not necessary in Swift Testing. [Idiomatic usage](https://developer.apple.com/documentation/testing/migratingfromxctest#Convert-test-methods) of Swift Testing excludes the "`test`" prefix.
+
+  ```swift
+  import Testing
+  
+  /// WRONG
+  struct SpaceshipTests {
+    @Test
+    func testWarpDriveEnablesFTLTravel() { ... }
+
+    @Test
+    func testArtificialGravityMatchesEarthGravity() { ... }
+  }
+
+  /// RIGHT
+  struct SpaceshipTests {
+    @Test
+    func warpDriveEnablesFTLTravel() { ... }
+
+    @Test
+    func artificialGravityMatchesEarthGravity() { ... }
+  }
   ```
   </details>
 

--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -122,3 +122,4 @@
 --rules unusedPrivateDeclarations
 --rules emptyExtensions
 --rules preferCountWhere
+--rules swiftTestingTestCaseNames


### PR DESCRIPTION
#### Summary

This PR proposes a new rule to avoid prefixing Swift Testing test case methods with a "`test`" prefix. Autocorrect is implemented in the `swiftTestingTestCaseNames` SwiftFormat rule ([nicklockwood/SwiftFormat#1979](https://github.com/nicklockwood/SwiftFormat/pull/1979#issuecomment-2667272951)).

```swift
import Testing

/// WRONG
struct SpaceshipTests {
  @Test
  func testWarpDriveEnablesFTLTravel() { ... }

  @Test
  func testArtificialGravityMatchesEarthGravity() { ... }
}

/// RIGHT
struct SpaceshipTests {
  @Test
  func warpDriveEnablesFTLTravel() { ... }

  @Test
  func artificialGravityMatchesEarthGravity() { ... }
}
```

#### Reasoning

Prefixing test case methods with "`test`" was necessary with XCTest, but is not necessary in Swift Testing. [Idiomatic usage](https://developer.apple.com/documentation/testing/migratingfromxctest#Convert-test-methods) of Swift Testing excludes the "`test`" prefix.

From Apple's [migration guide](https://developer.apple.com/documentation/testing/migratingfromxctest#Convert-test-methods):

<img width="969" alt="image" src="https://github.com/user-attachments/assets/c1679476-8d86-485e-9345-9a1fb270dbb4" />

