### PR TITLE
Remove unusedPrivateDeclarations rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -4231,39 +4231,6 @@ _You can enable the following settings in Xcode by running [this script](resourc
   ```
 
   </details>
-      
-* <a id='unused-private-declaration'></a>(<a href='#unused-private-declaration'>link</a>) **Remove unused private and fileprivate properties, functions, and typealiases** [![SwiftFormat: unusedPrivateDeclarations](https://img.shields.io/badge/SwiftFormat-unusedPrivateDeclarations-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#unusedPrivateDeclarations)
-
-  <details>
-
-  #### Why?
-  
-  Improves readability since the code has no effect and should be removed for clarity.
-  
-  ```swift
-  // WRONG: Includes private declarations that are unused
-  struct Planet {
-    var ageInBillionYears: Double {
-      ageInMillionYears / 1000
-    }
-    
-    private var ageInMillionsOfYears: Double
-    private typealias Dependencies = UniverseBuilderProviding // unused
-    private var mass: Double // unused
-    private func distance(to: Planet) { } // unused
-  }
-    
-  // RIGHT
-  struct Planet {
-    var ageInBillionsOfYears: Double {
-      ageInMillionYears / 1000
-    }
-
-    private var ageInMillionYears: Double
-  }
-  ```
-  
-  </details>
   
 * <a id='remove-empty-extensions'></a>(<a href='#remove-empty-extensions'>link</a>) **Remove empty extensions that define no properties, functions, or conformances.** [![SwiftFormat: emptyExtensions](https://img.shields.io/badge/SwiftFormat-emptyExtensions-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#emptyExtensions)
 

--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -119,7 +119,6 @@
 --rules semicolons
 --rules propertyTypes
 --rules blankLinesBetweenChainedFunctions
---rules unusedPrivateDeclarations
 --rules emptyExtensions
 --rules preferCountWhere
 --rules swiftTestingTestCaseNames


### PR DESCRIPTION
#### Summary

We are removing the `unusedPrivateDeclarations` rule from the Airbnb Swift Style Guide

#### Reasoning

Limits the capabilities of Swift macros and creates more edge cases since linting is destructive.
