### PR TITLE
Update SwiftFormat `--swift-version` to 6.3

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -47,8 +47,8 @@ let package = Package(
 
     .binaryTarget(
       name: "swiftformat",
-      url: "https://github.com/calda/SwiftFormat-nightly/releases/download/2026-03-20-b/SwiftFormat.artifactbundle.zip",
-      checksum: "063265b080c9e88cccf75f94cda2e817646b1021eab4e832bc8737d1dfa39f7c"
+      url: "https://github.com/calda/SwiftFormat-nightly/releases/download/2026-04-07/SwiftFormat.artifactbundle.zip",
+      checksum: "66941154b99909a999ae4b3c2192858e127697fad8e3e8e51c5525f4c7488389"
     ),
 
     .binaryTarget(

--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -2,7 +2,7 @@
 --exclude Carthage,Pods,.build
 
 # options
---swift-version 6.2
+--swift-version 6.3
 --language-mode 5
 --self remove # redundantSelf
 --import-grouping testable-bottom # sortedImports


### PR DESCRIPTION
This PR updates the SwiftFormat `--swift-version` to 6.3 now that we are using Swift 6.3 at Airbnb.