### PR TITLE
Add rule to reuse the existing identifier when unwrapping an optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -1136,37 +1136,37 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  [![SwiftFormat: redundantOptionalBinding](https://img.shields.io/badge/SwiftFormat-redundantOptionalBinding-7B0051.svg)](http://swiftformat.info/rules/prerelease#redundantOptionalBinding)
+[![SwiftFormat: redundantOptionalBinding](https://img.shields.io/badge/SwiftFormat-redundantOptionalBinding-7B0051.svg)](http://swiftformat.info/rules/prerelease#redundantOptionalBinding)
 
-  #### Why?
+#### Why?
 
-  Following the rationale in [SE-0345](https://github.com/apple/swift-evolution/blob/main/proposals/0345-if-let-shorthand.md), this shorthand syntax removes unnecessary boilerplate while retaining clarity. Reusing the optional's existing name, rather than introducing a new identifier for the unwrapped value, reduces cognitive load by avoiding introducing new variable names for the same object.
+Following the rationale in [SE-0345](https://github.com/apple/swift-evolution/blob/main/proposals/0345-if-let-shorthand.md), this shorthand syntax removes unnecessary boilerplate while retaining clarity. Reusing the optional's existing name, rather than introducing a new identifier for the unwrapped value, reduces cognitive load by avoiding introducing new variable names for the same object.
 
-  ```swift
-  // WRONG
-  if let ship = spaceship {
-    launch(ship)
-  }
+```swift
+// WRONG
+if let ship = spaceship {
+  launch(ship)
+}
 
-  if
-    let galaxy = galaxy,
-    galaxy.name == "Milky Way"
-  { ... }
+if
+  let galaxy = galaxy,
+  galaxy.name == "Milky Way"
+{ ... }
 
-  guard let self = self else { ... }
+guard let self = self else { ... }
 
-  // RIGHT
-  if let spaceship {
-    launch(spaceship)
-  }
+// RIGHT
+if let spaceship {
+  launch(spaceship)
+}
 
-  if
-    let galaxy,
-    galaxy.name == "Milky Way"
-  { ... }
+if
+  let galaxy,
+  galaxy.name == "Milky Way"
+{ ... }
 
-  guard let self else { ... }
-  ```
+guard let self else { ... }
+```
 
   </details>
 

--- a/README.md
+++ b/README.md
@@ -1130,11 +1130,11 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   </details>
 
-- <a id='prefer-if-let-shorthand'></a>(<a href='#prefer-if-let-shorthand'>link</a>) **When unwrapping an optional, reuse the existing identifier rather than introducing a new identifier.**
+- <a id='prefer-if-let-shorthand'></a>(<a href='#prefer-if-let-shorthand'>link</a>) **When unwrapping an optional, prefer reusing the existing identifier rather than introducing a new one.** However, it's fine to introduce a new name when doing so improves clarity at the use site.
 
   <details>
 
-  <!-- ai-skill-include: not fully autocorrectable (edge cases in complex cases) -->
+  <!-- ai-skill-include: autocorrect only applies to `if let galaxy = galaxy` -->
 
   [![SwiftFormat: redundantOptionalBinding](https://img.shields.io/badge/SwiftFormat-redundantOptionalBinding-7B0051.svg)](http://swiftformat.info/rules/prerelease#redundantOptionalBinding)
 
@@ -1142,12 +1142,10 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   Following the rationale in [SE-0345](https://github.com/apple/swift-evolution/blob/main/proposals/0345-if-let-shorthand.md), this shorthand syntax removes unnecessary boilerplate while retaining clarity. Reusing the optional's existing name, rather than introducing a new identifier for the unwrapped value, reduces cognitive load by avoiding introducing new variable names for the same object.
 
+  A binding that reuses the same name (like `let galaxy = galaxy` or `guard let self = self`) is always redundant and should use the shorthand syntax:
+
   ```swift
   // WRONG
-  if let ship = spaceship {
-    launch(ship)
-  }
-
   if
     let galaxy = galaxy,
     galaxy.name == "Milky Way"
@@ -1156,16 +1154,33 @@ _You can enable the following settings in Xcode by running [this script](https:/
   guard let self = self else { ... }
 
   // RIGHT
-  if let spaceship {
-    launch(spaceship)
-  }
-
   if
     let galaxy,
     galaxy.name == "Milky Way"
   { ... }
 
   guard let self else { ... }
+  ```
+
+  ```swift
+  // PREFERRED
+  if let spaceship {
+    launch(spaceship)
+  }
+
+  // LESS PREFERRED
+  if let ship = spaceship {
+    launch(ship)
+  }
+  ```
+
+  It's fine to introduce a new name, however, when doing so improves clarity at the use site:
+
+  ```swift
+  // ALSO RIGHT
+  if let destination = pendingDestination {
+    spaceship.travel(to: destination)
+  }
   ```
 
   </details>

--- a/README.md
+++ b/README.md
@@ -1132,41 +1132,41 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
 - <a id='prefer-if-let-shorthand'></a>(<a href='#prefer-if-let-shorthand'>link</a>) **When unwrapping an optional, reuse the existing identifier rather than introducing a new identifier.**
 
-<!-- ai-skill-include: not fully autocorrectable (edge cases in complex cases) -->
-
   <details>
 
-[![SwiftFormat: redundantOptionalBinding](https://img.shields.io/badge/SwiftFormat-redundantOptionalBinding-7B0051.svg)](http://swiftformat.info/rules/prerelease#redundantOptionalBinding)
+  <!-- ai-skill-include: not fully autocorrectable (edge cases in complex cases) -->
 
-#### Why?
+  [![SwiftFormat: redundantOptionalBinding](https://img.shields.io/badge/SwiftFormat-redundantOptionalBinding-7B0051.svg)](http://swiftformat.info/rules/prerelease#redundantOptionalBinding)
 
-Following the rationale in [SE-0345](https://github.com/apple/swift-evolution/blob/main/proposals/0345-if-let-shorthand.md), this shorthand syntax removes unnecessary boilerplate while retaining clarity. Reusing the optional's existing name, rather than introducing a new identifier for the unwrapped value, reduces cognitive load by avoiding introducing new variable names for the same object.
+  #### Why?
 
-```swift
-// WRONG
-if let ship = spaceship {
-  launch(ship)
-}
+  Following the rationale in [SE-0345](https://github.com/apple/swift-evolution/blob/main/proposals/0345-if-let-shorthand.md), this shorthand syntax removes unnecessary boilerplate while retaining clarity. Reusing the optional's existing name, rather than introducing a new identifier for the unwrapped value, reduces cognitive load by avoiding introducing new variable names for the same object.
 
-if
-  let galaxy = galaxy,
-  galaxy.name == "Milky Way"
-{ ... }
+  ```swift
+  // WRONG
+  if let ship = spaceship {
+    launch(ship)
+  }
 
-guard let self = self else { ... }
+  if
+    let galaxy = galaxy,
+    galaxy.name == "Milky Way"
+  { ... }
 
-// RIGHT
-if let spaceship {
-  launch(spaceship)
-}
+  guard let self = self else { ... }
 
-if
-  let galaxy,
-  galaxy.name == "Milky Way"
-{ ... }
+  // RIGHT
+  if let spaceship {
+    launch(spaceship)
+  }
 
-guard let self else { ... }
-```
+  if
+    let galaxy,
+    galaxy.name == "Milky Way"
+  { ... }
+
+  guard let self else { ... }
+  ```
 
   </details>
 

--- a/README.md
+++ b/README.md
@@ -1130,7 +1130,9 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   </details>
 
-- <a id='prefer-if-let-shorthand'></a>(<a href='#prefer-if-let-shorthand'>link</a>) **Omit the right-hand side of the expression when unwrapping an optional property to a non-optional property with the same name.**
+- <a id='prefer-if-let-shorthand'></a>(<a href='#prefer-if-let-shorthand'>link</a>) **When unwrapping an optional, reuse the existing identifier rather than introducing a new identifier.**
+
+<!-- ai-skill-include: not fully autocorrectable (edge cases in complex cases) -->
 
   <details>
 
@@ -1138,30 +1140,32 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   #### Why?
 
-  Following the rationale in [SE-0345](https://github.com/apple/swift-evolution/blob/main/proposals/0345-if-let-shorthand.md), this shorthand syntax removes unnecessary boilerplate while retaining clarity.
+  Following the rationale in [SE-0345](https://github.com/apple/swift-evolution/blob/main/proposals/0345-if-let-shorthand.md), this shorthand syntax removes unnecessary boilerplate while retaining clarity. Reusing the optional's existing name, rather than introducing a new identifier for the unwrapped value, reduces cognitive load by avoiding introducing new variable names for the same object.
 
   ```swift
   // WRONG
+  if let ship = spaceship {
+    launch(ship)
+  }
+
   if
     let galaxy = galaxy,
     galaxy.name == "Milky Way"
   { ... }
 
-  guard
-    let galaxy = galaxy,
-    galaxy.name == "Milky Way"
-  else { ... }
+  guard let self = self else { ... }
 
   // RIGHT
+  if let spaceship {
+    launch(spaceship)
+  }
+
   if
     let galaxy,
     galaxy.name == "Milky Way"
   { ... }
 
-  guard
-    let galaxy,
-    galaxy.name == "Milky Way"
-  else { ... }
+  guard let self else { ... }
   ```
 
   </details>

--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -48,6 +48,7 @@
 --single-line-for-each convert # preferForLoop
 --short-optionals always # typeSugar
 --semicolons never # semicolons
+--redundant-optional-binding always #redundantOptionalBinding
 --doc-comments preserve # docComments
 --prefer-synthesized-init-for-internal-structs View,ViewBuilder # redundantMemberwiseInit
 --guard-like-if-statements convert # noGuardInTests

--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -48,7 +48,6 @@
 --single-line-for-each convert # preferForLoop
 --short-optionals always # typeSugar
 --semicolons never # semicolons
---redundant-optional-binding always # redundantOptionalBinding
 --doc-comments preserve # docComments
 --prefer-synthesized-init-for-internal-structs View,ViewBuilder # redundantMemberwiseInit
 --guard-like-if-statements convert # noGuardInTests

--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -48,7 +48,7 @@
 --single-line-for-each convert # preferForLoop
 --short-optionals always # typeSugar
 --semicolons never # semicolons
---redundant-optional-binding always #redundantOptionalBinding
+--redundant-optional-binding always # redundantOptionalBinding
 --doc-comments preserve # docComments
 --prefer-synthesized-init-for-internal-structs View,ViewBuilder # redundantMemberwiseInit
 --guard-like-if-statements convert # noGuardInTests


### PR DESCRIPTION
#### Summary

This PR extends the optional binding rule to cases where the lhs and rhs identifiers are different: "when unwrapping an optional, prefer reusing the existing identifier rather than introducing a new identifier."

```swift
// NOT PREFERRED
if let ship = spaceship {
  launch(ship)
}

// PREFERRED
if let spaceship {
  launch(spaceship)
}
```

#### Reasoning

Reusing the optional's existing name, rather than introducing a new identifier for the unwrapped value, is more idiomatic and reduces cognitive load by avoiding introducing new variable names for the same object.

However, since there is nuance, we will not enforce this with code autocorrect.

>  It's fine to introduce a new name, however, when doing so improves clarity at the use site:
>
>  ```swift
>  // ALSO RIGHT
>  if let destination = pendingDestination {
>    spaceship.travel(to: destination)
>  }
>  ```
