### PR TITLE
Match call-site paren on multi-line function calls

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,15 +16,18 @@ let package = Package(
       capability: .command(
         intent: .custom(
           verb: "format",
-          description: "Formats Swift source files according to the Airbnb Swift Style Guide"),
+          description: "Formats Swift source files according to the Airbnb Swift Style Guide"
+        ),
         permissions: [
           .writeToPackageDirectory(reason: "Format Swift source files"),
-        ]),
+        ]
+      ),
       dependencies: [
         "AirbnbSwiftFormatTool",
         "swiftformat",
         "SwiftLintBinary",
-      ]),
+      ]
+    ),
 
     .executableTarget(
       name: "AirbnbSwiftFormatTool",
@@ -34,19 +37,24 @@ let package = Package(
       resources: [
         .process("airbnb.swiftformat"),
         .process("swiftlint.yml"),
-      ]),
+      ]
+    ),
 
     .testTarget(
       name: "AirbnbSwiftFormatToolTests",
-      dependencies: ["AirbnbSwiftFormatTool"]),
+      dependencies: ["AirbnbSwiftFormatTool"]
+    ),
 
     .binaryTarget(
       name: "swiftformat",
       url: "https://github.com/calda/SwiftFormat-nightly/releases/download/2025-05-15-b/SwiftFormat.artifactbundle.zip",
-      checksum: "0d6f365f00de0567c5a7a0caf33b593c2a9029cf27462c63879280839f5f2d9c"),
+      checksum: "0d6f365f00de0567c5a7a0caf33b593c2a9029cf27462c63879280839f5f2d9c"
+    ),
 
     .binaryTarget(
       name: "SwiftLintBinary",
       url: "https://github.com/realm/SwiftLint/releases/download/0.55.1/SwiftLintBinary-macos.artifactbundle.zip",
-      checksum: "722a705de1cf4e0e07f2b7d2f9f631f3a8b2635a0c84cce99f9677b38aa4a1d6"),
-  ])
+      checksum: "722a705de1cf4e0e07f2b7d2f9f631f3a8b2635a0c84cce99f9677b38aa4a1d6"
+    ),
+  ]
+)

--- a/Plugins/FormatSwift/Plugin.swift
+++ b/Plugins/FormatSwift/Plugin.swift
@@ -106,7 +106,8 @@ extension AirbnbSwiftFormatPlugin: CommandPlugin {
     try performCommand(
       context: context,
       inputPaths: inputPaths,
-      arguments: arguments)
+      arguments: arguments
+    )
   }
 
   // MARK: Private
@@ -125,7 +126,8 @@ extension AirbnbSwiftFormatPlugin: CommandPlugin {
     let packageDirectoryContents = try FileManager.default.contentsOfDirectory(
       at: URL(fileURLWithPath: package.directory.string),
       includingPropertiesForKeys: nil,
-      options: [.skipsHiddenFiles])
+      options: [.skipsHiddenFiles]
+    )
 
     let subdirectories = packageDirectoryContents.filter { $0.hasDirectoryPath }
     let rootSwiftFiles = packageDirectoryContents.filter { $0.pathExtension.hasSuffix("swift") }
@@ -154,7 +156,8 @@ extension AirbnbSwiftFormatPlugin: XcodeCommandPlugin {
     try performCommand(
       context: context,
       inputPaths: Array(inputPaths),
-      arguments: argumentExtractor.remainingArguments)
+      arguments: argumentExtractor.remainingArguments
+    )
   }
 
 }
@@ -212,7 +215,8 @@ extension Package {
     // Look for all of the package manifest files in the directory root
     let filesInRootDirectory = try? FileManager.default.contentsOfDirectory(
       at: projectDirectory,
-      includingPropertiesForKeys: nil)
+      includingPropertiesForKeys: nil
+    )
 
     for fileURL in filesInRootDirectory ?? [] {
       let fileName = fileURL.lastPathComponent

--- a/README.md
+++ b/README.md
@@ -1633,7 +1633,8 @@ _You can enable the following settings in Xcode by running [this script](resourc
   class Planet {
     func terraform(
       atmosphereOptions: AtmosphereOptions = .default,
-      oceanOptions: OceanOptions = .default) {
+      oceanOptions: OceanOptions = .default
+    ) {
       generateAtmosphere(atmosphereOptions)
       generateOceans(oceanOptions)
     }
@@ -1650,8 +1651,8 @@ _You can enable the following settings in Xcode by running [this script](resourc
   class Planet {
     func terraform(
       atmosphereOptions: AtmosphereOptions = .default,
-      oceanOptions: OceanOptions = .default)
-    {
+      oceanOptions: OceanOptions = .default
+    ) {
       generateAtmosphere(atmosphereOptions)
       generateOceans(oceanOptions)
     }
@@ -2115,7 +2116,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
-* <a id='long-function-invocation'></a>(<a href='#long-function-invocation'>link</a>) **[Long](https://github.com/airbnb/swift#column-width) function invocations should also break on each argument.** Put the closing parenthesis on the last line of the invocation. [![SwiftFormat: wrapArguments](https://img.shields.io/badge/SwiftFormat-wrapArguments-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#wrapArguments)
+* <a id='long-function-invocation'></a>(<a href='#long-function-invocation'>link</a>) **[Long](https://github.com/airbnb/swift#column-width) function calls should also break on each argument.** Put the closing parenthesis on its own line. [![SwiftFormat: wrapArguments](https://img.shields.io/badge/SwiftFormat-wrapArguments-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#wrapArguments)
 
   <details>
 
@@ -2134,8 +2135,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
     at: location,
     count: 5,
     color: starColor,
-    withAverageDistance: 4
-  )
+    withAverageDistance: 4)
 
   // WRONG
   universe.generate(5,
@@ -2147,13 +2147,15 @@ _You can enable the following settings in Xcode by running [this script](resourc
     at: location,
     count: 5,
     color: starColor,
-    withAverageDistance: 4)
+    withAverageDistance: 4
+  )
 
   // RIGHT
   universe.generate(
     5,
     .stars,
-    at: location)
+    at: location
+  )
   ```
 
   </details>
@@ -2184,13 +2186,14 @@ _You can enable the following settings in Xcode by running [this script](resourc
       at location: Point,
       count: Int,
       color: StarColor,
-      withAverageDistance averageDistance: Float)
-    {
+      withAverageDistance averageDistance: Float
+    ) {
       let universe = generateUniverse()
       universe.generateStars(
         at: location,
         count: count,
-        withAverageDistance: averageDistance)
+        withAverageDistance: averageDistance
+      )
     }
     ```
 
@@ -2213,13 +2216,14 @@ _You can enable the following settings in Xcode by running [this script](resourc
       at location: Point,
       count: Int,
       color _: StarColor,
-      withAverageDistance averageDistance: Float)
-    {
+      withAverageDistance averageDistance: Float
+    ) {
       let universe = generateUniverse()
       universe.generateStars(
         at: location,
         count: count,
-        withAverageDistance: averageDistance)
+        withAverageDistance: averageDistance
+      )
     }
     ```
 
@@ -2424,16 +2428,18 @@ _You can enable the following settings in Xcode by running [this script](resourc
     
     func colonizePlanet() {
       spaceship.travel(to: planet, onArrival: { [weak self] in
-        guard let self else { return }
-        planet.colonize()
-      })
+          guard let self else { return }
+          planet.colonize()
+        }
+      )
     }
     
     func exploreSystem() {
       spaceship.travel(to: planet, nextDestination: { [weak self] in
-        guard let self else { return nil }
-        return planet.moons?.first
-      })
+          guard let self else { return nil }
+          return planet.moons?.first
+        }
+      )
     }
   }
   ```
@@ -2448,14 +2454,16 @@ _You can enable the following settings in Xcode by running [this script](resourc
     
     func colonizePlanet() {
       spaceship.travel(to: planet, onArrival: { [planet] in
-        planet.colonize()
-      })
+          planet.colonize()
+        }
+      )
     }
     
     func exploreSystem() {
       spaceship.travel(to: planet, nextDestination: { [planet] in
-        planet.moons?.first
-      })
+          planet.moons?.first
+        }
+      )
     }
   }
   ```
@@ -3201,14 +3209,16 @@ _You can enable the following settings in Xcode by running [this script](resourc
   var size: CGSize {
     return CGSize(
       width: 100.0,
-      height: 100.0)
+      height: 100.0
+    )
   }
 
   func makeInfoAlert(message: String) -> UIAlertController {
     return UIAlertController(
       title: "ℹ️ Info",
       message: message,
-      preferredStyle: .alert)
+      preferredStyle: .alert
+    )
   }
 
   var alertTitle: String {
@@ -3234,14 +3244,16 @@ _You can enable the following settings in Xcode by running [this script](resourc
   var size: CGSize {
     CGSize(
       width: 100.0,
-      height: 100.0)
+      height: 100.0
+    )
   }
 
   func makeInfoAlert(message: String) -> UIAlertController {
     UIAlertController(
       title: "ℹ️ Info",
       message: message,
-      preferredStyle: .alert)
+      preferredStyle: .alert
+    )
   }
 
   var alertTitle: String {
@@ -3371,7 +3383,8 @@ _You can enable the following settings in Xcode by running [this script](resourc
       at: location,
       count: 5,
       color: starColor,
-      withAverageDistance: 4)
+      withAverageDistance: 4
+    )
   }()
 
   // RIGHT
@@ -3381,7 +3394,8 @@ _You can enable the following settings in Xcode by running [this script](resourc
     at: location,
     count: 5,
     color: starColor,
-    withAverageDistance: 4)
+    withAverageDistance: 4
+  )
   ```
 
   </details>
@@ -4267,7 +4281,8 @@ _You can enable the following settings in Xcode by running [this script](resourc
       acceptButton.addTarget(
         self,
         action: #selector(didTapAcceptButton),
-        forControlEvents: .touchUpInside)
+        forControlEvents: .touchUpInside
+      )
     }
 
     @objc

--- a/Sources/AirbnbSwiftFormatTool/AirbnbSwiftFormatTool.swift
+++ b/Sources/AirbnbSwiftFormatTool/AirbnbSwiftFormatTool.swift
@@ -116,7 +116,8 @@ struct AirbnbSwiftFormatTool: ParsableCommand {
     return Command(
       log: log,
       launchPath: swiftFormatPath,
-      arguments: arguments)
+      arguments: arguments
+    )
   }
 
   /// Builds a command that runs the SwiftLint tool
@@ -140,7 +141,8 @@ struct AirbnbSwiftFormatTool: ParsableCommand {
     return Command(
       log: log,
       launchPath: swiftLintPath,
-      arguments: arguments)
+      arguments: arguments
+    )
   }
 
   private func log(_ string: String) {

--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -18,7 +18,7 @@
 --wrapreturntype never #wrapArguments
 --wrapeffects never #wrapArguments
 --closingparen balanced # wrapArguments
---callsiteparen same-line # wrapArguments
+--callsiteparen balanced # wrapArguments
 --wraptypealiases before-first # wrapArguments
 --funcattributes prev-line # wrapAttributes
 --computedvarattrs prev-line # wrapAttributes

--- a/Tests/AirbnbSwiftFormatToolTests/AirbnbSwiftFormatToolTests.swift
+++ b/Tests/AirbnbSwiftFormatToolTests/AirbnbSwiftFormatToolTests.swift
@@ -30,7 +30,9 @@ final class AirbnbSwiftFormatToolTest: XCTestCase {
         swiftLintAutocorrect: {
           ranSwiftLintAutocorrect = true
           return EXIT_SUCCESS
-        }))
+        }
+      )
+    )
 
     XCTAssertNil(error)
     XCTAssertTrue(ranSwiftFormat)
@@ -57,7 +59,9 @@ final class AirbnbSwiftFormatToolTest: XCTestCase {
         swiftLintAutocorrect: {
           ranSwiftLintAutocorrect = true
           return EXIT_SUCCESS
-        }))
+        }
+      )
+    )
 
     XCTAssertNil(error)
     XCTAssertTrue(ranSwiftFormat)
@@ -91,7 +95,9 @@ final class AirbnbSwiftFormatToolTest: XCTestCase {
           // When autocorrecting SwiftLint returns EXIT_SUCCESS
           // even if there were violations that were fixed
           return EXIT_SUCCESS
-        }))
+        }
+      )
+    )
 
     XCTAssertEqual(error as? ExitCode, ExitCode(SwiftFormatExitCode.lintFailure))
     XCTAssertTrue(ranSwiftFormat)
@@ -129,7 +135,9 @@ final class AirbnbSwiftFormatToolTest: XCTestCase {
           // In this case, SwiftLint still returns a zero exit code.
           ranSwiftLintAutocorrect = true
           return EXIT_SUCCESS
-        }))
+        }
+      )
+    )
 
     // Even though there was a SwiftLint failure, it was autocorrected so doesn't require attention.
     // The tool should not return an error (e.g. it should return a zero exit code).
@@ -159,7 +167,9 @@ final class AirbnbSwiftFormatToolTest: XCTestCase {
         swiftLintAutocorrect: {
           ranSwiftLintAutocorrect = true
           return EXIT_SUCCESS
-        }))
+        }
+      )
+    )
 
     XCTAssertEqual(error as? ExitCode, ExitCode.failure)
     XCTAssertTrue(ranSwiftFormat)
@@ -186,7 +196,9 @@ final class AirbnbSwiftFormatToolTest: XCTestCase {
         swiftLintAutocorrect: {
           ranSwiftLintAutocorrect = true
           return EXIT_SUCCESS
-        }))
+        }
+      )
+    )
 
     XCTAssertEqual(error as? ExitCode, ExitCode.failure)
     XCTAssertTrue(ranSwiftFormat)
@@ -213,7 +225,9 @@ final class AirbnbSwiftFormatToolTest: XCTestCase {
         swiftLintAutocorrect: {
           ranSwiftLintAutocorrect = true
           return EXIT_SUCCESS
-        }))
+        }
+      )
+    )
 
     XCTAssertEqual(error as? ExitCode, ExitCode.failure)
     XCTAssertTrue(ranSwiftFormat)
@@ -223,10 +237,12 @@ final class AirbnbSwiftFormatToolTest: XCTestCase {
 
   func testHandlesUnexpectedErrorCode() {
     let unexpectedSwiftFormatExitCode = runFormatTool(
-      with: MockCommands(swiftFormat: { 1234 }))
+      with: MockCommands(swiftFormat: { 1234 })
+    )
 
     let unexpectedSwiftLintExitCode = runFormatTool(
-      with: MockCommands(swiftLint: { 42 }))
+      with: MockCommands(swiftLint: { 42 })
+    )
 
     XCTAssertEqual(unexpectedSwiftFormatExitCode as? ExitCode, ExitCode(1234))
     XCTAssertEqual(unexpectedSwiftLintExitCode as? ExitCode, ExitCode(42))


### PR DESCRIPTION
## Summary

This PR updates our Swift formatting rules to enable `callsiteparen = balanced`, which ensures consistent placement of parentheses and arguments in multiline function **calls**. With this option, the opening and closing parentheses are always balanced across lines, improving readability and making edits and diffs more predictable. It also works seamlessly with trailing commas to simplify future changes.

---

## Reasoning

Currently, multiline function calls can inconsistently close the parenthesis on the same line as the last argument:

```swift
let result = executeRequest(
  request,
  onSuccess: { ... },
  onFailure: { ... })
```

With `callsiteparen = balanced`, this becomes:

```swift
let result = executeRequest(
  request,
  onSuccess: { ... },
  onFailure: { ... }
)
```

### Benefits

- **Predictable structure**  
  The closing parenthesis always appears vertically aligned with the opening parenthesis, reducing visual clutter and ambiguity - particularly with SwiftUI chains.

Before - `setBehaviors` is aligned with the arguments.
```swift
AttributedLabel.groupItem(
  dataID: DataID.subtitleLabel,
  content: .stylableText(subtitle),
  style: style.subtitleFont)
  .setBehaviors { [weak self] context in
    guard let self else { return }
    context.constrainable.numberOfLines = style.subtitleNumberOfLines
  }
```

After - `setBehaviors` is aligned with what it is modifying.
```swift
AttributedLabel.groupItem(
  dataID: DataID.subtitleLabel,
  content: .stylableText(subtitle),
  style: style.subtitleFont
)
.setBehaviors { [weak self] context in
  guard let self else { return }
  context.constrainable.numberOfLines = style.subtitleNumberOfLines
}
```

- **Simplifies use of trailing commas**  
  Trailing commas make adding or removing parameters much cleaner and reduce diff noise:

```swift
let result = executeRequest(
  request,
  onSuccess: { ... },
  onFailure: { ... },
)
```

  Adding another argument:

```diff
  onFailure: { ... },
+ completion: { ... },
)
```

  Removing an argument:

```diff
- onFailure: { ... },
)
```

- **Easier visual diffing**  
  The uniform style prevents mismatched or ambiguous closings, which is especially useful in large nested calls.

- **Community alignment**  
  This approach is common in modern Swift style guides and is fully supported by `swift-format` and `swiftlint`.

---

## Conclusion

Enabling `callsiteparen = balanced` gives us consistent, clear multiline call formatting that reduces code review noise and makes refactoring safer.
