### PR TITLE
Sort `@_spi` imports last

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -47,8 +47,8 @@ let package = Package(
 
     .binaryTarget(
       name: "swiftformat",
-      url: "https://github.com/calda/SwiftFormat-nightly/releases/download/2026-08-21-b/SwiftFormat.artifactbundle.zip",
-      checksum: "a14bac018f3816573ab68ab91923f8697f3266cda2e27c0c5dd6b40dc6f80dee"
+      url: "https://github.com/calda/SwiftFormat-nightly/releases/download/2026-09-01-b/SwiftFormat.artifactbundle.zip",
+      checksum: "2747e869d98e8d90db4c8b0612144134cf289d7e817bbe87f7fd64964d714d6a"
     ),
 
     .binaryTarget(

--- a/README.md
+++ b/README.md
@@ -4532,7 +4532,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
 ## File Organization
 
-- <a id='alphabetize-and-deduplicate-imports'></a>(<a href='#alphabetize-and-deduplicate-imports'>link</a>) **Alphabetize and deduplicate module imports within a file.** Place all imports at the top of the file below the header comments. Do not add additional line breaks between import statements. Add a single empty line before the first import and after the last import.
+- <a id='alphabetize-and-deduplicate-imports'></a>(<a href='#alphabetize-and-deduplicate-imports'>link</a>) **Alphabetize and deduplicate module imports within a file.** Place all imports at the top of the file below the header comments. Add a single empty line before the first import and after the last import. Sort `@testable import` statements after the regular imports, followed by `@_spi` imports.
 
   <details>
 
@@ -4545,51 +4545,41 @@ _You can enable the following settings in Xcode by running [this script](https:/
   ```swift
   // WRONG
 
-  //  Copyright © 2018 Airbnb. All rights reserved.
-  //
-  import DLSPrimitives
-  import Constellation
-  import Constellation
-  import Epoxy
+  // Copyright © 2026 Airbnb. All rights reserved.
+
+  import SolarSystemFeature
+  import GalaxyUI
+  import GalaxyUI
+  import OrbitService
 
   import Foundation
 
   // RIGHT
 
-  //  Copyright © 2018 Airbnb. All rights reserved.
-  //
+  // Copyright © 2026 Airbnb. All rights reserved.
 
-  import Constellation
-  import DLSPrimitives
-  import Epoxy
   import Foundation
+  import GalaxyUI
+  import OrbitService
+  import SolarSystemFeature
   ```
-
-  _Exception: `@testable import` should be grouped after the regular import and separated by an empty line._
 
   ```swift
   // WRONG
 
-  //  Copyright © 2018 Airbnb. All rights reserved.
-  //
-
-  import DLSPrimitives
-  @testable import Epoxy
   import Foundation
-  import Nimble
-  import Quick
+  @testable import OrbitService
+  import SolarSystemFeature
+  @_spi(Internal) import GalaxyUI
+  import Testing
 
   // RIGHT
 
-  //  Copyright © 2018 Airbnb. All rights reserved.
-  //
-
-  import DLSPrimitives
   import Foundation
-  import Nimble
-  import Quick
-
-  @testable import Epoxy
+  import SolarSystemFeature
+  import Testing
+  @testable import OrbitService
+  @_spi(Internal) import GalaxyUI
   ```
 
   </details>

--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -5,7 +5,7 @@
 --swift-version 6.3
 --language-mode 5
 --self remove # redundantSelf
---import-grouping testable-bottom # sortedImports
+--import-grouping access-control,alpha,testable-last,spi-last # sortedImports
 --trailing-commas multi-element-lists # trailingCommas
 --trim-whitespace always # trailingSpace
 --indent 2 #indent


### PR DESCRIPTION
#### Summary

This PR proposes an update to the "sort imports" rule, where we sort `@_spi` imports last, below any `@testable` imports.

  ```swift
  // WRONG

  import Foundation
  @testable import OrbitService
  import SolarSystemFeature
  @_spi(Internal) import GalaxyUI
  import Testing

  // RIGHT

  import Foundation
  import SolarSystemFeature
  import Testing
  @testable import OrbitService
  @_spi(Internal) import GalaxyUI
  ```

#### Reasoning

Similarly to sorting `@testable` imports last, this keeps the same kinds of imports grouped together.
