### PR TITLE
Add rule to omit SwiftUI `Group` wrappers where redundant, and prefer `@ViewBuilder` over `Group` where equivalent

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -47,8 +47,8 @@ let package = Package(
 
     .binaryTarget(
       name: "swiftformat",
-      url: "https://github.com/calda/SwiftFormat-nightly/releases/download/2026-04-27/SwiftFormat.artifactbundle.zip",
-      checksum: "cfd0477174dde0f053b0606a1284b3bd71347bc7033752625a832d98ef7a37ff"
+      url: "https://github.com/calda/SwiftFormat-nightly/releases/download/2026-06-10/SwiftFormat.artifactbundle.zip",
+      checksum: "3998613fa1b26c1f70d9d13260eff43fbaeb916a8fd2183419814da5efbcd8b7"
     ),
 
     .binaryTarget(

--- a/README.md
+++ b/README.md
@@ -5073,6 +5073,62 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   </details>
 
+- <a id='redundant-swiftui-group'></a>(<a href='#redundant-swiftui-group'>link</a>) **Omit SwiftUI `Group` wrappers where redundant, and prefer `@ViewBuilder` over `Group` where equivalent.** Inside a `@ViewBuilder` context (like a `View.body` or a `@ViewBuilder` property), a `Group` that wraps the entire content and applies no modifiers is unnecessary and adds an extra layer of nesting.
+
+  <details>
+
+  [![SwiftFormat: redundantSwiftUIGroup](https://img.shields.io/badge/SwiftFormat-redundantSwiftUIGroup-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#redundantSwiftUIGroup)
+
+  #### Why?
+
+  The body of a `View` is implicitly a `@ViewBuilder`, so a `Group` that wraps the entire body and has no modifiers applied to it is completely redundant. In a `@ViewBuilder` property, `Group` and `@ViewBuilder` are equivalent, but `@ViewBuilder` is more idiomatic and reduces nesting.
+
+  ```swift
+  // WRONG
+  struct SpacecraftView: View {
+    var body: some View {
+      Group {
+        Text("Voyager")
+        instruments
+      }
+    }
+
+    var instruments: some View {
+      Group {
+        Text("Altimeter")
+        Text("Gyroscope")
+      }
+    }
+  }
+
+  // RIGHT
+  struct SpacecraftView: View {
+    var body: some View {
+      Text("Voyager")
+      instruments
+    }
+
+    @ViewBuilder
+    var instruments: some View {
+      Text("Altimeter")
+      Text("Gyroscope")
+    }
+  }
+
+  // ALSO RIGHT: Group is not redundant when a modifier is applied to it
+  struct SpacecraftView: View {
+    var body: some View {
+      Group {
+        Text("Voyager")
+        instruments
+      }
+      .padding()
+    }
+  }
+  ```
+
+  </details>
+
 **[⬆ back to top](#table-of-contents)**
 
 ## Testing

--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -151,3 +151,4 @@
 --rules simplifyGenericConstraints
 --rules redundantEmptyView
 --rules redundantViewBuilder
+--rules redundantSwiftUIGroup


### PR DESCRIPTION
#### Summary

This PR adds a new rule to omit SwiftUI `Group` wrappers where redundant, and prefer `@ViewBuilder` over `Group` where equivalent.

#### Reasoning

A `Group` instead of a `@ViewBuilder` with no additional modifiers is redundant. Prefer `@ViewBuilder` over `Group` where equivalent because `@ViewBuilder` is more idiomatic and results in one less layer of nesting.

Another benefit is that this makes `VStack` / `HStack` use cases, which affect layout, visually distinct from `Group` use cases (now instead `@ViewBuilder`), which _don't_ affect layout.


  ```swift
  // WRONG
  struct SpacecraftView: View {
    var body: some View {
      Group {
        Text("Voyager")
        instruments
      }
    }

    var instruments: some View {
      Group {
        Text("Altimeter")
        Text("Gyroscope")
      }
    }
  }

  // RIGHT
  struct SpacecraftView: View {
    var body: some View {
      Text("Voyager")
      instruments
    }

    @ViewBuilder
    var instruments: some View {
      Text("Altimeter")
      Text("Gyroscope")
    }
  }

  // ALSO RIGHT: Group is not redundant when a modifier is applied to it
  struct SpacecraftView: View {
    var body: some View {
      Group {
        Text("Voyager")
        instruments
      }
      .padding()
    }
  }
  ```
