### PR TITLE
Update SwiftFormat build and renamed rules

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -47,8 +47,8 @@ let package = Package(
 
     .binaryTarget(
       name: "swiftformat",
-      url: "https://github.com/calda/SwiftFormat-nightly/releases/download/2026-06-30/SwiftFormat.artifactbundle.zip",
-      checksum: "77f88a52151c55090ec2bd9c950f9ef5202bb2b252a3fe60d136f1c0f272baa4"
+      url: "https://github.com/calda/SwiftFormat-nightly/releases/download/2026-07-07/SwiftFormat.artifactbundle.zip",
+      checksum: "aa108373407da339355f896c77254519e667e5905db9d239b767ac315e275b4c"
     ),
 
     .binaryTarget(

--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -50,6 +50,7 @@
 --semicolons never # semicolons
 --doc-comments preserve # docComments
 --prefer-synthesized-init-for-internal-structs View,ViewBuilder # redundantMemberwiseInit
+--guard-like-if-statements convert # noGuardInTests
 
 # Customized default modifier order to put `override` after access control
 --modifier-order private,fileprivate,internal,package,public,open,private(set),fileprivate(set),internal(set),package(set),public(set),open(set),override,final,dynamic,optional,required,convenience,indirect,isolated,nonisolated,nonisolated(unsafe),lazy,weak,unowned,unowned(safe),unowned(unsafe),static,class,borrowing,consuming,mutating,nonmutating,prefix,infix,postfix,async # modifierOrder
@@ -136,8 +137,7 @@
 --rules preferCountWhere
 --rules isEmpty
 --rules preferFlatMap
---rules preferContainsOverFirst
---rules preferContainsOverRange
+--rules preferContains
 --rules preferFirstWhere
 --rules preferMinOverSorted
 --rules swiftTestingTestCaseNames


### PR DESCRIPTION
This PR updates the SwiftFormat build and applies some configuration changes:
 - `preferContainsOverFirst` and `preferContainsOverRange` were merged into `preferContains`
 - The default of `--guard-like-if-statements` was changed from `convert` to `preserve`, so add `--guard-like-if-statements convert `.