### PR TITLE
Include a blank line at the bottom of a type body only if the type body starts a blank line

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -47,8 +47,8 @@ let package = Package(
 
     .binaryTarget(
       name: "swiftformat",
-      url: "https://github.com/calda/SwiftFormat-nightly/releases/download/2026-04-07/SwiftFormat.artifactbundle.zip",
-      checksum: "66941154b99909a999ae4b3c2192858e127697fad8e3e8e51c5525f4c7488389"
+      url: "https://github.com/calda/SwiftFormat-nightly/releases/download/2026-04-27/SwiftFormat.artifactbundle.zip",
+      checksum: "cfd0477174dde0f053b0606a1284b3bd71347bc7033752625a832d98ef7a37ff"
     ),
 
     .binaryTarget(

--- a/Plugins/FormatSwift/Plugin.swift
+++ b/Plugins/FormatSwift/Plugin.swift
@@ -249,4 +249,5 @@ extension Package {
 
     return SwiftVersion(major: major, minor: minor)
   }
+
 }

--- a/README.md
+++ b/README.md
@@ -4554,7 +4554,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   </details>
 
-- <a id='blank-line-at-start-or-end-of-scopes'></a>(<a href='#blank-line-at-start-or-end-of-scopes'>link</a>) **Omit blank lines at the top and bottom of scopes.** Blank lines are permitted at the top of type bodies. Include a blank line at the bottom of a type body if it starts with a blank line.
+- <a id='blank-line-at-start-or-end-of-scopes'></a>(<a href='#blank-line-at-start-or-end-of-scopes'>link</a>) **Omit blank lines at the top and bottom of scopes.** Include a blank line at the bottom of a type body if and only if it starts with a blank line.
 
   <details>
 
@@ -4579,7 +4579,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
     }
   }
 
-  // RIGHT
+  // ALSO RIGHT
   class Planet {
 
     func terraform() {

--- a/README.md
+++ b/README.md
@@ -4554,7 +4554,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   </details>
 
-- <a id='no-blank-lines-at-start-or-end-of-non-type-scopes'></a>(<a href='#no-blank-lines-at-start-or-end-of-non-type-scopes'>link</a>) **Remove blank lines at the top and bottom of scopes**, excluding type bodies which can optionally include blank lines.
+- <a id='blank-line-at-start-or-end-of-scopes'></a>(<a href='#blank-line-at-start-or-end-of-scopes'>link</a>) **Omit blank lines at the top and bottom of scopes.** Blank lines are permitted at the top of type bodies. Include a blank line at the bottom of a type body if it starts with a blank line.
 
   <details>
 
@@ -4579,7 +4579,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
     }
   }
 
-  // Also fine!
+  // RIGHT
   class Planet {
 
     func terraform() {
@@ -4587,6 +4587,24 @@ _You can enable the following settings in Xcode by running [this script](https:/
       generateOceans()
     }
 
+  }
+
+  // WRONG: Not consistent
+  class Planet {
+    func terraform() {
+      generateAtmosphere()
+      generateOceans()
+    }
+
+  }
+
+  // WRONG: Not consistent
+  class Planet {
+
+    func terraform() {
+      generateAtmosphere()
+      generateOceans()
+    }
   }
   ```
 

--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -38,7 +38,7 @@
 --extension-acl on-declarations # extensionAccessControl
 --pattern-let inline # hoistPatternLet
 --property-types inferred # redundantType, propertyTypes
---type-blank-lines preserve # blankLinesAtStartOfScope, blankLinesAtEndOfScope
+--type-blank-lines consistent # blankLinesAtStartOfScope, blankLinesAtEndOfScope
 --empty-braces spaced # emptyBraces
 --ranges preserve # spaceAroundOperators
 --operator-func no-space # spaceAroundOperators


### PR DESCRIPTION
#### Summary

This PR proposes to tweak our "blank line at start/end of scope" rule for type bodies: Include a blank line at the bottom of a type body only if the type body starts a blank line.

#### Reasoning

This avoids unbalanced type bodies like:

  ```swift
  // WRONG: Not consistent
  class Planet {
    func terraform() {
      generateAtmosphere()
      generateOceans()
    }

  }

  // WRONG: Not consistent
  class Planet {

    func terraform() {
      generateAtmosphere()
      generateOceans()
    }
  }
  ```

in favor of:

  ```swift
  // RIGHT
  class Planet {
    func terraform() {
      generateAtmosphere()
      generateOceans()
    }
  }

  // ALSO RIGHT
  class Planet {

    func terraform() {
      generateAtmosphere()
      generateOceans()
    }

  }
  ```