### PR TITLE
Update SwiftLint to 0.59.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -47,6 +47,6 @@ let package = Package(
 
     .binaryTarget(
       name: "SwiftLintBinary",
-      url: "https://github.com/realm/SwiftLint/releases/download/0.55.1/SwiftLintBinary-macos.artifactbundle.zip",
-      checksum: "722a705de1cf4e0e07f2b7d2f9f631f3a8b2635a0c84cce99f9677b38aa4a1d6"),
+      url: "https://github.com/realm/SwiftLint/releases/download/0.59.1/SwiftLintBinary.artifactbundle.zip",
+      checksum: "b9f915a58a818afcc66846740d272d5e73f37baf874e7809ff6f246ea98ad8a2"),
   ])


### PR DESCRIPTION
#### Summary

This PR updates SwiftLint to the latest version, as of now, which is 0.59.1.