### PR TITLE
Move "Swift Testing test case names" rule to new "Testing" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -3881,37 +3881,6 @@ _You can enable the following settings in Xcode by running [this script](resourc
   ```
   </details>
 
-* <a id='swift-testing-test-case-names'></a>(<a href='#swift-testing-test-case-names'>link</a>) **In Swift Testing, don't prefix test case methods with "`test`".** [![SwiftFormat: swiftTestingTestCaseNames](https://img.shields.io/badge/SwiftFormat-swiftTestingTestCaseNames-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#swiftTestingTestCaseNames)
-
-  <details>
-
-  ### Why?
-
-  Prefixing test case methods with "`test`" was necessary with XCTest, but is not necessary in Swift Testing. [Idiomatic usage](https://developer.apple.com/documentation/testing/migratingfromxctest#Convert-test-methods) of Swift Testing excludes the "`test`" prefix.
-
-  ```swift
-  import Testing
-  
-  /// WRONG
-  struct SpaceshipTests {
-    @Test
-    func testWarpDriveEnablesFTLTravel() { ... }
-
-    @Test
-    func testArtificialGravityMatchesEarthGravity() { ... }
-  }
-
-  /// RIGHT
-  struct SpaceshipTests {
-    @Test
-    func warpDriveEnablesFTLTravel() { ... }
-
-    @Test
-    func artificialGravityMatchesEarthGravity() { ... }
-  }
-  ```
-  </details>
-
 **[⬆ back to top](#table-of-contents)**
 
 ## File Organization
@@ -4341,6 +4310,37 @@ _You can enable the following settings in Xcode by running [this script](resourc
 **[⬆ back to top](#table-of-contents)**
 
 ## Testing
+
+* <a id='swift-testing-test-case-names'></a>(<a href='#swift-testing-test-case-names'>link</a>) **In Swift Testing, don't prefix test case methods with "`test`".** [![SwiftFormat: swiftTestingTestCaseNames](https://img.shields.io/badge/SwiftFormat-swiftTestingTestCaseNames-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#swiftTestingTestCaseNames)
+
+  <details>
+
+  ### Why?
+
+  Prefixing test case methods with "`test`" was necessary with XCTest, but is not necessary in Swift Testing. [Idiomatic usage](https://developer.apple.com/documentation/testing/migratingfromxctest#Convert-test-methods) of Swift Testing excludes the "`test`" prefix.
+
+  ```swift
+  import Testing
+  
+  /// WRONG
+  struct SpaceshipTests {
+    @Test
+    func testWarpDriveEnablesFTLTravel() { ... }
+
+    @Test
+    func testArtificialGravityMatchesEarthGravity() { ... }
+  }
+
+  /// RIGHT
+  struct SpaceshipTests {
+    @Test
+    func warpDriveEnablesFTLTravel() { ... }
+
+    @Test
+    func artificialGravityMatchesEarthGravity() { ... }
+  }
+  ```
+  </details>
 
 * <a id='prefer-unwrapping-apis'></a>(<a href='#prefer-unwrapping-apis'>link</a>) **Prefer Test APIs for unwrapping optionals over `if let`.** XCTest and Swift Testing have APIs for unwrapping an optional and failing the test, which are much simpler than unwrapping the optionals yourself.
 


### PR DESCRIPTION
@jqsilver added a new "Testing" section to the style guide in https://github.com/airbnb/swift/pull/313.

This PR moves the existing "Swift Testing test case names" rule to the testing section.