### PR TITLE
Add rule: prefer contains over range(of:) compared against nil

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -47,8 +47,8 @@ let package = Package(
 
     .binaryTarget(
       name: "swiftformat",
-      url: "https://github.com/calda/SwiftFormat-nightly/releases/download/2026-06-24/SwiftFormat.artifactbundle.zip",
-      checksum: "77cd21d4d4218ba741745848e60c184ac72357717c0ab67722c33c4cdb654ea6"
+      url: "https://github.com/calda/SwiftFormat-nightly/releases/download/2026-06-26/SwiftFormat.artifactbundle.zip",
+      checksum: "94fd5f5bf9d17dfbe4a687cda40302a2e3a70e853a3dc27c9ac58d64f3ab175b"
     ),
 
     .binaryTarget(

--- a/README.md
+++ b/README.md
@@ -4446,6 +4446,28 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   </details>
 
+- <a id='prefer-contains-over-range'></a>(<a href='#prefer-contains-over-range'>link</a>) **Prefer using `contains` over `range(of:)` compared against `nil`**.
+
+  <details>
+
+  [![SwiftFormat: preferContainsOverRange](https://img.shields.io/badge/SwiftFormat-preferContainsOverRange-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#preferContainsOverRange)
+
+  #### Why?
+
+  `range(of:) != nil` computes a range only to discard it and test for membership. `contains` expresses that membership check directly and reads more clearly.
+
+  ```swift
+  // WRONG
+  if text.range(of: "needle") != nil { ... }
+  if text.range(of: "needle") == nil { ... }
+
+  // RIGHT
+  if text.contains("needle") { ... }
+  if !text.contains("needle") { ... }
+  ```
+
+  </details>
+
 - <a id='url-macro'></a>(<a href='#url-macro'>link</a>) **If available in your project, prefer using a `#URL(_:)` macro instead of force-unwrapping `URL(string:)!` initializer**.
 
   <details>

--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -136,6 +136,7 @@
 --rules preferCountWhere
 --rules isEmpty
 --rules preferFlatMap
+--rules preferContainsOverRange
 --rules swiftTestingTestCaseNames
 --rules redundantSwiftTestingSuite
 --rules modifiersOnSameLine


### PR DESCRIPTION
#### Summary

Enables SwiftFormat's `preferContainsOverRange` rule and documents the corresponding style-guide entry (sibling to the existing `count(where:)`, `isEmpty`, and `flatMap` collection rules). Also bumps the SwiftFormat artifactbundle to the `2026-06-26` nightly, the first release to include the rule.

#### Reasoning

`range(of:) != nil` computes a range only to discard it and test for membership; `contains` expresses that membership check directly and reads more clearly (`range(of:) == nil` becomes `!contains`).

The rule is conservative — only a single `of:` argument is matched, and the `== nil` negation bails on optional-chained receivers and other cases where a prefix `!` can't be placed safely. It ships disabled-by-default (in rare cases the rewrite can change behavior, e.g. an `NSString` receiver whose `range(of:)` returns a non-optional `NSRange` where `!= nil` is always true); listing it in `--rules` enables it, as we already do for `isEmpty`.
