### PR TITLE
Add wildcard pattern support for `—exclude` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,9 @@ $ swift package format --lint
 
 # By default the command plugin runs on the entire package directory.
 # You can exclude directories using `exclude`:
-$ swift package format --exclude Tests
+$ swift package format --exclude "/Tests" # Only exclude the `Tests` directory under the root directory
+$ swift package format --exclude "Tests/" # Exclude all directories named `Tests` and their contents
+$ swift package format --exclude "*.tmp" # Exclude all files ending with `.tmp`
 
 # Alternatively you can explicitly list the set of paths and/or SPM targets:
 $ swift package format --paths Sources Tests Package.swift


### PR DESCRIPTION
#### Summary

Enhances the path exclusion functionality to support wildcard patterns:
- Add support for * (match any number of characters) and ? (match single character)
- Implement special path formats:
  - /pattern: Only match at root level
  - pattern/: Match directories and their contents
- Improve performance by using efficient pattern matching

This change allows for more flexible and precise control over which paths
should be excluded during processing, without requiring third-party dependencies.

#### Reasoning

Currently, only fixed folders are supported, and wildcards are not supported. This is not easy to use in some scenarios. For example, Tuist will put the automatically generated files into the `Derived` folder. These folders may be scattered in multiple subfolders of the same project, such as the following:

<details>

```
.
├── App
│   ├── Derived
│   │   ├── InfoPlists
│   │   └── Sources
│   ├── App.xcodeproj
│   ├── Project.swift
│   ├── Resources
│   │   └── Assets.xcassets
│   ├── Sources
│   └── Tests
├── Components
│   ├── Settings
│   │   ├── Settings.xcodeproj
│   │   ├── Derived
│   │   ├── Project.swift
│   │   ├── Sources
│   │   └── Tests
│   └── InternalTools
│       ├── Derived
│       ├── Project.swift
│       ├── Resources
│       ├── Sources
│       ├── InternalTools.xcodeproj
│       └── Tests
├── App.xcworkspace
├── Package.resolved
├── Package.swift
├── Tuist
│   ├── ProjectDescriptionHelpers
│   └── ResourceSynthesizers
├── Tuist.swift
└── Workspace.swift
```

</details>

After adding the wildcard function, you can use `--exclude "Derived/"` to exclude all `Derived` directories. When adding new submodules in the future, there is no need to modify the format configuration.

#### Break

This change affects existing functionality. For the original README:
```
$ swift package format --exclude Tests
```

Now matches all paths containing a file or directory component named "Test", e.g.
- `Tests` (a single `Tests` file or directory)
- `path/to/Tests` (a file or directory named `Tests` at any level)
- `src/Tests/file.swift` (a path containing a `Tests` directory)