### PR TITLE
Add rule to omit backticks unless required by the language

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -47,8 +47,8 @@ let package = Package(
 
     .binaryTarget(
       name: "swiftformat",
-      url: "https://github.com/calda/SwiftFormat-nightly/releases/download/2026-07-07/SwiftFormat.artifactbundle.zip",
-      checksum: "aa108373407da339355f896c77254519e667e5905db9d239b767ac315e275b4c"
+      url: "https://github.com/calda/SwiftFormat-nightly/releases/download/2026-08-03/SwiftFormat.artifactbundle.zip",
+      checksum: "f2d3f77d689b88a0715bcb34f8b1131f4316bb4f42d6ead6a1c7c71db13e468f"
     ),
 
     .binaryTarget(

--- a/README.md
+++ b/README.md
@@ -740,6 +740,36 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   </details>
 
+- <a id='redundant-backticks'></a>(<a href='#redundant-backticks'>link</a>) **Omit backticks around identifiers unless required by the language.**
+
+  <details>
+
+  [![SwiftFormat: redundantBackticks](https://img.shields.io/badge/SwiftFormat-redundantBackticks-7B0051.svg)](https://swiftformat.info/rules/prerelease#redundantBackticks)
+
+  #### Why?
+
+  Backticks are only required when escaping a keyword that would otherwise be invalid in that position. Many Swift keywords are contextual and are allowed as identifiers.
+
+  ```swift
+  // WRONG
+  func travel(to planet: Planet, orbit: Orbit = .`default`) { ... }
+
+  // RIGHT
+  func travel(to planet: Planet, orbit: Orbit = .default) { ... }
+  ```
+
+  Backticks are required, however, when declaring an enum case named after a keyword:
+
+  ```swift
+  // ALSO RIGHT
+  enum Orbit {
+    case `default`
+    case geostationary
+  }
+  ```
+
+  </details>
+
 - <a id='unnecessary-enum-arguments'></a> (<a href='#unnecessary-enum-arguments'>link</a>) **Omit enum associated values from case statements when all arguments are unlabeled.**
 
   <details>

--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -70,6 +70,7 @@
 --rules indent
 --rules markTypes
 --rules organizeDeclarations
+--rules redundantBackticks
 --rules redundantParens
 --rules redundantReturn
 --rules redundantSelf


### PR DESCRIPTION
#### Summary

Omit backticks around identifiers unless required by the language.


  ```swift
  // WRONG
  func travel(to planet: Planet, orbit: Orbit = .`default`) { ... }

  // RIGHT
  func travel(to planet: Planet, orbit: Orbit = .default) { ... }
  ```

#### Reasoning

Backticks are only required when escaping a keyword that would otherwise be invalid in that position. Many Swift keywords are contextual and are allowed as identifiers.
