### PR TITLE
Add rule: prefer flatMap over map { ... }.reduce([], +)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -47,8 +47,8 @@ let package = Package(
 
     .binaryTarget(
       name: "swiftformat",
-      url: "https://github.com/calda/SwiftFormat-nightly/releases/download/2026-06-10/SwiftFormat.artifactbundle.zip",
-      checksum: "3998613fa1b26c1f70d9d13260eff43fbaeb916a8fd2183419814da5efbcd8b7"
+      url: "https://github.com/calda/SwiftFormat-nightly/releases/download/2026-06-24/SwiftFormat.artifactbundle.zip",
+      checksum: "77cd21d4d4218ba741745848e60c184ac72357717c0ab67722c33c4cdb654ea6"
     ),
 
     .binaryTarget(

--- a/README.md
+++ b/README.md
@@ -4404,6 +4404,26 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   </details>
 
+- <a id='prefer-flatmap'></a>(<a href='#prefer-flatmap'>link</a>) **Prefer using `flatMap { ... }` over `map { ... }.reduce([], +)`**.
+
+  <details>
+
+  [![SwiftFormat: preferFlatMap](https://img.shields.io/badge/SwiftFormat-preferFlatMap-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#preferFlatMap)
+
+  #### Why?
+
+  `map { ... }.reduce([], +)` builds an intermediate array of arrays and then flattens it by repeated concatenation, reallocating on each `+`. `flatMap { ... }` produces the same result directly, avoids the intermediate allocations, and reads more clearly.
+
+  ```swift
+  // WRONG
+  let allItems = sections.map { $0.items }.reduce([], +)
+
+  // RIGHT
+  let allItems = sections.flatMap { $0.items }
+  ```
+
+  </details>
+
 - <a id='url-macro'></a>(<a href='#url-macro'>link</a>) **If available in your project, prefer using a `#URL(_:)` macro instead of force-unwrapping `URL(string:)!` initializer**.
 
   <details>

--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -134,6 +134,7 @@
 --rules propertyTypes
 --rules blankLinesBetweenChainedFunctions
 --rules preferCountWhere
+--rules preferFlatMap
 --rules swiftTestingTestCaseNames
 --rules redundantSwiftTestingSuite
 --rules modifiersOnSameLine


### PR DESCRIPTION
#### Summary

Enables SwiftFormat's `preferFlatMap` rule and documents the corresponding style-guide entry (sibling to the existing `count(where:)` / `preferCountWhere` and `isEmpty` collection rules). Also bumps the SwiftFormat artifactbundle to the `2026-06-24` nightly, the first release to include the rule.

#### Reasoning

`map { ... }.reduce([], +)` builds an intermediate array of arrays and then flattens it by repeated concatenation, reallocating on each `+`. `flatMap { ... }` produces the same result directly, avoids the intermediate allocations, and reads more clearly.

The transform exists as a lint-only (non-autocorrectable) [`flatmap_over_map_reduce`](https://realm.github.io/SwiftLint/flatmap_over_map_reduce.html) rule in SwiftLint; this brings it to SwiftFormat as an autocorrecting rule ([nicklockwood/SwiftFormat#2558](https://github.com/nicklockwood/SwiftFormat/pull/2558)).

The rule is intentionally conservative — only `map` is rewritten (not `compactMap`, which isn't equivalent to `flatMap` when the closure returns an optional), and only the exact `reduce([], +)` shape (empty array-literal seed + `+` operator); non-empty seeds, other operators, and closure combinators are preserved.
