### PR TITLE
Add cifilter-builtins style guide rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -3884,6 +3884,50 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
 **[⬆ back to top](#table-of-contents)**
 
+* <a id='cifilter-builtins'></a>(<a href='#cifilter-builtins'>link</a>) **Prefer CIFilter's typed factory methods (via `CIFilterBuiltins`) over the string-based `CIFilter(name:)` initializer and KVO `setValue(_:forKey:)`.**
+
+  <details>
+
+  #### Why?
+
+  The typed factory methods introduced in iOS 14 (`import CoreImage.CIFilterBuiltins`) return non-optional, concrete filter objects with strongly-typed properties. This eliminates:
+
+  - The failable `CIFilter(name:)` initializer, which returns `nil` for typos and requires a `guard`/`if-let`.
+  - `setValue(_:forKey:)` calls that accept `Any?` and crash at runtime on wrong types or misspelled keys.
+
+  Using the built-in protocol conformances gives you compile-time type safety and autocompletion for every parameter.
+
+  > **Note:** You must add `import CoreImage.CIFilterBuiltins` (a submodule import) to access the factory methods.
+
+  ```swift
+  // WRONG
+  import CoreImage
+
+  guard
+    let kMeansFilter = CIFilter(name: "CIKMeans")
+  else { return nil }
+
+  kMeansFilter.setValue(ciImage, forKey: kCIInputImageKey)
+  kMeansFilter.setValue(CIVector(cgRect: ciImage.extent), forKey: "inputExtent")
+  kMeansFilter.setValue(1, forKey: "inputCount")
+  kMeansFilter.setValue(5, forKey: "inputPasses")
+  ```
+
+  ```swift
+  // RIGHT
+  import CoreImage.CIFilterBuiltins
+
+  let kMeansFilter = CIFilter.kMeans()
+  kMeansFilter.inputImage = ciImage
+  kMeansFilter.extent = CIVector(cgRect: ciImage.extent)
+  kMeansFilter.count = 1
+  kMeansFilter.passes = 5
+  ```
+
+  </details>
+
+**[⬆ back to top](#table-of-contents)**
+
 ## File Organization
 
 * <a id='alphabetize-and-deduplicate-imports'></a>(<a href='#alphabetize-and-deduplicate-imports'>link</a>) **Alphabetize and deduplicate module imports within a file. Place all imports at the top of the file below the header comments. Do not add additional line breaks between import statements. Add a single empty line before the first import and after the last import.** [![SwiftFormat: sortedImports](https://img.shields.io/badge/SwiftFormat-sortedImports-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#sortedImports) [![SwiftFormat: duplicateImports](https://img.shields.io/badge/SwiftFormat-duplicateImports-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#duplicateImports)

--- a/README.md
+++ b/README.md
@@ -5506,6 +5506,48 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   </details>
 
+* <a id='cifilter-builtins'></a>(<a href='#cifilter-builtins'>link</a>) **Prefer CIFilter's typed factory methods (via `CIFilterBuiltins`) over the string-based `CIFilter(name:)` initializer and KVO `setValue(_:forKey:)`.**
+
+  <details>
+
+  #### Why?
+
+  The typed factory methods introduced in iOS 14 (`import CoreImage.CIFilterBuiltins`) return non-optional, concrete filter objects with strongly-typed properties. This eliminates:
+
+  - The failable `CIFilter(name:)` initializer, which returns `nil` for typos and requires a `guard`/`if-let`.
+  - `setValue(_:forKey:)` calls that accept `Any?` and crash at runtime on wrong types or misspelled keys.
+
+  Using the built-in protocol conformances gives you compile-time type safety and autocompletion for every parameter.
+
+  > **Note:** You must add `import CoreImage.CIFilterBuiltins` (a submodule import) to access the factory methods, as it's not included in the general `CoreImage` header.
+
+  ```swift
+  // WRONG
+  import CoreImage
+
+  guard
+    let kMeansFilter = CIFilter(name: "CIKMeans")
+  else { return nil }
+
+  kMeansFilter.setValue(ciImage, forKey: kCIInputImageKey)
+  kMeansFilter.setValue(CIVector(cgRect: ciImage.extent), forKey: "inputExtent")
+  kMeansFilter.setValue(1, forKey: "inputCount")
+  kMeansFilter.setValue(5, forKey: "inputPasses")
+  ```
+
+  ```swift
+  // RIGHT
+  import CoreImage.CIFilterBuiltins
+
+  let kMeansFilter = CIFilter.kMeans()
+  kMeansFilter.inputImage = ciImage
+  kMeansFilter.extent = CIVector(cgRect: ciImage.extent)
+  kMeansFilter.count = 1
+  kMeansFilter.passes = 5
+  ```
+
+  </details>
+
 **[⬆ back to top](#table-of-contents)**
 
 ## Contributors


### PR DESCRIPTION
Prefer CIFilter typed factory methods (CIFilterBuiltins) over string-based CIFilter(name:) and setValue(_:forKey:). Adds rule entry to the Patterns section immediately before File Organization.

#### Summary

Adds a new **Patterns** rule recommending `CIFilter`'s typed factory methods (from `CIFilterBuiltins`) over the string-based `CIFilter(name:)` initializer and KVO `setValue(_:forKey:)`.

No SwiftLint or SwiftFormat rule exists for this — it is a style guide entry only.

#### Reasoning

`CIFilter(name:)` returns an optional and requires stringly-typed KVO for parameter access. The `CIFilterBuiltins` factory methods (available since iOS 14) provide non-optional returns and compile-time type-checked properties, eliminating an entire class of runtime errors.

The typed API requires `import CoreImage.CIFilterBuiltins`, which is an unusual submodule import but is Apple's documented approach.

Reference: https://developer.apple.com/documentation/coreimage/processing-an-image-using-built-in-filters