### PR TITLE
Add rule: prefer lazy.map before single-pass operations

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -47,8 +47,8 @@ let package = Package(
 
     .binaryTarget(
       name: "swiftformat",
-      url: "https://github.com/calda/SwiftFormat-nightly/releases/download/2026-08-03/SwiftFormat.artifactbundle.zip",
-      checksum: "f2d3f77d689b88a0715bcb34f8b1131f4316bb4f42d6ead6a1c7c71db13e468f"
+      url: "https://github.com/calda/SwiftFormat-nightly/releases/download/2026-08-20-b/SwiftFormat.artifactbundle.zip",
+      checksum: "c57b02c844817482856f3f058e25184b360180e07d1382156adb7413992424f6"
     ),
 
     .binaryTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -47,8 +47,8 @@ let package = Package(
 
     .binaryTarget(
       name: "swiftformat",
-      url: "https://github.com/calda/SwiftFormat-nightly/releases/download/2026-08-20-b/SwiftFormat.artifactbundle.zip",
-      checksum: "c57b02c844817482856f3f058e25184b360180e07d1382156adb7413992424f6"
+      url: "https://github.com/calda/SwiftFormat-nightly/releases/download/2026-08-21-b/SwiftFormat.artifactbundle.zip",
+      checksum: "a14bac018f3816573ab68ab91923f8697f3266cda2e27c0c5dd6b40dc6f80dee"
     ),
 
     .binaryTarget(

--- a/README.md
+++ b/README.md
@@ -5811,6 +5811,34 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   </details>
 
+- <a id='prefer-lazy-map'></a>(<a href='#prefer-lazy-map'>link</a>) **Prefer `lazy.map` over `map` when the result is consumed in a single pass**.
+
+  <details>
+
+  <!-- ai-skill-include: generally autocorrectable, but still an important best practice -->
+
+  [![SwiftFormat: preferLazyMap](https://img.shields.io/badge/SwiftFormat-preferLazyMap-7B0051.svg)](https://swiftformat.info/rules/prerelease#preferLazyMap)
+
+  #### Why?
+
+  `map` allocates an array of every transformed element. When the only thing that happens to that array is a single walk over it, the allocation is pure waste: `lazy.map` transforms each element as it is visited instead. Operations that qualify are the ones that consume their receiver exactly once — `min`, `max`, `reduce`, `joined(separator:)` — plus `contains`, `allSatisfy`, and `first(where:)`, which can additionally stop early and skip transforming the rest.
+
+  ```swift
+  // WRONG
+  let minY = vertices.map { $0.y }.min()
+  let names = users.map { $0.name }.joined(separator: ", ")
+  let hasEmpty = rows.map { $0.title }.contains(where: { $0.isEmpty })
+
+  // RIGHT
+  let minY = vertices.lazy.map { $0.y }.min()
+  let names = users.lazy.map { $0.name }.joined(separator: ", ")
+  let hasEmpty = rows.lazy.map { $0.title }.contains(where: { $0.isEmpty })
+  ```
+
+  Reach for `lazy` only when the result really is consumed once. `sorted()` has to materialize its receiver anyway, and anything that walks the result more than once will redo the transform on each pass.
+
+  </details>
+
 **[⬆ back to top](#table-of-contents)**
 
 ## Apple Frameworks

--- a/README.md
+++ b/README.md
@@ -5821,19 +5821,19 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   #### Why?
 
-  `map` allocates an array of every transformed element. When the only thing that happens to that array is a single walk over it, the allocation is pure waste: `lazy.map` transforms each element as it is visited instead. Operations that qualify are the ones that consume their receiver exactly once — `min`, `max`, `reduce`, `joined(separator:)` — plus `contains`, `allSatisfy`, and `first(where:)`, which can additionally stop early and skip transforming the rest.
+  `map` allocates an array of every transformed element. When the only thing that happens to that array is a single walk over it, the allocation is pure waste: `lazy.map` transforms each element as it is visited instead. With an operation that can exit early, it also stops transforming as soon as it has an answer — the eager version below transforms every row before looking at any of them, even if the first row is the empty one it is searching for.
 
   ```swift
   // WRONG
-  let minY = vertices.map { $0.y }.min()
-  let names = users.map { $0.name }.joined(separator: ", ")
   let hasEmpty = rows.map { $0.title }.contains(where: { $0.isEmpty })
+  let minY = vertices.map { $0.y }.min()
 
   // RIGHT
-  let minY = vertices.lazy.map { $0.y }.min()
-  let names = users.lazy.map { $0.name }.joined(separator: ", ")
   let hasEmpty = rows.lazy.map { $0.title }.contains(where: { $0.isEmpty })
+  let minY = vertices.lazy.map { $0.y }.min()
   ```
+
+  Operations that qualify are the ones that consume their receiver exactly once — `min`, `max`, `reduce`, `joined(separator:)` — plus `contains`, `allSatisfy`, and `first(where:)`, which can additionally stop early.
 
   Reach for `lazy` only when the result really is consumed once. `sorted()` has to materialize its receiver anyway, and anything that walks the result more than once will redo the transform on each pass.
 

--- a/README.md
+++ b/README.md
@@ -5811,7 +5811,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   </details>
 
-- <a id='prefer-lazy-map'></a>(<a href='#prefer-lazy-map'>link</a>) **Prefer `lazy.map` over `map` when the result is consumed in a single pass (`contains`, `min`, `max`, `reduce`, `joined(separator:)`, etc)**.
+- <a id='prefer-lazy-map'></a>(<a href='#prefer-lazy-map'>link</a>) **Prefer `lazy.map` over `map` when the chain reduces to a single result (`joined(separator:)`, `min`, `max`, `reduce`, `contains`, etc)**.
 
   <details>
 
@@ -5821,21 +5821,29 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   #### Why?
 
-  `map` allocates an array of every transformed element. When the only thing that happens to that array is a single walk over it, the allocation is pure waste: `lazy.map` transforms each element as it is visited instead. With an operation that can exit early, it also stops transforming as soon as it has an answer — the eager version below transforms every row before looking at any of them, even if the first row is the empty one it is searching for.
+  `map` allocates an array of every transformed element. When that array only exists to be reduced to one value, the allocation is pure waste — `lazy.map` transforms each element as the reducing operation reaches it, and nothing is stored.
+
+  ```swift
+  // WRONG
+  let names = users.map { $0.name }.joined(separator: ", ")
+  let minY = vertices.map { $0.y }.min()
+
+  // RIGHT
+  let names = users.lazy.map { $0.name }.joined(separator: ", ")
+  let minY = vertices.lazy.map { $0.y }.min()
+  ```
+
+  This applies to any operation that turns the sequence into a single value: `joined(separator:)`, `min`, `max`, `reduce`, and also `contains`, `allSatisfy`, and `first(where:)`, which stop as soon as they have an answer. It does not apply to an operation that produces another sequence, like `filter` or `sorted()`, since the transformed elements are needed more than once — or, in `sorted()`'s case, have to be materialized anyway.
+
+  When the operation takes a predicate, folding the transform into that predicate is better still, because then there is no `map` to make lazy:
 
   ```swift
   // WRONG
   let hasEmpty = rows.map { $0.title }.contains(where: { $0.isEmpty })
-  let minY = vertices.map { $0.y }.min()
 
   // RIGHT
-  let hasEmpty = rows.lazy.map { $0.title }.contains(where: { $0.isEmpty })
-  let minY = vertices.lazy.map { $0.y }.min()
+  let hasEmpty = rows.contains(where: { $0.title.isEmpty })
   ```
-
-  Operations that qualify are the ones that consume their receiver exactly once — `min`, `max`, `reduce`, `joined(separator:)` — plus `contains`, `allSatisfy`, and `first(where:)`, which can additionally stop early.
-
-  Reach for `lazy` only when the result really is consumed once. `sorted()` has to materialize its receiver anyway, and anything that walks the result more than once will redo the transform on each pass.
 
   </details>
 

--- a/README.md
+++ b/README.md
@@ -5811,7 +5811,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   </details>
 
-- <a id='prefer-lazy-map'></a>(<a href='#prefer-lazy-map'>link</a>) **Prefer `lazy.map` over `map` when the result is consumed in a single pass**.
+- <a id='prefer-lazy-map'></a>(<a href='#prefer-lazy-map'>link</a>) **Prefer `lazy.map` over `map` when the result is consumed in a single pass (`contains`, `min`, `max`, `reduce`, `joined(separator:)`, etc)**.
 
   <details>
 

--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -144,6 +144,7 @@
 --rules preferFlatMap
 --rules preferContains
 --rules preferFirstWhere
+--rules preferLazyMap
 --rules preferMinOverSorted
 --rules swiftTestingTestCaseNames
 --rules redundantSwiftTestingSuite


### PR DESCRIPTION
#### Summary

Enables SwiftFormat's `preferLazyMap` rule and documents the corresponding style-guide entry (a sibling of the existing `preferMinOverSorted`, `preferFirstWhere`, and `preferContains` collection rules).

#### Reasoning

`map` allocates an array of every transformed element. When all that happens to that array is a single walk over it, that allocation is waste — `lazy.map` transforms each element as it's visited instead.

```swift
// WRONG
let names = users.map { $0.name }.joined(separator: ", ")
let minY = vertices.map { $0.y }.min()

// RIGHT
let names = users.lazy.map { $0.name }.joined(separator: ", ")
let minY = vertices.lazy.map { $0.y }.min()
```

Qualifying operations consume their receiver exactly once (`min`, `max`, `reduce`, `joined(separator:)`) or can additionally stop early and skip transforming the rest (`contains`, `allSatisfy`, `first(where:)`). The style-guide entry notes the converse too: `lazy` is only right when the result really is consumed once, since `sorted()` materializes anyway and anything walking the result twice redoes the transform.