### PR TITLE
Add redundantBreak SwiftFormat rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -1501,6 +1501,35 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
+* <a id='omit-redundant-break'></a>(<a href='#omit-redundant-break'>link</a>) **Omit redundant `break` statements in switch cases.** [![SwiftFormat: redundantBreak](https://img.shields.io/badge/SwiftFormat-redundantBreak-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#redundantBreak)
+
+  <details>
+
+  #### Why?
+  Swift automatically breaks out of a switch case after executing its code, so explicit `break` statements are usually unnecessary and add visual clutter.
+
+  ```swift
+  // WRONG
+  switch spaceship.warpDriveState {
+  case .engaged:
+    navigator.engageWarpDrive()
+    break
+  case .disengaged:
+    navigator.disengageWarpDrive()
+    break
+  }
+
+  // RIGHT  
+  switch spaceship.warpDriveState {
+  case .engaged:
+    navigator.engageWarpDrive()
+  case .disengaged:
+    navigator.disengageWarpDrive()
+  }
+  ```
+
+  </details>
+
 * <a id='wrap-guard-else'></a>(<a href='#wrap-guard-else'>link</a>) **Add a line break before the `else` keyword in a multi-line guard statement.** For single-line guard statements, keep the `else` keyword on the same line as the `guard` keyword. The open brace should immediately follow the `else` keyword. [![SwiftFormat: elseOnSameLine](https://img.shields.io/badge/SwiftFormat-elseOnSameLine-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#elseOnSameLine)
 
   <details>

--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -129,3 +129,4 @@
 --rules throwingTests
 --rules noGuardInTests
 --rules redundantMemberwiseInit
+--rules redundantBreak


### PR DESCRIPTION
## Summary
- Add documentation for the `redundantBreak` SwiftFormat rule
- This rule removes unnecessary `break` statements in switch cases
- Swift automatically breaks out of switch cases, making explicit breaks redundant

## Changes
- Added new rule `omit-redundant-break` to the Style section of README.md
- Placed it logically after the existing switch case spacing rule
- Includes examples showing how redundant `break` statements should be removed
- Follows the same format and style as existing SwiftFormat rule documentation

## Test plan
- [x] Verified the rule documentation follows existing patterns in README.md
- [x] Added appropriate examples showing WRONG and RIGHT usage with space-themed examples
- [x] Included SwiftFormat badge linking to rule documentation
- [x] Added "Why?" explanation about visual clutter and redundancy
- [x] Confirmed this PR contains ONLY the redundantBreak rule (previous PR was incorrectly mixed)

🤖 Generated with [Claude Code](https://claude.ai/code)