### PR TITLE
Add rule to avoid calling `State(wrappedValue:)` initializer directly

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -47,8 +47,8 @@ let package = Package(
 
     .binaryTarget(
       name: "swiftformat",
-      url: "https://github.com/calda/SwiftFormat-nightly/releases/download/2026-06-10/SwiftFormat.artifactbundle.zip",
-      checksum: "3998613fa1b26c1f70d9d13260eff43fbaeb916a8fd2183419814da5efbcd8b7"
+      url: "https://github.com/calda/SwiftFormat-nightly/releases/download/2026-06-11-b/SwiftFormat.artifactbundle.zip",
+      checksum: "0019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5"
     ),
 
     .binaryTarget(

--- a/README.md
+++ b/README.md
@@ -5129,6 +5129,67 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   </details>
 
+- <a id='redundant-state-init'></a>(<a href='#redundant-state-init'>link</a>) **Avoid calling the `State(wrappedValue:)` initializer explicitly** when equivalent to assigning the wrapped property directly.
+
+  <details>
+
+  [![SwiftFormat: redundantStateInit](https://img.shields.io/badge/SwiftFormat-redundantStateInit-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#redundantStateInit)
+
+  #### Why?
+
+  ```swift
+  // WRONG
+  struct SpacecraftView: View {
+    init(telemetryService: TelemetryService) {
+      _spacecraftName = .init(wrappedValue: "Voyager")
+      _telemetryService = .init(wrappedValue: telemetryService)
+    }
+
+    @State private var spacecraftName: String
+    @ObservedObject private var telemetryService: TelemetryService
+  }
+
+  // RIGHT
+  struct SpacecraftView: View {
+    init(telemetryService: TelemetryService) {
+      spacecraftName = "Voyager"
+      self.telemetryService = telemetryService
+    }
+
+    @State private var spacecraftName: String
+    @ObservedObject private var telemetryService: TelemetryService
+  }
+  ```
+
+  This doesn't apply if the `@State` property declaration itself has an initial value:
+
+  ```swift
+  // ALSO RIGHT
+  struct SpacecraftView: View {
+    init() {
+      _spacecraftName = .init(wrappedValue: "Voyager") // Replaces the existing initial value
+      // `spacecraftName = "Voyager"` would have no effect here.
+    }
+
+    @State private var spacecraftName = "Pioneer"
+  }
+  ```
+
+  This doesn't apply to `StateObject(wrappedValue:)`: since a `@StateObject`'s value is not mutable, the property can't be assigned directly.
+
+  ```swift
+  // RIGHT: @StateObject must be initialized via its storage
+  struct SpacecraftView: View {
+    init() {
+      _navigationComputer = StateObject(wrappedValue: NavigationComputer())
+    }
+
+    @StateObject private var navigationComputer: NavigationComputer
+  }
+  ```
+
+  </details>
+
 **[⬆ back to top](#table-of-contents)**
 
 ## Testing

--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -152,3 +152,4 @@
 --rules redundantEmptyView
 --rules redundantViewBuilder
 --rules redundantSwiftUIGroup
+--rules redundantStateInit


### PR DESCRIPTION
#### Summary

This PR adds a new rule to avoid calling the `State(wrappedValue:)` initializer explicitly, in favor of just setting the wrapped property directly.

#### Reasoning

Calling `State(wrappedValue:)` or `State(initialValue)` explicitly is always unnecessary. The [SwiftUI docs](https://developer.apple.com/documentation/swiftui/state/init(wrappedvalue:)) say: "You don’t call this initializer directly".

#### Examples

  ```swift
  // WRONG
  struct SpacecraftView: View {
    init(telemetryService: TelemetryService) {
      _spacecraftName = .init(wrappedValue: "Voyager")
      _telemetryService = .init(wrappedValue: telemetryService)
    }

    @State private var spacecraftName: String
    @ObservedObject private var telemetryService: TelemetryService
  }

  // RIGHT
  struct SpacecraftView: View {
    init(telemetryService: TelemetryService) {
      spacecraftName = "Voyager"
      self.telemetryService = telemetryService
    }

    @State private var spacecraftName: String
    @ObservedObject private var telemetryService: TelemetryService
  }
  ```
