### PR TITLE
Sort imports with attributes last, alphabetized by the attribute name

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -47,8 +47,8 @@ let package = Package(
 
     .binaryTarget(
       name: "swiftformat",
-      url: "https://github.com/calda/SwiftFormat-nightly/releases/download/2026-09-01-b/SwiftFormat.artifactbundle.zip",
-      checksum: "2747e869d98e8d90db4c8b0612144134cf289d7e817bbe87f7fd64964d714d6a"
+      url: "https://github.com/calda/SwiftFormat-nightly/releases/download/2026-09-03-c/SwiftFormat.artifactbundle.zip",
+      checksum: "4b077e90527cae162bbed5f18a5d0aa5a6ef13c5ce6d2bd23ecca357829975d8"
     ),
 
     .binaryTarget(

--- a/README.md
+++ b/README.md
@@ -4532,7 +4532,7 @@ _You can enable the following settings in Xcode by running [this script](https:/
 
 ## File Organization
 
-- <a id='alphabetize-and-deduplicate-imports'></a>(<a href='#alphabetize-and-deduplicate-imports'>link</a>) **Alphabetize and deduplicate module imports within a file.** Place all imports at the top of the file below the header comments. Add a single empty line before the first import and after the last import. Sort `@testable import` statements after the regular imports, followed by `@_spi` imports.
+- <a id='alphabetize-and-deduplicate-imports'></a>(<a href='#alphabetize-and-deduplicate-imports'>link</a>) **Alphabetize and deduplicate module imports within a file.** Place all imports at the top of the file below the header comments. Add a single empty line before the first import and after the last import. Sort imports with attributes like `@testable` and `@_spi` last, alphabetized by the attribute name.
 
   <details>
 
@@ -4578,8 +4578,8 @@ _You can enable the following settings in Xcode by running [this script](https:/
   import Foundation
   import SolarSystemFeature
   import Testing
-  @testable import OrbitService
   @_spi(Internal) import GalaxyUI
+  @testable import OrbitService
   ```
 
   </details>

--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -5,7 +5,7 @@
 --swift-version 6.3
 --language-mode 5
 --self remove # redundantSelf
---import-grouping access-control,alpha,testable-last,spi-last # sortedImports
+--import-grouping access-control,alpha,attributes-last # sortedImports
 --trailing-commas multi-element-lists # trailingCommas
 --trim-whitespace always # trailingSpace
 --indent 2 #indent


### PR DESCRIPTION
#### Summary

After discussing https://github.com/airbnb/swift/pull/404, we realized it would be more scalable to just sort all imports with attributes last, sorted alphabetically by the attribute name.
