### PR TITLE
Update `update:swiftformat` to use nightly builds from `calda/SwiftFormat-nightly` repo

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -42,8 +42,8 @@ let package = Package(
 
     .binaryTarget(
       name: "swiftformat",
-      url: "https://github.com/calda/SwiftFormat/releases/download/0.56-beta-9/SwiftFormat.artifactbundle.zip",
-      checksum: "e23e0b25175ba71db1aca2e8ff78d0aa103f0f3312edf8009454ee8e5764ea15"),
+      url: "https://github.com/calda/SwiftFormat-nightly/releases/download/2025-05-08-b/SwiftFormat.artifactbundle.zip",
+      checksum: "ce079f8a7c8d8ba2f9d6aa461367808b2d56b99739b0791946ed23059da88017"),
 
     .binaryTarget(
       name: "SwiftLintBinary",

--- a/Rakefile
+++ b/Rakefile
@@ -20,15 +20,15 @@ end
 namespace :update do
   desc 'Updates SwiftFormat to the latest version'
   task :swiftformat do
-    # Find the most recent release of SwiftFormat in the https://github.com/calda/SwiftFormat repo.
-    response = Net::HTTP.get(URI('https://api.github.com/repos/calda/SwiftFormat/releases/latest'))
+    # Find the most recent nightly release of SwiftFormat in the https://github.com/calda/SwiftFormat-nightly repo.
+    response = Net::HTTP.get(URI('https://api.github.com/repos/calda/SwiftFormat-nightly/releases/latest'))
     latest_release_info = JSON.parse(response)
 
     latest_version_number = latest_release_info['tag_name']
 
     # Download the artifact bundle for the latest release and compute its checksum.
     temp_dir = Dir.mktmpdir
-    artifact_bundle_url = "https://github.com/calda/SwiftFormat/releases/download/#{latest_version_number}/swiftformat.artifactbundle.zip"
+    artifact_bundle_url = "https://github.com/calda/SwiftFormat-nightly/releases/download/#{latest_version_number}/swiftformat.artifactbundle.zip"
     artifact_bundle_zip_path = "#{temp_dir}/swiftformat.artifactbundle.zip"
     
     sh "curl #{artifact_bundle_url} -L --output #{artifact_bundle_zip_path}"
@@ -41,7 +41,7 @@ namespace :update do
     updated_swift_format_reference = <<-EOS
     .binaryTarget(
       name: "swiftformat",
-      url: "https://github.com/calda/SwiftFormat/releases/download/#{latest_version_number}/SwiftFormat.artifactbundle.zip",
+      url: "https://github.com/calda/SwiftFormat-nightly/releases/download/#{latest_version_number}/SwiftFormat.artifactbundle.zip",
       checksum: "#{checksum.strip}"),
     EOS
     


### PR DESCRIPTION
To simplify the process of adopting prerelease SwiftFormat builds, I set up a new nightly build pipeline in [calda/SwiftFormat-nightly](https://github.com/calda/SwiftFormat-nightly).

This PR updates `bundle exec rake update:swiftformat` to use the latest nightly build from that repo.

To confirm that works this PR also updates to the current nightly build.