### PR TITLE
Cal  wrap string interpolation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -47,9 +47,8 @@ let package = Package(
 
     .binaryTarget(
       name: "swiftformat",
-      url: "https://github.com/calda/SwiftFormat-nightly/releases/download/2025-05-15-b/SwiftFormat.artifactbundle.zip",
-      checksum: "0d6f365f00de0567c5a7a0caf33b593c2a9029cf27462c63879280839f5f2d9c"
-    ),
+      url: "https://github.com/calda/SwiftFormat-nightly/releases/download/2025-05-16-b/SwiftFormat.artifactbundle.zip",
+      checksum: "ebcf1b75d47b8bb413aa99edcad526e6a654926b3dd90302241d6d0203939c28"),
 
     .binaryTarget(
       name: "SwiftLintBinary",

--- a/Package.swift
+++ b/Package.swift
@@ -48,7 +48,8 @@ let package = Package(
     .binaryTarget(
       name: "swiftformat",
       url: "https://github.com/calda/SwiftFormat-nightly/releases/download/2025-05-16-b/SwiftFormat.artifactbundle.zip",
-      checksum: "ebcf1b75d47b8bb413aa99edcad526e6a654926b3dd90302241d6d0203939c28"),
+      checksum: "ebcf1b75d47b8bb413aa99edcad526e6a654926b3dd90302241d6d0203939c28"
+    ),
 
     .binaryTarget(
       name: "SwiftLintBinary",

--- a/Rakefile
+++ b/Rakefile
@@ -42,7 +42,8 @@ namespace :update do
     .binaryTarget(
       name: "swiftformat",
       url: "https://github.com/calda/SwiftFormat-nightly/releases/download/#{latest_version_number}/SwiftFormat.artifactbundle.zip",
-      checksum: "#{checksum.strip}"),
+      checksum: "#{checksum.strip}"
+    ),
     EOS
     
     regex = /[ ]*.binaryTarget\([\S\s]*name: "swiftformat"[\S\s]*?\),\s/

--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -26,6 +26,7 @@
 --complexattrs prev-line # wrapAttributes
 --typeattributes prev-line # wrapAttributes
 --wrapternary before-operators # wrap
+--wrapstringinterpolation preserve # wrap
 --structthreshold 20 # organizeDeclarations
 --enumthreshold 20 # organizeDeclarations
 --organizetypes class,struct,enum,extension,actor # organizeDeclarations


### PR DESCRIPTION
By default SwiftFormat will insert linebreaks in multi-line string interpolations. This is allowed by the language and doesn't affect the resulting string values, but in practice produces ugly results that hurts readability.

This PR enables `--wrapstringinterpolation preserve` option, which was added in https://github.com/nicklockwood/SwiftFormat/pull/2059.

Since we don't have a style rule specifically discussing line wrapping in string interpolation, and we just got this behavior by default when enabling the SwiftFormat wrapping behavior, I don't feel the need to address this case directly in the style guide.