### PR TITLE
Add rule: prefer first(where:) over filter(_:).first

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -47,8 +47,8 @@ let package = Package(
 
     .binaryTarget(
       name: "swiftformat",
-      url: "https://github.com/calda/SwiftFormat-nightly/releases/download/2026-06-24/SwiftFormat.artifactbundle.zip",
-      checksum: "77cd21d4d4218ba741745848e60c184ac72357717c0ab67722c33c4cdb654ea6"
+      url: "https://github.com/calda/SwiftFormat-nightly/releases/download/2026-06-26/SwiftFormat.artifactbundle.zip",
+      checksum: "94fd5f5bf9d17dfbe4a687cda40302a2e3a70e853a3dc27c9ac58d64f3ab175b"
     ),
 
     .binaryTarget(

--- a/README.md
+++ b/README.md
@@ -4446,6 +4446,26 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   </details>
 
+- <a id='prefer-first-where'></a>(<a href='#prefer-first-where'>link</a>) **Prefer using `first(where: { ... })` over `filter { ... }.first`**.
+
+  <details>
+
+  [![SwiftFormat: preferFirstWhere](https://img.shields.io/badge/SwiftFormat-preferFirstWhere-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#preferFirstWhere)
+
+  #### Why?
+
+  `filter { ... }.first` builds a filtered collection just to take its first element. `first(where:)` finds that element directly and stops at the first match.
+
+  ```swift
+  // WRONG
+  let firstActive = items.filter { $0.isActive }.first
+
+  // RIGHT
+  let firstActive = items.first(where: { $0.isActive })
+  ```
+
+  </details>
+
 - <a id='url-macro'></a>(<a href='#url-macro'>link</a>) **If available in your project, prefer using a `#URL(_:)` macro instead of force-unwrapping `URL(string:)!` initializer**.
 
   <details>

--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -136,6 +136,7 @@
 --rules preferCountWhere
 --rules isEmpty
 --rules preferFlatMap
+--rules preferFirstWhere
 --rules swiftTestingTestCaseNames
 --rules redundantSwiftTestingSuite
 --rules modifiersOnSameLine


### PR DESCRIPTION
#### Summary

Enables SwiftFormat's `preferFirstWhere` rule and documents the corresponding style-guide entry (sibling to the existing `count(where:)`, `isEmpty`, and `flatMap` collection rules). Also bumps the SwiftFormat artifactbundle to the `2026-06-26` nightly, the first release to include the rule.

#### Reasoning

`filter { ... }.first` builds an entire filtered collection just to take its first element; `first(where:)` finds that element directly and stops at the first match. The rule only matches the no-argument `.first` property (leaving `.first(where:)` / `.first(3)` method calls alone), so it's a behavior-preserving rewrite.
