### PR TITLE
Update trailing commas rule to apply to all comma-separated lists

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -47,8 +47,8 @@ let package = Package(
 
     .binaryTarget(
       name: "swiftformat",
-      url: "https://github.com/calda/SwiftFormat-nightly/releases/download/2025-07-09/SwiftFormat.artifactbundle.zip",
-      checksum: "0feced7d468d909095b4d69e4a17c3a8cb4cd219b3b5574c7835275d3305737e"
+      url: "https://github.com/calda/SwiftFormat-nightly/releases/download/2025-07-21/SwiftFormat.artifactbundle.zip",
+      checksum: "81625fc578842919314d3c77b5b79feec0697093554012db62d8de30ce3d4c68"
     ),
 
     .binaryTarget(

--- a/README.md
+++ b/README.md
@@ -526,25 +526,77 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
-* <a id='trailing-comma-array'></a>(<a href='#trailing-comma-array'>link</a>) **Add a trailing comma on the last element of a multi-line array.** [![SwiftFormat: trailingCommas](https://img.shields.io/badge/SwiftFormat-trailingCommas-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#trailingCommas)
+* <a id='trailing-commas'></a>(<a href='#trailing-commas'>link</a>) **Add a trailing comma after the last element of multi-line, multi-element comma-separated lists.* This includes arrays, dictionaries, function declarations, function calls, etc. Don't include a trailing comma if the list spans only a single line, or contains only a single element. [![SwiftFormat: trailingCommas](https://img.shields.io/badge/SwiftFormat-trailingCommas-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#trailingCommas)
 
   <details>
 
   ```swift
   // WRONG
-  let rowContent = [
-    listingUrgencyDatesRowContent(),
-    listingUrgencyBookedRowContent(),
-    listingUrgencyBookedShortRowContent()
+  let terrestrialPlanets = [
+    mercury,
+    venus,
+    earth,
+    mars
   ]
 
+  func buildSolarSystem(
+    innerPlanets: [Planet],
+    outerPlanets: [Planet]
+  ) { ... }
+
+  buildSolarSystem(
+    innertPlanets: terrestrialPlanets,
+    outerPlanets: gasGiants
+  )
+
   // RIGHT
-  let rowContent = [
-    listingUrgencyDatesRowContent(),
-    listingUrgencyBookedRowContent(),
-    listingUrgencyBookedShortRowContent(),
+  let terrestrialPlanets = [
+    mercury,
+    venus,
+    earth,
+    mars,
   ]
+
+  func buildSolarSystem(
+    innerPlanets: [Planet],
+    outerPlanets: [Planet],
+  ) { ... }
+
+  buildSolarSystem(
+    innertPlanets: terrestrialPlanets,
+    outerPlanets: gasGiants,
+  )
   ```
+
+  ```swift
+  // WRONG: Omit the trailing comma in single-element lists.
+  let planetsWithLife = [
+    earth,
+  ]
+
+  func buildSolarSystem(
+    _ planets: [Planet],
+  )
+
+  buildSolarSystem(
+    terrestrialPlanets + gasGiants,
+  )
+
+  // RIGHT
+  let planetsWithLife = [
+    earth
+  ]
+
+  func buildSolarSystem(
+    _ planets: [Planet]
+  ) { ... }
+
+  buildSolarSystem(
+    terrestrialPlanets + gasGiants
+  )
+  ```
+
+  </details>
 
 * <a id='no-space-inside-collection-brackets'></a>(<a href='#no-space-inside-brackets'>link</a>) **There should be no spaces inside the brackets of collection literals.** [![SwiftFormat: spaceInsideBrackets](https://img.shields.io/badge/SwiftFormat-spaceInsideBrackets-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#spaceInsideBrackets)
 

--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -2,11 +2,11 @@
 --exclude Carthage,Pods,.build
 
 # options
---swift-version 6.0
+--swift-version 6.1
 --language-mode 5
 --self remove # redundantSelf
 --import-grouping testable-bottom # sortedImports
---trailing-commas always # trailingCommas
+--trailing-commas multi-element-lists # trailingCommas
 --trim-whitespace always # trailingSpace
 --indent 2 #indent
 --ifdef no-indent #indent


### PR DESCRIPTION
#### Summary

This PR updates the trailing commas rule to apply to all comma-separated lists, including function calls and function declarations.

```swift
let terrestrialPlanets = [
  mercury,
  venus,
  earth,
  mars,
]

func buildSolarSystem(
  innerPlanets: [Planet],
  outerPlanets: [Planet],
) { ... }

buildSolarSystem(
  innertPlanets: terrestrialPlanets,
  outerPlanets: gasGiants,
)
```

This PR also refines the rule to omit the trailing comma if the list only contains a single element. We feel this is especially the right choice in function calls with only a single argument, where the trailing commas adds unnecessary noise:

```swift
// WRONG
let planetsWithLife = [
  earth,
]

func buildSolarSystem(
  _ planets: [Planet],
)

buildSolarSystem(
  terrestrialPlanets + gasGiants,
)

// RIGHT
let planetsWithLife = [
  earth
]

func buildSolarSystem(
  _ planets: [Planet]
) { ... }

buildSolarSystem(
  terrestrialPlanets + gasGiants
)
```

<!--- required --->
