### PR TITLE
Add rule: prefer replacing(_:with:) over replacingOccurrences(of:with:)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5909,6 +5909,37 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   </details>
 
+- <a id='prefer-swift-string-api'></a>(<a href='#prefer-swift-string-api'>link</a>) **Prefer the Swift-native `replacing(_:with:)` over Foundation's `replacingOccurrences(of:with:)`**.
+
+  <details>
+
+  <!-- ai-skill-include: generally autocorrectable, but still an important best practice -->
+
+  [![SwiftFormat: preferSwiftStringAPI](https://img.shields.io/badge/SwiftFormat-preferSwiftStringAPI-7B0051.svg)](https://swiftformat.info/rules/prerelease#preferSwiftStringAPI)
+
+  #### Why?
+
+  `replacingOccurrences(of:with:)` is an `NSString` method surfaced on `String` by Foundation. `replacing(_:with:)` is the Swift standard library's own spelling of the same operation: it reads better at the call site, is generic over `StringProtocol` and `RangeReplaceableCollection` rather than being String-specific, and it doesn't require Foundation.
+
+  ```swift
+  // WRONG
+  let slug = title.replacingOccurrences(of: " ", with: "-")
+
+  // RIGHT
+  let slug = title.replacing(" ", with: "-")
+  ```
+
+  Only the two-argument `of:with:` form has a native equivalent. The `options:` and `range:` overloads (`.caseInsensitive`, `.regularExpression`, and friends) have no direct counterpart, so leave those as they are.
+
+  Two behavioral differences to be aware of:
+
+  - On a `Substring` receiver, `replacing(_:with:)` returns a `Substring`, whereas `replacingOccurrences(of:with:)` returns a `String`.
+  - An _empty_ search string behaves differently: `"abc".replacingOccurrences(of: "", with: "-")` is a no-op, but `"abc".replacing("", with: "-")` returns `"-a-b-c-"`. This only matters when the search string is a runtime value that can be empty.
+
+  > **Note:** This is a readability and consistency preference, not a performance optimization. Foundation's implementation is currently the faster of the two — in local benchmarks `replacing(_:with:)` was between 1.1x and 4.2x slower, depending on input size and needle length. Both are well under a microsecond for the short strings this typically runs on, but prefer `replacingOccurrences(of:with:)`, or a different approach entirely, in a genuinely hot path over large strings.
+
+  </details>
+
 **[⬆ back to top](#table-of-contents)**
 
 ## Contributors

--- a/README.md
+++ b/README.md
@@ -5927,7 +5927,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
   let callSign = spaceshipName.replacing(" ", with: "-")
   ```
 
-  Only the two-argument `of:with:` form has a native equivalent. The `options:` and `range:` overloads (`.caseInsensitive`, `.regularExpression`, and friends) have no direct counterpart, so leave those as they are.
+  Only the two-argument `of:with:` form has a equivalent in the standard library. The `options:` and `range:` overloads (`.caseInsensitive`, `.regularExpression`, and friends) have no direct counterpart, so leave those as they are.
 
   One behavioral difference to watch for when making this change by hand: an empty search string is a no-op in `replacingOccurrences(of: "", with: "-")`, but `"abc".replacing("", with: "-")` returns `"-a-b-c-"`.
 

--- a/README.md
+++ b/README.md
@@ -5909,34 +5909,27 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   </details>
 
-- <a id='prefer-swift-string-api'></a>(<a href='#prefer-swift-string-api'>link</a>) **Prefer the Swift-native `replacing(_:with:)` over Foundation's `replacingOccurrences(of:with:)`**.
+- <a id='prefer-swift-string-api'></a>(<a href='#prefer-swift-string-api'>link</a>) **Prefer the standard library `String` `replacing(_:with:)` API over Foundation's `replacingOccurrences(of:with:)`**.
 
   <details>
-
-  <!-- ai-skill-include: generally autocorrectable, but still an important best practice -->
 
   [![SwiftFormat: preferSwiftStringAPI](https://img.shields.io/badge/SwiftFormat-preferSwiftStringAPI-7B0051.svg)](https://swiftformat.info/rules/prerelease#preferSwiftStringAPI)
 
   #### Why?
 
-  `replacingOccurrences(of:with:)` is an `NSString` method surfaced on `String` by Foundation. `replacing(_:with:)` is the Swift standard library's own spelling of the same operation: it reads better at the call site, is generic over `StringProtocol` and `RangeReplaceableCollection` rather than being String-specific, and it doesn't require Foundation.
+  `replacingOccurrences(of:with:)` is an `NSString` method surfaced on `String` by Foundation. `replacing(_:with:)` is the modern replacement in the Swift standard library.
 
   ```swift
   // WRONG
-  let slug = title.replacingOccurrences(of: " ", with: "-")
+  let slug = planetName.replacingOccurrences(of: " ", with: "-")
 
   // RIGHT
-  let slug = title.replacing(" ", with: "-")
+  let slug = planetName.replacing(" ", with: "-")
   ```
 
   Only the two-argument `of:with:` form has a native equivalent. The `options:` and `range:` overloads (`.caseInsensitive`, `.regularExpression`, and friends) have no direct counterpart, so leave those as they are.
 
-  Two behavioral differences to be aware of:
-
-  - On a `Substring` receiver, `replacing(_:with:)` returns a `Substring`, whereas `replacingOccurrences(of:with:)` returns a `String`.
-  - An _empty_ search string behaves differently: `"abc".replacingOccurrences(of: "", with: "-")` is a no-op, but `"abc".replacing("", with: "-")` returns `"-a-b-c-"`. This only matters when the search string is a runtime value that can be empty.
-
-  > **Note:** This is a readability and consistency preference, not a performance optimization. Foundation's implementation is currently the faster of the two — in local benchmarks `replacing(_:with:)` was between 1.1x and 4.2x slower, depending on input size and needle length. Both are well under a microsecond for the short strings this typically runs on, but prefer `replacingOccurrences(of:with:)`, or a different approach entirely, in a genuinely hot path over large strings.
+  One behavioral difference to watch for when making this change by hand: an empty search string is a no-op in `replacingOccurrences(of: "", with: "-")`, but `"abc".replacing("", with: "-")` returns `"-a-b-c-"`.
 
   </details>
 

--- a/README.md
+++ b/README.md
@@ -5921,10 +5921,10 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
   ```swift
   // WRONG
-  let slug = planetName.replacingOccurrences(of: " ", with: "-")
+  let callSign = spaceshipName.replacingOccurrences(of: " ", with: "-")
 
   // RIGHT
-  let slug = planetName.replacing(" ", with: "-")
+  let callSign = spaceshipName.replacing(" ", with: "-")
   ```
 
   Only the two-argument `of:with:` form has a native equivalent. The `options:` and `range:` overloads (`.caseInsensitive`, `.regularExpression`, and friends) have no direct counterpart, so leave those as they are.

--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -146,6 +146,7 @@
 --rules preferFirstWhere
 --rules preferLazyMap
 --rules preferMinOverSorted
+--rules preferSwiftStringAPI
 --rules swiftTestingTestCaseNames
 --rules redundantSwiftTestingSuite
 --rules modifiersOnSameLine


### PR DESCRIPTION
#### Summary

Enables SwiftFormat's `preferSwiftStringAPI` rule and adds the corresponding style-guide entry to the **Apple Frameworks** section, alongside the other "prefer the typed/native Swift API over the Objective-C spelling" entries.

The rule is disabled by default upstream ([SwiftFormat#2491](https://github.com/nicklockwood/SwiftFormat/pull/2491)) because `replacing(_:with:)` requires iOS 16 / macOS 13. No `Package.swift` change is needed — the currently pinned SwiftFormat build (`2026-08-21-b`) already includes the rule.

Applied across the Airbnb iOS codebase in `airbnb/apps#375174` (334 files).

#### Reasoning

`replacingOccurrences(of:with:)` is an `NSString` method surfaced on `String` by Foundation. `replacing(_:with:)` is the modern replacement in the Swift standard library.

```swift
// WRONG
let callSign = spaceshipName.replacingOccurrences(of: " ", with: "-")

// RIGHT
let callSign = spaceshipName.replacing(" ", with: "-")
```

Only the two-argument `of:with:` form has a native equivalent; the `options:` and `range:` overloads have no counterpart and are left alone.

#### Empty search strings

`replacingOccurrences(of: "", with: "-")` is a no-op, but `replacing("", with: "-")` returns `"-a-b-c-"`. The entry flags this for hand-written changes, and the rule now preserves such calls after [SwiftFormat#2678](https://github.com/nicklockwood/SwiftFormat/pull/2678).

We have no exposure to it either way: there are no `replacingOccurrences(of: "")` call sites in `airbnb/apps` at all, literal or otherwise, so the case never came up in the bulk migration. The 54 non-literal search arguments there are all non-empty token constants or decimal separators.

#### Notes

- Unicode canonical equivalence is **unchanged** between the two APIs — verified precomposed vs. decomposed matching in both directions.
- This is a readability change rather than a performance one. Measured locally with `swiftc -O`, `replacing(_:with:)` is 1.1x–4.2x *slower* than Foundation's version (~3x for a typical token substitution), reproducible with the measurement order reversed: Foundation has a fast Swift path, while the standard library's generic grapheme-based `Collection` algorithm does not. Both are comfortably sub-microsecond on the short strings this normally runs on. Per review this is deliberately kept out of the style-guide entry, but recording it here, since the common assumption runs the other way.
