### PR TITLE
Refine testing expectation message guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -5318,8 +5318,8 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   <details>
 
-  A message that restates the condition adds nothing over what `#expect` already reports on failure. Explain *why* the condition was expected to hold — here, because the test just engaged the warp drive:
-  
+  A message that restates the condition adds nothing over what `#expect` already reports on failure. Explain _why_ the condition was expected to hold — here, because the test just engaged the warp drive:
+
   ```swift
   // WRONG: Restates the condition
   #expect(spaceship.isWarpDriveActive, "Warp drive should be active")
@@ -5328,7 +5328,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
   ```
 
   A message can also capture the requirement behind the assertion, which the condition alone doesn't convey:
-  
+
   ```swift
   // WRONG: Restates the condition
   #expect(spaceship.speed > lightSpeed, "Speed should be greater than light speed")
@@ -5348,7 +5348,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
   ```
 
   It is fine to omit expectation message strings when there is no additional context to add that isn't already clear from surrounding context. For example, it's not necessary to restate the name of the test case itself in an assertion message:
-  
+
   ```swift
   // WRONG: The message just repeats the test name
   @Test

--- a/README.md
+++ b/README.md
@@ -5314,25 +5314,54 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   </details>
 
-- <a id='avoid-redundant-expectation-comments'></a>(<a href='#avoid-redundant-expectation-comments'>link</a>) **In Swift Testing, avoid expectation message strings that restate the expectation without adding additional context.** Unlike `XCTAssert`, the Swift Testing `#expect` macro generates detailed failure messages that include the expectation condition.
+- <a id='avoid-redundant-expectation-comments'></a>(<a href='#avoid-redundant-expectation-comments'>link</a>) **In Swift Testing, avoid expectation message strings that restate the expectation without adding additional context.** Unlike `XCTAssert`, the Swift Testing `#expect` macro generates detailed failure messages that include the expectation condition. When a message does add context, phrase it as the intent behind the assertion — the reason the condition was expected to hold — rather than a restatement. Avoid hardcoding expected values into the message so that the message can't drift from the assertion.
 
   <details>
 
+  A message that restates the condition adds nothing over what `#expect` already reports on failure. Explain *why* the condition was expected to hold — here, because the test just engaged the warp drive:
+  
   ```swift
-  // WRONG: Restates what #expect already reports in failure output
+  // WRONG: Restates the condition
+  #expect(spaceship.isWarpDriveActive, "Warp drive should be active")
+  // RIGHT: Explains why the drive should be active
+  #expect(spaceship.isWarpDriveActive, "The warp drive should be active after calling engageWarpDrive()")
+  ```
+
+  A message can also capture the requirement behind the assertion, which the condition alone doesn't convey:
+  
+  ```swift
+  // WRONG: Restates the condition
+  #expect(spaceship.speed > lightSpeed, "Speed should be greater than light speed")
+
+  // RIGHT: Explains why reaching light speed matters
+  #expect(spaceship.speed > lightSpeed, "Spaceship must reach light speed before the warp bubble can form")
+  ```
+
+  Don't hardcode expected values into the message, where they can drift from the assertion. Describe the significance of the value instead:
+
+  ```swift
+  // WRONG: Hardcodes the expected value
+  #expect(spaceship.speed == expectedCruisingSpeed, "Cruising speed should be warp 5")
+
+  // RIGHT: Describes the value's significance so the message can't drift
+  #expect(spaceship.speed == expectedCruisingSpeed, "Cruise control should keep the spaceship at cruising speed")
+  ```
+
+  When a single-assertion test is named as a sentence, a message that repeats that name is redundant:
+  
+  ```swift
+  // WRONG: The message just repeats the test name
   @Test
-  func `engage warp drive`() {
+  func `warp drive activates after engaging`() {
     spaceship.engageWarpDrive()
-    #expect(spaceship.isWarpDriveActive, "Warp drive should be active")
-    #expect(spaceship.speed > lightSpeed, "Speed should be greater than light speed")
+    #expect(spaceship.isWarpDriveActive, "The warp drive should be active after engaging")
   }
 
-  // RIGHT: Omits the message string, or adds valuable context
+  // RIGHT: The test name already conveys the relevant information, so the message is omitted
   @Test
-  func `engage warp drive`() {
+  func `warp drive activates after engaging`() {
     spaceship.engageWarpDrive()
     #expect(spaceship.isWarpDriveActive)
-    #expect(spaceship.speed > lightSpeed, "Spaceship must reach light speed before the warp bubble can form")
   }
   ```
 

--- a/README.md
+++ b/README.md
@@ -5347,7 +5347,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
   #expect(spaceship.speed == expectedCruisingSpeed, "Cruise control should keep the spaceship at cruising speed")
   ```
 
-  When a single-assertion test is named as a sentence, a message that repeats that name is redundant:
+  It is fine to omit expectation message strings when there is no additional context to add that isn't already clear from surrounding context. For example, it's not necessary to restate the name of the test case itself in an assertion message:
   
   ```swift
   // WRONG: The message just repeats the test name

--- a/README.md
+++ b/README.md
@@ -5314,7 +5314,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   </details>
 
-- <a id='avoid-redundant-expectation-comments'></a>(<a href='#avoid-redundant-expectation-comments'>link</a>) **In Swift Testing, avoid expectation message strings that restate the expectation without adding additional context.** Unlike `XCTAssert`, the Swift Testing `#expect` macro generates detailed failure messages that include the expectation condition. When a message does add context, phrase it as the intent behind the assertion — the reason the condition was expected to hold — rather than a restatement. Avoid hardcoding expected values into the message so that the message can't drift from the assertion.
+- <a id='avoid-redundant-expectation-comments'></a>(<a href='#avoid-redundant-expectation-comments'>link</a>) **In Swift Testing, avoid expectation message strings that restate the expectation without adding additional context.** Unlike `XCTAssert`, the Swift Testing `#expect` macro generates detailed failure messages that include the expectation condition. When an expectation message string does add valuable context, phrase it as the intent behind the assertion (the reason the condition was expected to hold) rather than restating the condition. Avoid hardcoding expected values into the message so that the message can't drift from the assertion.
 
   <details>
 


### PR DESCRIPTION
Add additional information about test expectation messages in order to improve the context captured in test failures.

#### Summary

<!--- required --->

Adds additional details to explain not just when you _shouldn't_ use expectation messages, but also when you _should_ use them and examples of how to use them effectively. When investigating a test failure, especially in an unfamiliar area of the codebase,  expectations such as `#expect(user == nil)` are often very difficult to troubleshoot. The expectation establishes what is expected, but it tells the debugger nothing about _why_ that expectation is there or _when_ it is expected to hold true. When triaging a test failure, `#expect(user == nil)` also fails to communicate the severity of the failure. In contrast, an effective expectation message, such as "Expected user not to have been populated after calling logout", signals to the triaging engineer "uh oh, the user is leaking after logout, which could be a severe issue". Expectation messages are powerful tools to give clues that aid developers in attempting to establish why a test has failed and why that failure is or is not significant.

#### Reasoning

<!--- only necessary for new rule proposals --->

The existing guidelines for test expectation methods could be interpreted as advocating for generally omitting them rather than advocating for using them prescriptively, which I believe was the original intent.
