### PR TITLE
Avoid using `withExtendedLifetime` in unit tests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -47,8 +47,8 @@ let package = Package(
 
     .binaryTarget(
       name: "swiftformat",
-      url: "https://github.com/calda/SwiftFormat-nightly/releases/download/2026-08-21-b/SwiftFormat.artifactbundle.zip",
-      checksum: "a14bac018f3816573ab68ab91923f8697f3266cda2e27c0c5dd6b40dc6f80dee"
+      url: "https://github.com/calda/SwiftFormat-nightly/releases/download/2026-09-01-b/SwiftFormat.artifactbundle.zip",
+      checksum: "2747e869d98e8d90db4c8b0612144134cf289d7e817bbe87f7fd64964d714d6a"
     ),
 
     .binaryTarget(

--- a/README.md
+++ b/README.md
@@ -5665,6 +5665,55 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   </details>
 
+- <a id='avoid-extended-lifetime-in-tests'></a>(<a href='#avoid-extended-lifetime-in-tests'>link</a>) **Avoid using `withExtendedLifetime` in unit tests**. It usually has no effect on runtime behavior, since a variable declared in a function scope is never deallocated before the end of that scope. `withExtendedLifetime` is permitted in cases where the variable would otherwise cause an "unused variable" warning.
+
+  <details>
+
+  [![SwiftFormat: redundantExtendedLifetime](https://img.shields.io/badge/SwiftFormat-redundantExtendedLifetime-7B0051.svg)](https://swiftformat.info/rules/prerelease#redundantExtendedLifetime)
+
+  ```swift
+  // WRONG
+  @Test
+  func `telescope tracks target`() {
+    let observatory = Observatory()
+    let telescope = observatory.veryLargeTelescope()
+
+    telescope.track(.mars)
+    #expect(telescope.isTracking)
+
+    // Ensure the observatory isn't deallocated before we finish our observation
+    withExtendedLifetime(observatory) { }
+
+    // Also wrong / redundant: underscored assignment is often used for the same purpose as `withExtendedLifetime`
+    _ = observatory
+  }
+
+  // RIGHT
+  @Test
+  func `telescope tracks target`() {
+    let observatory = Observatory()
+    let telescope = observatory.veryLargeTelescope()
+
+    telescope.track(.mars)
+    #expect(telescope.isTracking)
+  }
+
+  // ALSO RIGHT. Without `withExtendedLifetime`, `cancellable` would cause an "unused variable" warning.
+  @Test
+  func `telescope publishes target updates`() {
+    let telescope = Telescope()
+    var publishedTarget: Planet?
+    let cancellable = telescope.targetPublisher.sink { publishedTarget = $0 }
+
+    telescope.track(.mars)
+    #expect(publishedTarget == .mars)
+
+    withExtendedLifetime(cancellable) { }
+  }
+  ```
+
+  </details>
+
 **[⬆ back to top](#table-of-contents)**
 
 ## Performance

--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -153,6 +153,7 @@
 --rules noForceUnwrapInTests
 --rules redundantThrows
 --rules redundantAsync
+--rules redundantExtendedLifetime
 --rules noGuardInTests
 --rules testSuiteAccessControl
 --rules validateTestCases


### PR DESCRIPTION
#### Summary

This PR proposes a rule to avoid using `withExtendedLifetime` in unit tests.

#### Reasoning

We found internally that none of the 400+ uses of `withExtendedLifetime` in our test suite actually affect runtime behavior since a variable declared in a function scope is never deallocated before the end of that scope.

  ```swift
  // WRONG
  @Test
  func `telescope tracks target`() {
    let observatory = Observatory()
    let telescope = observatory.veryLargeTelescope()

    telescope.track(.mars)
    #expect(telescope.isTracking)

    // Ensure the observatory isn't deallocated before we finish our observation
    withExtendedLifetime(observatory) { }
  }

  // RIGHT
  @Test
  func `telescope tracks target`() {
    let observatory = Observatory()
    let telescope = observatory.veryLargeTelescope()

    telescope.track(.mars)
    #expect(telescope.isTracking)
  }
  ```

However, it is sometimes used to suppress an "unused variable" warning. This sort of usage is fine:

  ```swift
  // ALSO RIGHT. Without `withExtendedLifetime`, `cancellable` would cause an "unused variable" warning.
  @Test
  func `telescope publishes target updates`() {
    let telescope = Telescope()
    var publishedTarget: Planet?
    let cancellable = telescope.targetPublisher.sink { publishedTarget = $0 }

    telescope.track(.mars)
    #expect(publishedTarget == .mars)

    withExtendedLifetime(cancellable) { }
  }
  ```