### PR TITLE
Document noGuardInTests updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -5367,13 +5367,34 @@ _You can enable the following settings in Xcode by running [this script](https:/
     @Test
     func something() throws {
       // WRONG:
-      guard let value = optionalValue, value.matchesCondition {
+      guard let value = optionalValue, value.matchesCondition else {
         return
       }
 
       // RIGHT:
       let value = try #require(optionalValue)
-      #expect(value.matchesCondition)
+      try #require(value.matchesCondition)
+    }
+  }
+  ```
+
+  The same applies to an `if` statement used like a `guard`, where the `if` is the last statement in the test:
+
+  ```swift
+  import Testing
+
+  struct SomeTests {
+    @Test
+    func something() throws {
+      // WRONG:
+      if let value = optionalValue, value.matchesCondition {
+        #expect(value.isValid)
+      }
+
+      // RIGHT:
+      let value = try #require(optionalValue)
+      try #require(value.matchesCondition)
+      #expect(value.isValid)
     }
   }
   ```


### PR DESCRIPTION
This PR documents two updates to `noGuardInTests` from https://github.com/nicklockwood/SwiftFormat/pull/2573:
 1. We convert boolean checks to `try #require` instead of `#expect`. This matches the intent of stopping the test case if the guard condition fails.
 2. We also apply the rule to guard-like if statements, where the if statement is the last statement in the test (equivalent to a guard before the remainder of the test)