### PR TITLE
Add rule to only define a single property or enum case per line

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -47,8 +47,8 @@ let package = Package(
 
     .binaryTarget(
       name: "swiftformat",
-      url: "https://github.com/calda/SwiftFormat-nightly/releases/download/2025-07-09/SwiftFormat.artifactbundle.zip",
-      checksum: "0feced7d468d909095b4d69e4a17c3a8cb4cd219b3b5574c7835275d3305737e"
+      url: "https://github.com/calda/SwiftFormat-nightly/releases/download/2025-07-21/SwiftFormat.artifactbundle.zip",
+      checksum: "81625fc578842919314d3c77b5b79feec0697093554012db62d8de30ce3d4c68"
     ),
 
     .binaryTarget(

--- a/README.md
+++ b/README.md
@@ -4371,6 +4371,47 @@ _You can enable the following settings in Xcode by running [this script](resourc
   ```
 
   </details>
+
+* <a id='single-propery-per-line'></a>(<a href='#single-propery-per-line'>link</a>) **Only define a single property or enum case per line.** [![SwiftFormat: singlePropertyPerLine](https://img.shields.io/badge/SwiftFormat-singlePropertyPerLine-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#singlePropertyPerLine) [![SwiftFormat: wrapEnumCases](https://img.shields.io/badge/SwiftFormat-wrapEnumCases-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#wrapEnumCases)
+
+  <details>
+
+  #### Why?
+   - Declarations that define a single property are much more common, and more idiomatic.
+   - Only using the standard form of property declarations makes it easier to write and maintain tools that operate on source code, like macros, lint rules, and code autocorrect.
+
+  ```swift
+  // WRONG
+  let mercury, venus: Planet
+
+  let earth = planets[2], mars = planets[3]
+
+  let (jupiter, saturn) = (planets[4], planets[5])
+
+  enum IceGiants {
+    case neptune, uranus
+  }
+
+  // RIGHT
+  let mercury: Planet
+  let venus: Planet
+
+  let earth = planets[2]
+  let mars = planets[3]
+
+  let jupiter = planets[4]
+  let saturn = planets[5]
+
+  enum IceGiants {
+    case neptune
+    case uranus
+  }
+  
+  // ALSO RIGHT: Tuple destructing is fine for values like function call results.
+  let (ceres, pluto) = findAndClassifyDwarfPlanets()
+  ```
+
+  </details>
   
 * <a id='remove-empty-extensions'></a>(<a href='#remove-empty-extensions'>link</a>) **Remove empty extensions that define no properties, functions, or conformances.** [![SwiftFormat: emptyExtensions](https://img.shields.io/badge/SwiftFormat-emptyExtensions-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#emptyExtensions)
 

--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -83,6 +83,8 @@
 --rules wrapMultilineStatementBraces
 --rules wrapArguments
 --rules wrapAttributes
+--rules wrapEnumCases
+--rules singlePropertyPerLine
 --rules braces
 --rules redundantClosure
 --rules redundantInit


### PR DESCRIPTION
#### Summary

This PR adds a new rule to only define a single property or enum case per line.

```swift
// WRONG
let mercury, venus: Planet

let earth = planets[2], mars = planets[3]

let (jupiter, saturn) = (planets[4], planets[5])

enum IceGiants {
  case neptune, uranus
}

// RIGHT
let mercury: Planet
let venus: Planet

let earth = planets[2]
let mars = planets[3]

let jupiter = planets[4]
let saturn = planets[5]

enum IceGiants {
  case neptune
  case uranus
}

// ALSO RIGHT: Tuple destructing is fine for values like function call results.
let (ceres, pluto) = findAndClassifyDwarfPlanets()
```

#### Reasoning

 - Declarations that define a single property are much more common, and more idiomatic.
 - Only using the standard form of property declarations makes it easier to write and maintain tools that operate on source code, like macros, lint rules, and code autocorrect.
