### PR TITLE
Add rule: prefer min() over sorted().first

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -47,8 +47,8 @@ let package = Package(
 
     .binaryTarget(
       name: "swiftformat",
-      url: "https://github.com/calda/SwiftFormat-nightly/releases/download/2026-06-26/SwiftFormat.artifactbundle.zip",
-      checksum: "94fd5f5bf9d17dfbe4a687cda40302a2e3a70e853a3dc27c9ac58d64f3ab175b"
+      url: "https://github.com/calda/SwiftFormat-nightly/releases/download/2026-06-30/SwiftFormat.artifactbundle.zip",
+      checksum: "77f88a52151c55090ec2bd9c950f9ef5202bb2b252a3fe60d136f1c0f272baa4"
     ),
 
     .binaryTarget(

--- a/Plugins/FormatSwift/Plugin.swift
+++ b/Plugins/FormatSwift/Plugin.swift
@@ -196,7 +196,7 @@ extension Package {
 
   /// The minimum Swift version supported by this package
   var minimumSwiftVersion: SwiftVersion {
-    supportedSwiftVersions.sorted().first!
+    supportedSwiftVersions.min()!
   }
 
   // MARK: Private

--- a/README.md
+++ b/README.md
@@ -4488,6 +4488,28 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   </details>
 
+- <a id='prefer-min-over-sorted'></a>(<a href='#prefer-min-over-sorted'>link</a>) **Prefer using `min()` over `sorted().first`**.
+
+  <details>
+
+  [![SwiftFormat: preferMinOverSorted](https://img.shields.io/badge/SwiftFormat-preferMinOverSorted-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#preferMinOverSorted)
+
+  #### Why?
+
+  `sorted().first` sorts the entire sequence — `O(n log n)` plus a full copy — just to take the smallest element. `min()` finds it in a single `O(n)` pass with no allocation. `sorted(by:).first` likewise becomes `min(by:)`.
+
+  ```swift
+  // WRONG
+  let smallest = values.sorted().first
+  let earliest = events.sorted(by: { $0.date < $1.date }).first
+
+  // RIGHT
+  let smallest = values.min()
+  let earliest = events.min(by: { $0.date < $1.date })
+  ```
+
+  </details>
+
 - <a id='url-macro'></a>(<a href='#url-macro'>link</a>) **If available in your project, prefer using a `#URL(_:)` macro instead of force-unwrapping `URL(string:)!` initializer**.
 
   <details>

--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -138,6 +138,7 @@
 --rules preferFlatMap
 --rules preferContainsOverRange
 --rules preferFirstWhere
+--rules preferMinOverSorted
 --rules swiftTestingTestCaseNames
 --rules redundantSwiftTestingSuite
 --rules modifiersOnSameLine


### PR DESCRIPTION
#### Summary

Enables SwiftFormat's `preferMinOverSorted` rule and documents the corresponding style-guide entry (sibling to the existing `count(where:)`, `isEmpty`, `flatMap`, `preferContainsOverRange`, and `preferFirstWhere` collection rules). Also bumps the SwiftFormat artifactbundle to the `2026-06-30` nightly, the first release to include the rule.

#### Reasoning

`sorted().first` sorts the entire sequence — `O(n log n)` plus a full copy — just to take the smallest element; `min()` finds it in a single `O(n)` pass with no allocation. `sorted(by:).first` likewise becomes `min(by:)`.

Only `.first` is rewritten. `sorted().last` → `max()` is *not* behavior-preserving on comparator ties: both `min`/`max` keep the *first* element of a tie group, but `sorted().last` reads the *last*, so any element with identity beyond the comparator key (tuples-by-key, objects) would silently change. The rule intentionally leaves `.last` alone, so it's a behavior-preserving rewrite.

Enabling the rule also autocorrected one site in this repo (`Plugin.swift`: `supportedSwiftVersions.sorted().first!` → `.min()!`).