### PR TITLE
Update SwiftFormat links to http://swiftformat.info

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,14 +10,14 @@ At minimum every rule should contain:
 
 1. A permalink to reference easily.
 1. A short description.
-1. A link to the appropriate [SwiftLint](https://github.com/realm/SwiftLint) / [SwiftFormat](https://github.com/nicklockwood/SwiftFormat) rule.
+1. A link to the appropriate [SwiftFormat](http://swiftformat.info) / [SwiftLint](https://realm.github.io/SwiftLint/) rule.
 1. _(optional)_ A "Why?" section describing the reasoning behind the rule.
 1. A code example describing the incorrect and correct behaviours.
 
 #### Example:
 
 * <a id='an-id'></a><a href='#an-id'>(link)</a>
-**This is the description of the rule.** [![SwiftLint: some_rule](https://img.shields.io/badge/SwiftLint-some__rule-007A87.svg)](https://github.com/realm/SwiftLint/blob/master/Rules.md#some_rule) [![SwiftFormat: some_rule](https://img.shields.io/badge/SwiftFormat-some__rule-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat#rules)
+**This is the description of the rule.** [![SwiftLint: some_rule](https://img.shields.io/badge/SwiftLint-some__rule-007A87.svg)](https://realm.github.io/SwiftLint/some_rule.html) [![SwiftFormat: some_rule](https://img.shields.io/badge/SwiftFormat-some__rule-7B0051.svg)](http://swiftformat.info/rules/prerelease#ruleName)
 
   <details>
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Note that brevity is not a primary goal. Code should be made more concise only i
 
 ## Guiding Tenets
 
-- Most rules should be autocorrectable using [SwiftFormat](https://github.com/nicklockwood/SwiftFormat).
+- Most rules should be autocorrectable using [SwiftFormat](http://swiftformat.info).
   - Autocorrect results in the best developer experience.
   - If a rule purely affects the syntactical format of the code, it must be autocorrectable.
   - Autocorrect should be non-destructive and should not affect the runtime behavior of code.
@@ -102,7 +102,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: wrap](https://img.shields.io/badge/SwiftFormat-wrap-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#wrap)
+  [![SwiftFormat: wrap](https://img.shields.io/badge/SwiftFormat-wrap-7B0051.svg)](http://swiftformat.info/rules/prerelease#wrap)
 
   #### Why?
 
@@ -116,7 +116,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: indent](https://img.shields.io/badge/SwiftFormat-indent-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#indent)
+  [![SwiftFormat: indent](https://img.shields.io/badge/SwiftFormat-indent-7B0051.svg)](http://swiftformat.info/rules/prerelease#indent)
 
   </details>
 
@@ -124,7 +124,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: trailingSpace](https://img.shields.io/badge/SwiftFormat-trailingSpace-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#trailingSpace)
+  [![SwiftFormat: trailingSpace](https://img.shields.io/badge/SwiftFormat-trailingSpace-7B0051.svg)](http://swiftformat.info/rules/prerelease#trailingSpace)
 
   </details>
 
@@ -308,7 +308,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <!-- ai-skill-include: not fully autocorrectable -->
 
-  [![SwiftFormat: redundantType](https://img.shields.io/badge/SwiftFormat-redundantType-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#redundantType)
+  [![SwiftFormat: redundantType](https://img.shields.io/badge/SwiftFormat-redundantType-7B0051.svg)](http://swiftformat.info/rules/prerelease#redundantType)
 
   ```swift
   // WRONG
@@ -361,7 +361,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <!-- ai-skill-include: not fully autocorrectable -->
 
-  [![SwiftFormat: propertyTypes](https://img.shields.io/badge/SwiftFormat-propertyTypes-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#propertyTypes)
+  [![SwiftFormat: propertyTypes](https://img.shields.io/badge/SwiftFormat-propertyTypes-7B0051.svg)](http://swiftformat.info/rules/prerelease#propertyTypes)
 
   Prefer using inferred types when the right-hand-side value is a static member with a leading dot (e.g. an `init`, a `static` property / function, or an enum case). This applies to both local variables and property declarations:
 
@@ -445,7 +445,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <!-- ai-skill-include: not fully autocorrectable -->
 
-  [![SwiftFormat: redundantSelf](https://img.shields.io/badge/SwiftFormat-redundantSelf-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#redundantSelf)
+  [![SwiftFormat: redundantSelf](https://img.shields.io/badge/SwiftFormat-redundantSelf-7B0051.svg)](http://swiftformat.info/rules/prerelease#redundantSelf)
 
   ```swift
   final class Listing {
@@ -485,7 +485,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: strongifiedSelf](https://img.shields.io/badge/SwiftFormat-strongifiedSelf-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#strongifiedSelf)
+  [![SwiftFormat: strongifiedSelf](https://img.shields.io/badge/SwiftFormat-strongifiedSelf-7B0051.svg)](http://swiftformat.info/rules/prerelease#strongifiedSelf)
 
   ```swift
   // WRONG
@@ -519,7 +519,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: trailingCommas](https://img.shields.io/badge/SwiftFormat-trailingCommas-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#trailingCommas)
+  [![SwiftFormat: trailingCommas](https://img.shields.io/badge/SwiftFormat-trailingCommas-7B0051.svg)](http://swiftformat.info/rules/prerelease#trailingCommas)
 
   ```swift
   // WRONG
@@ -593,7 +593,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: spaceInsideBrackets](https://img.shields.io/badge/SwiftFormat-spaceInsideBrackets-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#spaceInsideBrackets)
+  [![SwiftFormat: spaceInsideBrackets](https://img.shields.io/badge/SwiftFormat-spaceInsideBrackets-7B0051.svg)](http://swiftformat.info/rules/prerelease#spaceInsideBrackets)
 
   ```swift
   // WRONG
@@ -642,7 +642,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: spaceAroundOperators](https://img.shields.io/badge/SwiftFormat-spaceAroundOperators-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#spacearoundoperators)
+  [![SwiftFormat: spaceAroundOperators](https://img.shields.io/badge/SwiftFormat-spaceAroundOperators-7B0051.svg)](http://swiftformat.info/rules/prerelease#spacearoundoperators)
 
   ```swift
   // WRONG
@@ -689,7 +689,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: spaceAroundOperators](https://img.shields.io/badge/SwiftFormat-spaceAroundOperators-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#spacearoundoperators)
+  [![SwiftFormat: spaceAroundOperators](https://img.shields.io/badge/SwiftFormat-spaceAroundOperators-7B0051.svg)](http://swiftformat.info/rules/prerelease#spacearoundoperators)
 
   ```swift
   // WRONG
@@ -721,7 +721,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: redundantParens](https://img.shields.io/badge/SwiftFormat-redundantParens-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#redundantParens)
+  [![SwiftFormat: redundantParens](https://img.shields.io/badge/SwiftFormat-redundantParens-7B0051.svg)](http://swiftformat.info/rules/prerelease#redundantParens)
 
   ```swift
   // WRONG
@@ -743,7 +743,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: redundantPattern](https://img.shields.io/badge/SwiftFormat-redundantPattern-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#redundantPattern)
+  [![SwiftFormat: redundantPattern](https://img.shields.io/badge/SwiftFormat-redundantPattern-7B0051.svg)](http://swiftformat.info/rules/prerelease#redundantPattern)
 
   ```swift
   // WRONG
@@ -769,7 +769,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: hoistPatternLet](https://img.shields.io/badge/SwiftFormat-hoistPatternLet-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#hoistPatternLet)
+  [![SwiftFormat: hoistPatternLet](https://img.shields.io/badge/SwiftFormat-hoistPatternLet-7B0051.svg)](http://swiftformat.info/rules/prerelease#hoistPatternLet)
 
   ```swift
   // WRONG
@@ -823,7 +823,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: wrapAttributes](https://img.shields.io/badge/SwiftFormat-wrapAttributes-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#wrapAttributes)
+  [![SwiftFormat: wrapAttributes](https://img.shields.io/badge/SwiftFormat-wrapAttributes-7B0051.svg)](http://swiftformat.info/rules/prerelease#wrapAttributes)
 
   ```swift
   // WRONG
@@ -862,7 +862,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: wrapAttributes](https://img.shields.io/badge/SwiftFormat-wrapAttributes-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#wrapAttributes)
+  [![SwiftFormat: wrapAttributes](https://img.shields.io/badge/SwiftFormat-wrapAttributes-7B0051.svg)](http://swiftformat.info/rules/prerelease#wrapAttributes)
 
   ```swift
   // WRONG. These simple property wrappers should be written on the same line as the declaration.
@@ -1015,7 +1015,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: modifiersOnSameLine](https://img.shields.io/badge/SwiftFormat-modifiersOnSameLine-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#modifiersOnSameLine)
+  [![SwiftFormat: modifiersOnSameLine](https://img.shields.io/badge/SwiftFormat-modifiersOnSameLine-7B0051.svg)](http://swiftformat.info/rules/prerelease#modifiersOnSameLine)
 
   ```swift
   // WRONG
@@ -1043,7 +1043,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: wrapArguments](https://img.shields.io/badge/SwiftFormat-wrapArguments-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#wrapArguments)
+  [![SwiftFormat: wrapArguments](https://img.shields.io/badge/SwiftFormat-wrapArguments-7B0051.svg)](http://swiftformat.info/rules/prerelease#wrapArguments)
 
   ```swift
   // WRONG
@@ -1072,7 +1072,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: wrapArguments](https://img.shields.io/badge/SwiftFormat-wrapArguments-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#wrapArguments)
+  [![SwiftFormat: wrapArguments](https://img.shields.io/badge/SwiftFormat-wrapArguments-7B0051.svg)](http://swiftformat.info/rules/prerelease#wrapArguments)
 
   ```swift
   // WRONG (too long)
@@ -1104,7 +1104,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: sortTypealiases](https://img.shields.io/badge/SwiftFormat-sortTypealiases-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#sortTypealiases)
+  [![SwiftFormat: sortTypealiases](https://img.shields.io/badge/SwiftFormat-sortTypealiases-7B0051.svg)](http://swiftformat.info/rules/prerelease#sortTypealiases)
 
   #### Why?
 
@@ -1134,7 +1134,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: redundantOptionalBinding](https://img.shields.io/badge/SwiftFormat-redundantOptionalBinding-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#redundantOptionalBinding)
+  [![SwiftFormat: redundantOptionalBinding](https://img.shields.io/badge/SwiftFormat-redundantOptionalBinding-7B0051.svg)](http://swiftformat.info/rules/prerelease#redundantOptionalBinding)
 
   #### Why?
 
@@ -1170,7 +1170,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: elseOnSameLine](https://img.shields.io/badge/SwiftFormat-elseOnSameLine-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#elseOnSameLine)
+  [![SwiftFormat: elseOnSameLine](https://img.shields.io/badge/SwiftFormat-elseOnSameLine-7B0051.svg)](http://swiftformat.info/rules/prerelease#elseOnSameLine)
 
   ```swift
   // WRONG
@@ -1228,7 +1228,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: wrapArguments](https://img.shields.io/badge/SwiftFormat-wrapArguments-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#wrapArguments)
+  [![SwiftFormat: wrapArguments](https://img.shields.io/badge/SwiftFormat-wrapArguments-7B0051.svg)](http://swiftformat.info/rules/prerelease#wrapArguments)
 
   #### Why?
 
@@ -1290,7 +1290,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: wrapMultilineConditionalAssignment](https://img.shields.io/badge/SwiftFormat-wrapMultilineConditionalAssignment-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#wrapMultilineConditionalAssignment)
+  [![SwiftFormat: wrapMultilineConditionalAssignment](https://img.shields.io/badge/SwiftFormat-wrapMultilineConditionalAssignment-7B0051.svg)](http://swiftformat.info/rules/prerelease#wrapMultilineConditionalAssignment)
 
   #### Why?
 
@@ -1356,7 +1356,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: conditionalAssignment](https://img.shields.io/badge/SwiftFormat-conditionalAssignment-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#conditionalAssignment)
+  [![SwiftFormat: conditionalAssignment](https://img.shields.io/badge/SwiftFormat-conditionalAssignment-7B0051.svg)](http://swiftformat.info/rules/prerelease#conditionalAssignment)
 
   #### Why?
 
@@ -1467,7 +1467,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: wrapSwitchCases](https://img.shields.io/badge/SwiftFormat-wrapSwitchCases-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#wrapSwitchCases)
+  [![SwiftFormat: wrapSwitchCases](https://img.shields.io/badge/SwiftFormat-wrapSwitchCases-7B0051.svg)](http://swiftformat.info/rules/prerelease#wrapSwitchCases)
 
   #### Examples
 
@@ -1497,7 +1497,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: blankLineAfterSwitchCase](https://img.shields.io/badge/SwiftFormat-blankLineAfterSwitchCase-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#blankLineAfterSwitchCase) [![SwiftFormat: consistentSwitchCaseSpacing](https://img.shields.io/badge/SwiftFormat-consistentSwitchCaseSpacing-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#consistentSwitchCaseSpacing)
+  [![SwiftFormat: blankLineAfterSwitchCase](https://img.shields.io/badge/SwiftFormat-blankLineAfterSwitchCase-7B0051.svg)](http://swiftformat.info/rules/prerelease#blankLineAfterSwitchCase) [![SwiftFormat: consistentSwitchCaseSpacing](https://img.shields.io/badge/SwiftFormat-consistentSwitchCaseSpacing-7B0051.svg)](http://swiftformat.info/rules/prerelease#consistentSwitchCaseSpacing)
 
   #### Why?
 
@@ -1624,7 +1624,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: redundantBreak](https://img.shields.io/badge/SwiftFormat-redundantBreak-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#redundantBreak)
+  [![SwiftFormat: redundantBreak](https://img.shields.io/badge/SwiftFormat-redundantBreak-7B0051.svg)](http://swiftformat.info/rules/prerelease#redundantBreak)
 
   #### Why?
 
@@ -1656,7 +1656,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: elseOnSameLine](https://img.shields.io/badge/SwiftFormat-elseOnSameLine-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#elseOnSameLine)
+  [![SwiftFormat: elseOnSameLine](https://img.shields.io/badge/SwiftFormat-elseOnSameLine-7B0051.svg)](http://swiftformat.info/rules/prerelease#elseOnSameLine)
 
   ```swift
   // WRONG (else should be on its own line for multi-line guard statements)
@@ -1687,7 +1687,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: indent](https://img.shields.io/badge/SwiftFormat-indent-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#indent)
+  [![SwiftFormat: indent](https://img.shields.io/badge/SwiftFormat-indent-7B0051.svg)](http://swiftformat.info/rules/prerelease#indent)
 
   ```swift
   // WRONG
@@ -1725,7 +1725,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: typeSugar](https://img.shields.io/badge/SwiftFormat-typeSugar-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#typeSugar)
+  [![SwiftFormat: typeSugar](https://img.shields.io/badge/SwiftFormat-typeSugar-7B0051.svg)](http://swiftformat.info/rules/prerelease#typeSugar)
 
   ```swift
   // WRONG
@@ -1745,7 +1745,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: redundantInit](https://img.shields.io/badge/SwiftFormat-redundantInit-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#redundantInit)
+  [![SwiftFormat: redundantInit](https://img.shields.io/badge/SwiftFormat-redundantInit-7B0051.svg)](http://swiftformat.info/rules/prerelease#redundantInit)
 
   ```swift
   // WRONG
@@ -1761,7 +1761,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: braces](https://img.shields.io/badge/SwiftFormat-braces-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#braces)
+  [![SwiftFormat: braces](https://img.shields.io/badge/SwiftFormat-braces-7B0051.svg)](http://swiftformat.info/rules/prerelease#braces)
 
   ```swift
   // WRONG
@@ -1798,7 +1798,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: wrapMultilineStatementBraces](https://img.shields.io/badge/SwiftFormat-wrapMultilineStatementBraces-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#wrapMultilineStatementBraces)
+  [![SwiftFormat: wrapMultilineStatementBraces](https://img.shields.io/badge/SwiftFormat-wrapMultilineStatementBraces-7B0051.svg)](http://swiftformat.info/rules/prerelease#wrapMultilineStatementBraces)
 
   ```swift
   // WRONG
@@ -1823,7 +1823,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: spaceInsideBraces](https://img.shields.io/badge/SwiftFormat-spaceInsideBraces-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#spaceInsideBraces) [![SwiftFormat: spaceAroundBraces](https://img.shields.io/badge/SwiftFormat-spaceAroundBraces-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#spaceAroundBraces)
+  [![SwiftFormat: spaceInsideBraces](https://img.shields.io/badge/SwiftFormat-spaceInsideBraces-7B0051.svg)](http://swiftformat.info/rules/prerelease#spaceInsideBraces) [![SwiftFormat: spaceAroundBraces](https://img.shields.io/badge/SwiftFormat-spaceAroundBraces-7B0051.svg)](http://swiftformat.info/rules/prerelease#spaceAroundBraces)
 
   ```swift
   // WRONG
@@ -1857,7 +1857,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: spaceInsideParens](https://img.shields.io/badge/SwiftFormat-spaceInsideParens-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#spaceInsideParens) [![SwiftFormat: spaceAroundParens](https://img.shields.io/badge/SwiftFormat-spaceAroundParens-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#spaceAroundParens)
+  [![SwiftFormat: spaceInsideParens](https://img.shields.io/badge/SwiftFormat-spaceInsideParens-7B0051.svg)](http://swiftformat.info/rules/prerelease#spaceInsideParens) [![SwiftFormat: spaceAroundParens](https://img.shields.io/badge/SwiftFormat-spaceAroundParens-7B0051.svg)](http://swiftformat.info/rules/prerelease#spaceAroundParens)
 
   ```swift
   // WRONG
@@ -1877,7 +1877,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: blockComments](https://img.shields.io/badge/SwiftFormat-blockComments-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#blockComments)
+  [![SwiftFormat: blockComments](https://img.shields.io/badge/SwiftFormat-blockComments-7B0051.svg)](http://swiftformat.info/rules/prerelease#blockComments)
 
   ```swift
   // WRONG
@@ -1929,7 +1929,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: docComments](https://img.shields.io/badge/SwiftFormat-docComments-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#docComments)
+  [![SwiftFormat: docComments](https://img.shields.io/badge/SwiftFormat-docComments-7B0051.svg)](http://swiftformat.info/rules/prerelease#docComments)
 
   ```swift
   // WRONG
@@ -2052,7 +2052,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: docCommentsBeforeModifiers](https://img.shields.io/badge/SwiftFormat-docCommentsBeforeModifiers-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#docCommentsBeforeModifiers)
+  [![SwiftFormat: docCommentsBeforeModifiers](https://img.shields.io/badge/SwiftFormat-docCommentsBeforeModifiers-7B0051.svg)](http://swiftformat.info/rules/prerelease#docCommentsBeforeModifiers)
 
   ```swift
   // WRONG
@@ -2081,7 +2081,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: spaceAroundComments](https://img.shields.io/badge/SwiftFormat-spaceAroundComments-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#spaceAroundComments) [![SwiftFormat: spaceInsideComments](https://img.shields.io/badge/SwiftFormat-spaceInsideComments-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#spaceInsideComments)
+  [![SwiftFormat: spaceAroundComments](https://img.shields.io/badge/SwiftFormat-spaceAroundComments-7B0051.svg)](http://swiftformat.info/rules/prerelease#spaceAroundComments) [![SwiftFormat: spaceInsideComments](https://img.shields.io/badge/SwiftFormat-spaceInsideComments-7B0051.svg)](http://swiftformat.info/rules/prerelease#spaceInsideComments)
 
   ```swift
   // WRONG
@@ -2113,7 +2113,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: emptyBraces](https://img.shields.io/badge/SwiftFormat-emptyBraces-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#emptyBraces)
+  [![SwiftFormat: emptyBraces](https://img.shields.io/badge/SwiftFormat-emptyBraces-7B0051.svg)](http://swiftformat.info/rules/prerelease#emptyBraces)
 
   ```swift
   // WRONG
@@ -2145,7 +2145,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <!-- ai-skill-include: not fully autocorrectable (e.g. forEach over an optional array) -->
 
-  [![SwiftFormat: forLoop](https://img.shields.io/badge/SwiftFormat-forLoop-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#forLoop)
+  [![SwiftFormat: forLoop](https://img.shields.io/badge/SwiftFormat-forLoop-7B0051.svg)](http://swiftformat.info/rules/prerelease#forLoop)
 
   #### Why?
 
@@ -2184,7 +2184,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: redundantVoidReturnType](https://img.shields.io/badge/SwiftFormat-redundantVoidReturnType-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#redundantVoidReturnType)
+  [![SwiftFormat: redundantVoidReturnType](https://img.shields.io/badge/SwiftFormat-redundantVoidReturnType-7B0051.svg)](http://swiftformat.info/rules/prerelease#redundantVoidReturnType)
 
   ```swift
   // WRONG
@@ -2204,7 +2204,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: wrapArguments](https://img.shields.io/badge/SwiftFormat-wrapArguments-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#wrapArguments) [![SwiftFormat: braces](https://img.shields.io/badge/SwiftFormat-braces-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#braces)
+  [![SwiftFormat: wrapArguments](https://img.shields.io/badge/SwiftFormat-wrapArguments-7B0051.svg)](http://swiftformat.info/rules/prerelease#wrapArguments) [![SwiftFormat: braces](https://img.shields.io/badge/SwiftFormat-braces-7B0051.svg)](http://swiftformat.info/rules/prerelease#braces)
 
   ```swift
   class Universe {
@@ -2281,7 +2281,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: wrapFunctionBodies](https://img.shields.io/badge/SwiftFormat-wrapFunctionBodies-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#wrapFunctionBodies) [![SwiftFormat: wrapPropertyBodies](https://img.shields.io/badge/SwiftFormat-wrapPropertyBodies-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#wrapPropertyBodies)
+  [![SwiftFormat: wrapFunctionBodies](https://img.shields.io/badge/SwiftFormat-wrapFunctionBodies-7B0051.svg)](http://swiftformat.info/rules/prerelease#wrapFunctionBodies) [![SwiftFormat: wrapPropertyBodies](https://img.shields.io/badge/SwiftFormat-wrapPropertyBodies-7B0051.svg)](http://swiftformat.info/rules/prerelease#wrapPropertyBodies)
 
   ```swift
   // WRONG
@@ -2327,7 +2327,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: wrapArguments](https://img.shields.io/badge/SwiftFormat-wrapArguments-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#wrapArguments)
+  [![SwiftFormat: wrapArguments](https://img.shields.io/badge/SwiftFormat-wrapArguments-7B0051.svg)](http://swiftformat.info/rules/prerelease#wrapArguments)
 
   ```swift
   // WRONG
@@ -2373,7 +2373,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: unusedArguments](https://img.shields.io/badge/SwiftFormat-unusedArguments-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#unusedArguments)
+  [![SwiftFormat: unusedArguments](https://img.shields.io/badge/SwiftFormat-unusedArguments-7B0051.svg)](http://swiftformat.info/rules/prerelease#unusedArguments)
 
   #### Why?
 
@@ -2445,7 +2445,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: blanklinesbetweenchainedfunctions](https://img.shields.io/badge/SwiftFormat-blankLinesBetweenChainedFunctions-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#blanklinesbetweenchainedfunctions)
+  [![SwiftFormat: blanklinesbetweenchainedfunctions](https://img.shields.io/badge/SwiftFormat-blankLinesBetweenChainedFunctions-7B0051.svg)](http://swiftformat.info/rules/prerelease#blanklinesbetweenchainedfunctions)
 
   #### Why?
 
@@ -2491,7 +2491,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: redundantTypedThrows](https://img.shields.io/badge/SwiftFormat-redundantTypedThrows-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#redundantTypedThrows)
+  [![SwiftFormat: redundantTypedThrows](https://img.shields.io/badge/SwiftFormat-redundantTypedThrows-7B0051.svg)](http://swiftformat.info/rules/prerelease#redundantTypedThrows)
 
   #### Why?
 
@@ -2525,7 +2525,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: void](https://img.shields.io/badge/SwiftFormat-void-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#void)
+  [![SwiftFormat: void](https://img.shields.io/badge/SwiftFormat-void-7B0051.svg)](http://swiftformat.info/rules/prerelease#void)
 
   ```swift
   // WRONG
@@ -2545,7 +2545,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: unusedArguments](https://img.shields.io/badge/SwiftFormat-unusedArguments-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#unusedArguments)
+  [![SwiftFormat: unusedArguments](https://img.shields.io/badge/SwiftFormat-unusedArguments-7B0051.svg)](http://swiftformat.info/rules/prerelease#unusedArguments)
 
   #### Why?
 
@@ -2570,7 +2570,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: spaceInsideBraces](https://img.shields.io/badge/SwiftFormat-spaceInsideBraces-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#spaceInsideBraces) [![SwiftFormat: spaceAroundBraces](https://img.shields.io/badge/SwiftFormat-spaceAroundBraces-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#spaceAroundBraces)
+  [![SwiftFormat: spaceInsideBraces](https://img.shields.io/badge/SwiftFormat-spaceInsideBraces-7B0051.svg)](http://swiftformat.info/rules/prerelease#spaceInsideBraces) [![SwiftFormat: spaceAroundBraces](https://img.shields.io/badge/SwiftFormat-spaceAroundBraces-7B0051.svg)](http://swiftformat.info/rules/prerelease#spaceAroundBraces)
 
   ```swift
   // WRONG
@@ -2610,7 +2610,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: redundantVoidReturnType](https://img.shields.io/badge/SwiftFormat-redundantVoidReturnType-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#redundantVoidReturnType)
+  [![SwiftFormat: redundantVoidReturnType](https://img.shields.io/badge/SwiftFormat-redundantVoidReturnType-7B0051.svg)](http://swiftformat.info/rules/prerelease#redundantVoidReturnType)
 
   ```swift
   // WRONG
@@ -2630,7 +2630,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: trailingClosures](https://img.shields.io/badge/SwiftFormat-trailingClosures-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#trailingClosures)
+  [![SwiftFormat: trailingClosures](https://img.shields.io/badge/SwiftFormat-trailingClosures-7B0051.svg)](http://swiftformat.info/rules/prerelease#trailingClosures)
 
   ```swift
   // WRONG
@@ -2736,7 +2736,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: spaceAroundOperators](https://img.shields.io/badge/SwiftFormat-spaceAroundOperators-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#spacearoundoperators)
+  [![SwiftFormat: spaceAroundOperators](https://img.shields.io/badge/SwiftFormat-spaceAroundOperators-7B0051.svg)](http://swiftformat.info/rules/prerelease#spacearoundoperators)
 
   ```swift
   // WRONG
@@ -2770,7 +2770,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: wrap](https://img.shields.io/badge/SwiftFormat-wrap-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#wrap)
+  [![SwiftFormat: wrap](https://img.shields.io/badge/SwiftFormat-wrap-7B0051.svg)](http://swiftformat.info/rules/prerelease#wrap)
 
   ```swift
   // WRONG (too long)
@@ -2797,7 +2797,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: andOperator](https://img.shields.io/badge/SwiftFormat-andOperator-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#andOperator)
+  [![SwiftFormat: andOperator](https://img.shields.io/badge/SwiftFormat-andOperator-7B0051.svg)](http://swiftformat.info/rules/prerelease#andOperator)
 
   ```swift
   // WRONG
@@ -2835,7 +2835,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <!-- ai-skill-include: not fully autocorrectable (SwiftFormat doesn't know if the extension is of a concrete type or a protocol) -->
 
-  [![SwiftFormat: genericExtensions](https://img.shields.io/badge/SwiftFormat-genericExtensions-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#genericExtensions)
+  [![SwiftFormat: genericExtensions](https://img.shields.io/badge/SwiftFormat-genericExtensions-7B0051.svg)](http://swiftformat.info/rules/prerelease#genericExtensions)
 
   ```swift
   // WRONG
@@ -2864,7 +2864,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: semicolons](https://img.shields.io/badge/SwiftFormat-semicolons-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#semicolons)
+  [![SwiftFormat: semicolons](https://img.shields.io/badge/SwiftFormat-semicolons-7B0051.svg)](http://swiftformat.info/rules/prerelease#semicolons)
 
   ### Examples
 
@@ -2908,7 +2908,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftLint: implicitly_unwrapped_optional](https://img.shields.io/badge/SwiftLint-implicitly__unwrapped__optional-007A87.svg)](https://realm.github.io/SwiftLint/implicitly_unwrapped_optional)
+  [![SwiftLint: implicitly_unwrapped_optional](https://img.shields.io/badge/SwiftLint-implicitly__unwrapped__optional-007A87.svg)](https://realm.github.io/SwiftLint/implicitly_unwrapped_optional.html)
 
   ```swift
   // WRONG
@@ -2944,7 +2944,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <!-- ai-skill-include: not fully autocorrectable (e.g. have to preserve existing init parameter ordering to not break build) -->
 
-  [![SwiftFormat: redundantMemberwiseInit](https://img.shields.io/badge/SwiftFormat-redundantMemberwiseInit-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#redundantMemberwiseInit)
+  [![SwiftFormat: redundantMemberwiseInit](https://img.shields.io/badge/SwiftFormat-redundantMemberwiseInit-7B0051.svg)](http://swiftformat.info/rules/prerelease#redundantMemberwiseInit)
 
   #### Why?
 
@@ -3131,7 +3131,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: modifierOrder](https://img.shields.io/badge/SwiftFormat-modifierOrder-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#modifierOrder)
+  [![SwiftFormat: modifierOrder](https://img.shields.io/badge/SwiftFormat-modifierOrder-7B0051.svg)](http://swiftformat.info/rules/prerelease#modifierOrder)
 
   ```swift
   // WRONG
@@ -3149,7 +3149,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: redundantFileprivate](https://img.shields.io/badge/SwiftFormat-redundantFileprivate-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#redundantFileprivate) [![SwiftFormat: redundantPublic](https://img.shields.io/badge/SwiftFormat-redundantPublic-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#redundantPublic)
+  [![SwiftFormat: redundantFileprivate](https://img.shields.io/badge/SwiftFormat-redundantFileprivate-7B0051.svg)](http://swiftformat.info/rules/prerelease#redundantFileprivate) [![SwiftFormat: redundantPublic](https://img.shields.io/badge/SwiftFormat-redundantPublic-7B0051.svg)](http://swiftformat.info/rules/prerelease#redundantPublic)
 
   ```swift
   // WRONG
@@ -3237,7 +3237,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: redundantInternal](https://img.shields.io/badge/SwiftFormat-redundantInternal-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#redundantInternal)
+  [![SwiftFormat: redundantInternal](https://img.shields.io/badge/SwiftFormat-redundantInternal-7B0051.svg)](http://swiftformat.info/rules/prerelease#redundantInternal)
 
   ```swift
   // WRONG
@@ -3259,7 +3259,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: extensionAccessControl](https://img.shields.io/badge/SwiftFormat-extensionAccessControl-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#extensionaccesscontrol)
+  [![SwiftFormat: extensionAccessControl](https://img.shields.io/badge/SwiftFormat-extensionAccessControl-7B0051.svg)](http://swiftformat.info/rules/prerelease#extensionaccesscontrol)
 
   #### Why?
 
@@ -3330,7 +3330,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: enumNamespaces](https://img.shields.io/badge/SwiftFormat-enumNamespaces-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#enumNamespaces)
+  [![SwiftFormat: enumNamespaces](https://img.shields.io/badge/SwiftFormat-enumNamespaces-7B0051.svg)](http://swiftformat.info/rules/prerelease#enumNamespaces)
   - Avoid creating non-namespaced global constants and functions.
   - Feel free to nest namespaces where it adds clarity.
   - `private` globals are permitted, since they are scoped to a single file and do not pollute the global namespace. Consider placing private globals in an `enum` namespace to match the guidelines for other declaration types.
@@ -3377,7 +3377,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: redundantRawValues](https://img.shields.io/badge/SwiftFormat-redundantRawValues-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#redundantRawValues)
+  [![SwiftFormat: redundantRawValues](https://img.shields.io/badge/SwiftFormat-redundantRawValues-7B0051.svg)](http://swiftformat.info/rules/prerelease#redundantRawValues)
 
   #### Why?
 
@@ -3539,7 +3539,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftLint: fatal_error_message](https://img.shields.io/badge/SwiftLint-fatal__error__message-007A87.svg)](https://realm.github.io/SwiftLint/fatal_error_message)
+  [![SwiftLint: fatal_error_message](https://img.shields.io/badge/SwiftLint-fatal__error__message-007A87.svg)](https://realm.github.io/SwiftLint/fatal_error_message.html)
 
   ```swift
   func didSubmitText(_ text: String) {
@@ -3573,7 +3573,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: simplifyGenericConstraints](https://img.shields.io/badge/SwiftFormat-simplifyGenericConstraints-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#simplifyGenericConstraints)
+  [![SwiftFormat: simplifyGenericConstraints](https://img.shields.io/badge/SwiftFormat-simplifyGenericConstraints-7B0051.svg)](http://swiftformat.info/rules/prerelease#simplifyGenericConstraints)
 
   #### Why?
 
@@ -3622,7 +3622,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <!-- ai-skill-include -->
 
-  [![SwiftFormat: preferFinalClasses](https://img.shields.io/badge/SwiftFormat-preferFinalClasses-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#preferFinalClasses)
+  [![SwiftFormat: preferFinalClasses](https://img.shields.io/badge/SwiftFormat-preferFinalClasses-7B0051.svg)](http://swiftformat.info/rules/prerelease#preferFinalClasses)
 
   ```swift
   // WRONG
@@ -3781,7 +3781,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftLint: unused_optional_binding](https://img.shields.io/badge/SwiftLint-unused__optional__binding-007A87.svg)](https://realm.github.io/SwiftLint/unused_optional_binding)
+  [![SwiftLint: unused_optional_binding](https://img.shields.io/badge/SwiftLint-unused__optional__binding-007A87.svg)](https://realm.github.io/SwiftLint/unused_optional_binding.html)
 
   #### Why?
 
@@ -3807,7 +3807,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: redundantReturn](https://img.shields.io/badge/SwiftFormat-redundantReturn-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#redundantReturn)
+  [![SwiftFormat: redundantReturn](https://img.shields.io/badge/SwiftFormat-redundantReturn-7B0051.svg)](http://swiftformat.info/rules/prerelease#redundantReturn)
 
   ```swift
   // WRONG
@@ -3887,7 +3887,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: anyObjectProtocol](https://img.shields.io/badge/SwiftFormat-anyObjectProtocol-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#anyobjectprotocol)
+  [![SwiftFormat: anyObjectProtocol](https://img.shields.io/badge/SwiftFormat-anyObjectProtocol-7B0051.svg)](http://swiftformat.info/rules/prerelease#anyobjectprotocol)
 
   #### Why?
 
@@ -3945,7 +3945,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: redundantClosure](https://img.shields.io/badge/SwiftFormat-redundantClosure-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#redundantClosure)
+  [![SwiftFormat: redundantClosure](https://img.shields.io/badge/SwiftFormat-redundantClosure-7B0051.svg)](http://swiftformat.info/rules/prerelease#redundantClosure)
 
   ```swift
   // WRONG
@@ -3979,7 +3979,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: redundantGet](https://img.shields.io/badge/SwiftFormat-redundantGet-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#redundantGet)
+  [![SwiftFormat: redundantGet](https://img.shields.io/badge/SwiftFormat-redundantGet-7B0051.svg)](http://swiftformat.info/rules/prerelease#redundantGet)
 
   ```swift
   // WRONG
@@ -4009,7 +4009,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <!-- ai-skill-include -->
 
-  [![SwiftFormat: opaqueGenericParameters](https://img.shields.io/badge/SwiftFormat-opaqueGenericParameters-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#opaqueGenericParameters)
+  [![SwiftFormat: opaqueGenericParameters](https://img.shields.io/badge/SwiftFormat-opaqueGenericParameters-7B0051.svg)](http://swiftformat.info/rules/prerelease#opaqueGenericParameters)
 
   #### Why?
 
@@ -4246,7 +4246,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: redundantVariable](https://img.shields.io/badge/SwiftFormat-redundantVariable-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#redundantVariable)
+  [![SwiftFormat: redundantVariable](https://img.shields.io/badge/SwiftFormat-redundantVariable-7B0051.svg)](http://swiftformat.info/rules/prerelease#redundantVariable)
 
   ### Why?
 
@@ -4286,7 +4286,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <!-- ai-skill-include -->
 
-  [![SwiftFormat: redundantEquatable](https://img.shields.io/badge/SwiftFormat-redundantEquatable-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#redundantEquatable)
+  [![SwiftFormat: redundantEquatable](https://img.shields.io/badge/SwiftFormat-redundantEquatable-7B0051.svg)](http://swiftformat.info/rules/prerelease#redundantEquatable)
 
   ### Why?
 
@@ -4356,7 +4356,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: void](https://img.shields.io/badge/SwiftFormat-void-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#void)
+  [![SwiftFormat: void](https://img.shields.io/badge/SwiftFormat-void-7B0051.svg)](http://swiftformat.info/rules/prerelease#void)
 
   ```swift
   // WRONG
@@ -4372,7 +4372,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: void](https://img.shields.io/badge/SwiftFormat-void-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#void)
+  [![SwiftFormat: void](https://img.shields.io/badge/SwiftFormat-void-7B0051.svg)](http://swiftformat.info/rules/prerelease#void)
 
   ```swift
   let completion: (Result<Void, Error>) -> Void
@@ -4390,7 +4390,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: preferCountWhere](https://img.shields.io/badge/SwiftFormat-preferCountWhere-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#preferCountWhere)
+  [![SwiftFormat: preferCountWhere](https://img.shields.io/badge/SwiftFormat-preferCountWhere-7B0051.svg)](http://swiftformat.info/rules/prerelease#preferCountWhere)
 
   Swift 6.0 ([finally!](https://forums.swift.org/t/accepted-again-se-0220-count-where/66659)) added a `count(where:)` method to the standard library. Prefer using the `count(where:)` method over using the `filter(_:)` method followed by a `count` call.
 
@@ -4408,7 +4408,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: isEmpty](https://img.shields.io/badge/SwiftFormat-isEmpty-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#isEmpty)
+  [![SwiftFormat: isEmpty](https://img.shields.io/badge/SwiftFormat-isEmpty-7B0051.svg)](http://swiftformat.info/rules/prerelease#isEmpty)
 
   #### Why?
 
@@ -4430,7 +4430,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: preferFlatMap](https://img.shields.io/badge/SwiftFormat-preferFlatMap-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#preferFlatMap)
+  [![SwiftFormat: preferFlatMap](https://img.shields.io/badge/SwiftFormat-preferFlatMap-7B0051.svg)](http://swiftformat.info/rules/prerelease#preferFlatMap)
 
   #### Why?
 
@@ -4450,7 +4450,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: preferContainsOverRange](https://img.shields.io/badge/SwiftFormat-preferContainsOverRange-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#preferContainsOverRange)
+  [![SwiftFormat: preferContainsOverRange](https://img.shields.io/badge/SwiftFormat-preferContainsOverRange-7B0051.svg)](http://swiftformat.info/rules/prerelease#preferContainsOverRange)
 
   #### Why?
 
@@ -4472,7 +4472,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: preferFirstWhere](https://img.shields.io/badge/SwiftFormat-preferFirstWhere-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#preferFirstWhere)
+  [![SwiftFormat: preferFirstWhere](https://img.shields.io/badge/SwiftFormat-preferFirstWhere-7B0051.svg)](http://swiftformat.info/rules/prerelease#preferFirstWhere)
 
   #### Why?
 
@@ -4492,7 +4492,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: preferContainsOverFirst](https://img.shields.io/badge/SwiftFormat-preferContainsOverFirst-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#preferContainsOverFirst)
+  [![SwiftFormat: preferContainsOverFirst](https://img.shields.io/badge/SwiftFormat-preferContainsOverFirst-7B0051.svg)](http://swiftformat.info/rules/prerelease#preferContainsOverFirst)
 
   #### Why?
 
@@ -4514,7 +4514,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: preferMinOverSorted](https://img.shields.io/badge/SwiftFormat-preferMinOverSorted-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#preferMinOverSorted)
+  [![SwiftFormat: preferMinOverSorted](https://img.shields.io/badge/SwiftFormat-preferMinOverSorted-7B0051.svg)](http://swiftformat.info/rules/prerelease#preferMinOverSorted)
 
   #### Why?
 
@@ -4538,7 +4538,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <!-- ai-skill-include -->
 
-  [![SwiftFormat: urlMacro](https://img.shields.io/badge/SwiftFormat-urlMacro-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#urlMacro)
+  [![SwiftFormat: urlMacro](https://img.shields.io/badge/SwiftFormat-urlMacro-7B0051.svg)](http://swiftformat.info/rules/prerelease#urlMacro)
 
   #### Why?
 
@@ -4562,7 +4562,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: sortedImports](https://img.shields.io/badge/SwiftFormat-sortedImports-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#sortedImports) [![SwiftFormat: duplicateImports](https://img.shields.io/badge/SwiftFormat-duplicateImports-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#duplicateImports)
+  [![SwiftFormat: sortedImports](https://img.shields.io/badge/SwiftFormat-sortedImports-7B0051.svg)](http://swiftformat.info/rules/prerelease#sortedImports) [![SwiftFormat: duplicateImports](https://img.shields.io/badge/SwiftFormat-duplicateImports-7B0051.svg)](http://swiftformat.info/rules/prerelease#duplicateImports)
 
   #### Why?
   - A standard organization method helps engineers more quickly determine which modules a file depends on.
@@ -4624,7 +4624,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: consecutiveBlankLines](https://img.shields.io/badge/SwiftFormat-consecutiveBlankLines-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#consecutiveBlankLines) [![SwiftFormat: consecutiveSpaces](https://img.shields.io/badge/SwiftFormat-consecutiveSpaces-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#consecutiveSpaces)
+  [![SwiftFormat: consecutiveBlankLines](https://img.shields.io/badge/SwiftFormat-consecutiveBlankLines-7B0051.svg)](http://swiftformat.info/rules/prerelease#consecutiveBlankLines) [![SwiftFormat: consecutiveSpaces](https://img.shields.io/badge/SwiftFormat-consecutiveSpaces-7B0051.svg)](http://swiftformat.info/rules/prerelease#consecutiveSpaces)
 
   ```swift
   // WRONG
@@ -4655,7 +4655,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: linebreakAtEndOfFile](https://img.shields.io/badge/SwiftFormat-linebreakAtEndOfFile-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#linebreakatendoffile)
+  [![SwiftFormat: linebreakAtEndOfFile](https://img.shields.io/badge/SwiftFormat-linebreakAtEndOfFile-7B0051.svg)](http://swiftformat.info/rules/prerelease#linebreakatendoffile)
 
   </details>
 
@@ -4663,7 +4663,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: blankLinesBetweenScopes](https://img.shields.io/badge/SwiftFormat-blankLinesBetweenScopes-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#blankLinesBetweenScopes)
+  [![SwiftFormat: blankLinesBetweenScopes](https://img.shields.io/badge/SwiftFormat-blankLinesBetweenScopes-7B0051.svg)](http://swiftformat.info/rules/prerelease#blankLinesBetweenScopes)
 
   #### Why?
 
@@ -4716,7 +4716,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: blankLinesAtStartOfScope](https://img.shields.io/badge/SwiftFormat-blankLinesAtStartOfScope-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#blankLinesAtStartOfScope) [![SwiftFormat: blankLinesAtEndOfScope](https://img.shields.io/badge/SwiftFormat-blankLinesAtEndOfScope-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#blankLinesAtEndOfScope)
+  [![SwiftFormat: blankLinesAtStartOfScope](https://img.shields.io/badge/SwiftFormat-blankLinesAtStartOfScope-7B0051.svg)](http://swiftformat.info/rules/prerelease#blankLinesAtStartOfScope) [![SwiftFormat: blankLinesAtEndOfScope](https://img.shields.io/badge/SwiftFormat-blankLinesAtEndOfScope-7B0051.svg)](http://swiftformat.info/rules/prerelease#blankLinesAtEndOfScope)
 
   ```swift
   // WRONG
@@ -4778,7 +4778,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: markTypes](https://img.shields.io/badge/SwiftFormat-markTypes-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#markTypes)
+  [![SwiftFormat: markTypes](https://img.shields.io/badge/SwiftFormat-markTypes-7B0051.svg)](http://swiftformat.info/rules/prerelease#markTypes)
 
   ```swift
   // MARK: - GalaxyView
@@ -4811,7 +4811,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: organizeDeclarations](https://img.shields.io/badge/SwiftFormat-organizeDeclarations-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#organizeDeclarations)
+  [![SwiftFormat: organizeDeclarations](https://img.shields.io/badge/SwiftFormat-organizeDeclarations-7B0051.svg)](http://swiftformat.info/rules/prerelease#organizeDeclarations)
 
   </details>
 
@@ -4829,7 +4829,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: organizeDeclarations](https://img.shields.io/badge/SwiftFormat-organizeDeclarations-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#organizeDeclarations)
+  [![SwiftFormat: organizeDeclarations](https://img.shields.io/badge/SwiftFormat-organizeDeclarations-7B0051.svg)](http://swiftformat.info/rules/prerelease#organizeDeclarations)
 
   Computed properties and properties with property observers should appear at the end of the set of declarations of the same kind. (e.g. instance properties.)
 
@@ -4952,7 +4952,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: organizeDeclarations](https://img.shields.io/badge/SwiftFormat-organizeDeclarations-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#organizeDeclarations)
+  [![SwiftFormat: organizeDeclarations](https://img.shields.io/badge/SwiftFormat-organizeDeclarations-7B0051.svg)](http://swiftformat.info/rules/prerelease#organizeDeclarations)
 
   ```swift
   // WRONG
@@ -4973,7 +4973,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: singlePropertyPerLine](https://img.shields.io/badge/SwiftFormat-singlePropertyPerLine-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#singlePropertyPerLine) [![SwiftFormat: wrapEnumCases](https://img.shields.io/badge/SwiftFormat-wrapEnumCases-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#wrapEnumCases)
+  [![SwiftFormat: singlePropertyPerLine](https://img.shields.io/badge/SwiftFormat-singlePropertyPerLine-7B0051.svg)](http://swiftformat.info/rules/prerelease#singlePropertyPerLine) [![SwiftFormat: wrapEnumCases](https://img.shields.io/badge/SwiftFormat-wrapEnumCases-7B0051.svg)](http://swiftformat.info/rules/prerelease#wrapEnumCases)
 
   #### Why?
   - Declarations that define a single property are much more common, and more idiomatic.
@@ -5022,7 +5022,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <!-- ai-skill-include: not fully autocorrectable (e.g. have to preserve existing init parameter ordering to not break build) -->
 
-  [![SwiftFormat: redundantMemberwiseInit](https://img.shields.io/badge/SwiftFormat-redundantMemberwiseInit-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#redundantMemberwiseInit)
+  [![SwiftFormat: redundantMemberwiseInit](https://img.shields.io/badge/SwiftFormat-redundantMemberwiseInit-7B0051.svg)](http://swiftformat.info/rules/prerelease#redundantMemberwiseInit)
 
   #### Why?
 
@@ -5092,7 +5092,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: environmentEntry](https://img.shields.io/badge/SwiftFormat-environmentEntry-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/develop/Rules.md#environmentEntry)
+  [![SwiftFormat: environmentEntry](https://img.shields.io/badge/SwiftFormat-environmentEntry-7B0051.svg)](http://swiftformat.info/rules/prerelease#environmentEntry)
 
   ### Why?
 
@@ -5123,7 +5123,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: redundantViewBuilder](https://img.shields.io/badge/SwiftFormat-redundantViewBuilder-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#redundantViewBuilder)
+  [![SwiftFormat: redundantViewBuilder](https://img.shields.io/badge/SwiftFormat-redundantViewBuilder-7B0051.svg)](http://swiftformat.info/rules/prerelease#redundantViewBuilder)
 
   #### Why?
 
@@ -5179,7 +5179,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: redundantEmptyView](https://img.shields.io/badge/SwiftFormat-redundantEmptyView-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#redundantEmptyView)
+  [![SwiftFormat: redundantEmptyView](https://img.shields.io/badge/SwiftFormat-redundantEmptyView-7B0051.svg)](http://swiftformat.info/rules/prerelease#redundantEmptyView)
 
   ```swift
   // WRONG
@@ -5205,7 +5205,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: redundantSwiftUIGroup](https://img.shields.io/badge/SwiftFormat-redundantSwiftUIGroup-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#redundantSwiftUIGroup)
+  [![SwiftFormat: redundantSwiftUIGroup](https://img.shields.io/badge/SwiftFormat-redundantSwiftUIGroup-7B0051.svg)](http://swiftformat.info/rules/prerelease#redundantSwiftUIGroup)
 
   #### Why?
 
@@ -5267,7 +5267,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <!-- ai-skill-include: generally autocorrectable, but still an important best practice -->
 
-  [![SwiftFormat: swiftTestingTestCaseNames](https://img.shields.io/badge/SwiftFormat-swiftTestingTestCaseNames-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#swiftTestingTestCaseNames)
+  [![SwiftFormat: swiftTestingTestCaseNames](https://img.shields.io/badge/SwiftFormat-swiftTestingTestCaseNames-7B0051.svg)](http://swiftformat.info/rules/prerelease#swiftTestingTestCaseNames)
 
   ### Why?
 
@@ -5312,7 +5312,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: redundantSwiftTestingSuite](https://img.shields.io/badge/SwiftFormat-redundantSwiftTestingSuite-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#redundantSwiftTestingSuite)
+  [![SwiftFormat: redundantSwiftTestingSuite](https://img.shields.io/badge/SwiftFormat-redundantSwiftTestingSuite-7B0051.svg)](http://swiftformat.info/rules/prerelease#redundantSwiftTestingSuite)
 
   ```swift
   import Testing
@@ -5384,7 +5384,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <!-- ai-skill-include: not fully autocorrectable -->
 
-  [![SwiftFormat: noGuardInTests](https://img.shields.io/badge/SwiftFormat-noGuardInTests-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#noGuardInTests)
+  [![SwiftFormat: noGuardInTests](https://img.shields.io/badge/SwiftFormat-noGuardInTests-7B0051.svg)](http://swiftformat.info/rules/prerelease#noGuardInTests)
 
   ```swift
   import XCTest
@@ -5449,7 +5449,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: noForceTryInTests](https://img.shields.io/badge/SwiftFormat-noForceTryInTests-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#noForceTryInTests)
+  [![SwiftFormat: noForceTryInTests](https://img.shields.io/badge/SwiftFormat-noForceTryInTests-7B0051.svg)](http://swiftformat.info/rules/prerelease#noForceTryInTests)
 
   ```swift
   import XCTest
@@ -5493,7 +5493,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <!-- ai-skill-include: not fully autocorrectable -->
 
-  [![SwiftFormat: testSuiteAccessControl](https://img.shields.io/badge/SwiftFormat-testSuiteAccessControl-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#testSuiteAccessControl)
+  [![SwiftFormat: testSuiteAccessControl](https://img.shields.io/badge/SwiftFormat-testSuiteAccessControl-7B0051.svg)](http://swiftformat.info/rules/prerelease#testSuiteAccessControl)
 
   #### Why?
 
@@ -5587,7 +5587,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <!-- ai-skill-include: not fully autocorrectable -->
 
-  [![SwiftFormat: noForceUnwrapInTests](https://img.shields.io/badge/SwiftFormat-noForceUnwrapInTests-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#noForceUnwrapInTests)
+  [![SwiftFormat: noForceUnwrapInTests](https://img.shields.io/badge/SwiftFormat-noForceUnwrapInTests-7B0051.svg)](http://swiftformat.info/rules/prerelease#noForceUnwrapInTests)
 
   ```swift
   import XCTest
@@ -5649,7 +5649,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: redundantThrows](https://img.shields.io/badge/SwiftFormat-redundantThrows-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#redundantThrows) [![SwiftFormat: redundantAsync](https://img.shields.io/badge/SwiftFormat-redundantAsync-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#redundantAsync)
+  [![SwiftFormat: redundantThrows](https://img.shields.io/badge/SwiftFormat-redundantThrows-7B0051.svg)](http://swiftformat.info/rules/prerelease#redundantThrows) [![SwiftFormat: redundantAsync](https://img.shields.io/badge/SwiftFormat-redundantAsync-7B0051.svg)](http://swiftformat.info/rules/prerelease#redundantAsync)
 
   ```swift
   import XCTest
@@ -5699,7 +5699,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftLint: legacy_constructor](https://img.shields.io/badge/SwiftLint-legacy__constructor-007A87.svg)](https://realm.github.io/SwiftLint/legacy_constructor)
+  [![SwiftLint: legacy_constructor](https://img.shields.io/badge/SwiftLint-legacy__constructor-007A87.svg)](https://realm.github.io/SwiftLint/legacy_constructor.html)
 
   ```swift
   // WRONG

--- a/site/site_content_spec.rb
+++ b/site/site_content_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe SiteContent do
 
     # Relative file URLs resolve differently on github.com/airbnb/swift vs swift.airbnb.tech
     it 'does not use relative URLs' do
-      # Match markdown links that don't start with # or https
-      relative_links = readme_content.scan(/\]\((?!#|https)([^)]+)\)/).flatten
+      # Match markdown links that don't start with # or http(s)
+      relative_links = readme_content.scan(/\]\((?!#|https?:)([^)]+)\)/).flatten
       expect(relative_links).to be_empty, "Found relative links: #{relative_links.join(', ')}"
     end
 


### PR DESCRIPTION
SwiftFormat has a new website: http://swiftformat.info

Prerelease rules on the develop branch are documented at http://swiftformat.info/rules/prerelease. We can link to that page to ensure that none of our prerelease rules result in dead links.