### PR TITLE
Add rule to avoid `public` access control in `internal` types

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -47,8 +47,8 @@ let package = Package(
 
     .binaryTarget(
       name: "swiftformat",
-      url: "https://github.com/calda/SwiftFormat-nightly/releases/download/2025-05-16-b/SwiftFormat.artifactbundle.zip",
-      checksum: "ebcf1b75d47b8bb413aa99edcad526e6a654926b3dd90302241d6d0203939c28"
+      url: "https://github.com/calda/SwiftFormat-nightly/releases/download/2025-06-01/SwiftFormat.artifactbundle.zip",
+      checksum: "f9ccd25f8a195758de5a5463b36cdab8ad9ea1fbcf2c27bb55bd7a4aefef0872"
     ),
 
     .binaryTarget(

--- a/README.md
+++ b/README.md
@@ -2007,14 +2007,32 @@ _You can enable the following settings in Xcode by running [this script](resourc
   // WRONG
   internal class Spaceship {
     internal init() { … }
-
     internal func travel(to planet: Planet) { … }
   }
 
   // RIGHT, because internal access control is implied if no other access control level is specified.
   class Spaceship {
     init() { … }
+    func travel(to planet: Planet) { … }
+  }
+  ```
 
+  </details>
+
+* <a id='omit-redundant-public'></a>(<a href='#omit-redundant-public'>link</a>) **Avoid using `public` access control in `internal` types.** In this case the `public` modifier is redundant and has no effect. [![SwiftFormat: redundantPublic](https://img.shields.io/badge/SwiftFormat-redundantPublic-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#redundantPublic)
+
+  <details>
+
+  ```swift
+  // WRONG: Public declarations in internal types are internal, not public.
+  class Spaceship {
+    public init() { … }
+    public func travel(to planet: Planet) { … }
+  }
+
+  // RIGHT
+  class Spaceship {
+    init() { … }
     func travel(to planet: Planet) { … }
   }
   ```

--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -89,6 +89,7 @@
 --rules redundantVoidReturnType
 --rules redundantOptionalBinding
 --rules redundantInternal
+--rules redundantPublic
 --rules redundantProperty
 --rules unusedArguments
 --rules spaceInsideBrackets


### PR DESCRIPTION
#### Summary

This PR proposes a new rule to avoid `public` access control in `internal` types.

Autocorrect is implemented in the `redundantPublic` SwiftFormat rule, which was added in [nicklockwood/SwiftFormat#2075](https://github.com/nicklockwood/SwiftFormat/pull/2075).

#### Reasoning

In an `internal` type, any body declaration with a `public` modifier is actually `internal` -- the `public` modifier is redundant and has no effect.

```swift
// WRONG
class Spaceship {
  public init() { … }
  public func travel(to planet: Planet) { … }
}

// RIGHT
class Spaceship {
  init() { … }
  func travel(to planet: Planet) { … }
}
```
