### PR TITLE
Add rule: prefer contains(where:) over first(where:) compared against nil

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -47,8 +47,8 @@ let package = Package(
 
     .binaryTarget(
       name: "swiftformat",
-      url: "https://github.com/calda/SwiftFormat-nightly/releases/download/2026-06-26/SwiftFormat.artifactbundle.zip",
-      checksum: "94fd5f5bf9d17dfbe4a687cda40302a2e3a70e853a3dc27c9ac58d64f3ab175b"
+      url: "https://github.com/calda/SwiftFormat-nightly/releases/download/2026-07-01/SwiftFormat.artifactbundle.zip",
+      checksum: "2fb157eb72ca787f783892b93f97d80ee110972b919dd2d778adae59c8f5fae7"
     ),
 
     .binaryTarget(

--- a/README.md
+++ b/README.md
@@ -4488,6 +4488,28 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   </details>
 
+- <a id='prefer-contains-over-first'></a>(<a href='#prefer-contains-over-first'>link</a>) **Prefer using `contains(where:)` over `first(where:)` / `firstIndex(where:)` compared against `nil`**.
+
+  <details>
+
+  [![SwiftFormat: preferContainsOverFirst](https://img.shields.io/badge/SwiftFormat-preferContainsOverFirst-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#preferContainsOverFirst)
+
+  #### Why?
+
+  `first(where:) != nil` (and `firstIndex(where:) != nil`) finds and returns the matched element or index only to discard it and test for existence. `contains(where:)` expresses that existence check directly and returns a `Bool`. The `== nil` forms become `!contains(where:)`.
+
+  ```swift
+  // WRONG
+  if items.first(where: { $0.isActive }) != nil { ... }
+  if items.firstIndex(where: { $0.isActive }) == nil { ... }
+
+  // RIGHT
+  if items.contains(where: { $0.isActive }) { ... }
+  if !items.contains(where: { $0.isActive }) { ... }
+  ```
+
+  </details>
+
 - <a id='url-macro'></a>(<a href='#url-macro'>link</a>) **If available in your project, prefer using a `#URL(_:)` macro instead of force-unwrapping `URL(string:)!` initializer**.
 
   <details>

--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -136,6 +136,7 @@
 --rules preferCountWhere
 --rules isEmpty
 --rules preferFlatMap
+--rules preferContainsOverFirst
 --rules preferContainsOverRange
 --rules preferFirstWhere
 --rules swiftTestingTestCaseNames


### PR DESCRIPTION
#### Summary

Enables SwiftFormat's `preferContainsOverFirst` rule and documents the corresponding style-guide entry (sibling to the existing `count(where:)`, `isEmpty`, `flatMap`, `preferContainsOverRange`, and `preferFirstWhere` collection rules). Also bumps the SwiftFormat artifactbundle to the `2026-06-30` nightly, the first release to include the rule.

#### Reasoning

`first(where:) != nil` (and `firstIndex(where:) != nil`) finds and returns the matched element or index only to discard it and test for existence; `contains(where:)` expresses that existence check directly and returns a `Bool`. The `== nil` forms become the negated `!contains(where:)`. `firstIndex(where:)` is equivalent because an index exists exactly when a matching element exists.

The rule is conservative — it matches only `where:`-closure calls (leaving `firstIndex(of:)`, the bare `.first` property, and `first(n)` alone), only `!= nil` / `== nil` comparisons, and the `== nil` negation bails on optional-chained receivers and other cases where a prefix `!` can't be placed safely. So it's a behavior-preserving rewrite.

Pairs with the existing `preferContainsOverRange` rule (same `!= nil` / `== nil` → `contains` / `!contains` shape).